### PR TITLE
[fact] Add students as optional argument to get_repo_urls

### DIFF
--- a/repobee/command.py
+++ b/repobee/command.py
@@ -166,9 +166,8 @@ def update_student_repos(
         raise ValueError("master_repo_urls contains duplicates")
 
     master_repo_names = [util.repo_name(url) for url in urls]
-    student_repo_names = util.generate_repo_names(students, master_repo_names)
 
-    repo_urls = api.get_repo_urls(student_repo_names)
+    repo_urls = api.get_repo_urls(master_repo_names, students=students)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         LOGGER.info("cloning into master repos ...")
@@ -356,8 +355,7 @@ def clone_repos(
         students: Student usernames.
         api: A GitHubAPI instance.
     """
-    repo_names = util.generate_repo_names(students, master_repo_names)
-    repo_urls = api.get_repo_urls(repo_names)
+    repo_urls = api.get_repo_urls(master_repo_names, students=students)
 
     LOGGER.info("cloning into student repos ...")
     git.clone(repo_urls)
@@ -365,6 +363,7 @@ def clone_repos(
     if (
         len(plug.manager.get_plugins()) > 1
     ):  # something else than the default loaded
+        repo_names = util.generate_repo_names(students, master_repo_names)
         _execute_post_clone_hooks(repo_names, api)
 
 

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -20,6 +20,7 @@ import github
 
 from repobee import exception
 from repobee import tuples
+from repobee import util
 
 REQUIRED_OAUTH_SCOPES = {"admin:org", "repo"}
 
@@ -327,16 +328,23 @@ class GitHubAPI:
         return [self._insert_auth(url) for url in repo_urls]
 
     def get_repo_urls(
-        self, repo_names: Iterable[str], org_name: Optional[str] = None
+        self,
+        master_repo_names: Iterable[str],
+        org_name: Optional[str] = None,
+        students: Optional[List[tuples.Group]] = None,
     ) -> List[str]:
-        """Get repo urls for all specified repo names in organization.  Assumes
+        """Get repo urls for all specified repo names in organization. Assumes
         that the repos exist, there is no guarantee that they actually do as
         checking this with the REST API takes too much time.
 
+        If the `students` argument is supplied, student repo urls are
+        computed instead of master repo urls.
+
         Args:
-            repo_names: A list of repository names.
+            master_repo_names: A list of master repository names.
             org_name: Organization in which repos are expected. Defaults to the
                 target organization of the API instance.
+            students: A list of student groups.
 
         Returns:
             a list of urls corresponding to the repo names.
@@ -347,6 +355,11 @@ class GitHubAPI:
                 if not org_name
                 else self._github.get_organization(org_name)
             )
+        repo_names = (
+            master_repo_names
+            if not students
+            else util.generate_repo_names(students, master_repo_names)
+        )
         return [
             self._insert_auth(url)
             for url in (

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -471,6 +471,24 @@ class TestGetRepoUrls:
         for url in urls:
             assert "{}:{}".format(USER, TOKEN) in url
 
+    def test_with_students(self, repos, api):
+        """Test that supplying students causes student repo names to be
+        generated as the Cartesian product of the supplied repo names and the
+        students.
+        """
+        students = list(constants.STUDENTS)
+        master_repo_names = [repo.name for repo in repos]
+        expected_repo_names = util.generate_repo_names(
+            students, master_repo_names
+        )
+        # assume works correctly when called with just repo names
+        expected_urls = api.get_repo_urls(expected_repo_names)
+
+        actual_urls = api.get_repo_urls(master_repo_names, students=students)
+
+        assert len(actual_urls) == len(students) * len(master_repo_names)
+        assert sorted(expected_urls) == sorted(actual_urls)
+
 
 class TestOpenIssue:
     """Tests for open_issue."""


### PR DESCRIPTION
Also refactors calling code to supply students+master repo names instead of student repo names.

Fix #179 