### PR TITLE
Document apimeta.APISpec method stubs

### DIFF
--- a/docs/code.rst
+++ b/docs/code.rst
@@ -25,12 +25,6 @@ exception
 .. automodule:: repobee.exception
     :members:
 
-github_api
-====================
-
-.. automodule:: repobee.github_api
-    :members:
-
 git
 ====================
 
@@ -48,6 +42,29 @@ util
 
 .. automodule:: repobee.util
     :members:
+
+
+API-related modules
+===================
+
+apimeta
+-------
+
+.. automodule:: repobee.apimeta
+   :members:
+
+github_api
+----------
+
+.. automodule:: repobee.github_api
+    :members:
+
+gitlab_api
+----------
+
+.. automodule:: repobee.gitlab_api
+   :members:
+
 
 Core plugins
 ============

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -259,8 +259,8 @@ class APISpec:
         considered done.
 
         Note that reviews only count if the student is in the review team for
-        that repo. Review teams must only have one associated repo, or the
-        repo is skipped.
+        that repo. Review teams must only have one associated repo, or the repo
+        is skipped.
 
         Args:
             review_team_names: Names of review teams.
@@ -272,11 +272,51 @@ class APISpec:
             assigned_repos is a :py:class:`repobee.tuples.Review`.
         """
 
-    def delete_teams(self, team_names):
+    def delete_teams(self, team_names: Iterable[str]) -> None:
+        """Delete all teams in the target organizatoin that exactly match one
+        of the provided ``team_names``. Skip any team name for which no match
+        is found.
+
+        Args:
+            team_names: A list of team names for teams to be deleted.
+        """
         _not_implemented()
 
     @staticmethod
-    def verify_settings(user, org_name, base_url, token, master_org_name):
+    def verify_settings(
+        user: str,
+        org_name: str,
+        base_url: str,
+        token: str,
+        master_org_name: Optional[str] = None,
+    ):
+        """Verify the following (to the extent that is possible and makes sense
+        for the specifi platform):
+
+        1. Base url is correct
+        2. The token has sufficient access privileges
+        3. Target organization (specifiend by ``org_name``) exists
+            - If master_org_name is supplied, this is also checked to
+              exist.
+        4. User is owner in organization (verify by getting
+            - If master_org_name is supplied, user is also checked to be an
+              owner of it.
+        organization member list and checking roles)
+
+        Should raise an appropriate subclass of
+        :py:class:`repobee.exception.APIError` when a problem is encountered.
+
+        Args:
+            user: The username to try to fetch.
+            org_name: Name of the target organization.
+            base_url: A base url to a github API.
+            token: A secure OAUTH2 token.
+            org_name: Name of the master organization.
+        Returns:
+            True if the connection is well formed.
+        Raises:
+            :py:class:`repobee.exception.APIError`
+        """
         _not_implemented()
 
 

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -20,7 +20,7 @@ NotImplementedError) for any unimplemented API methods.
 """
 import inspect
 import collections
-from typing import List
+from typing import List, Iterable
 
 import daiquiri
 
@@ -119,7 +119,23 @@ class APISpec:
     def __init__(self, base_url, token, org_name, user):
         _not_implemented()
 
-    def ensure_teams_and_members(self, teams, permission):
+    def ensure_teams_and_members(
+        self, teams: Iterable[Team], permission: str
+    ) -> List[Team]:
+        """Ensure that the teams exist, and that their members are added to the
+        teams.
+
+        Teams that do not exist are created, teams that already exist are
+        fetched. Members that are not in their teams are added, members that do
+        not exist or are already in their teams are ignored.
+
+        Args:
+            teams: A list of teams specifying student groups.
+
+        Returns:
+            A list of Team API objects of the teams provided to the function,
+            both those that were created and those that already existed.
+        """
         _not_implemented()
 
     def get_teams(self) -> List[Team]:

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -20,7 +20,7 @@ NotImplementedError) for any unimplemented API methods.
 """
 import inspect
 import collections
-from typing import List, Iterable
+from typing import List, Iterable, Optional
 
 import daiquiri
 
@@ -157,7 +157,32 @@ class APISpec:
         """
         _not_implemented()
 
-    def get_repo_urls(self, master_repo_names, org_name, teams):
+    def get_repo_urls(
+        self,
+        master_repo_names: Iterable[str],
+        org_name: Optional[str] = None,
+        teams: Optional[List[Team]] = None,
+    ) -> List[str]:
+        """Get repo urls for all specified repo names in the organization. As
+        checking if every single repo actually exists takes a long time with a
+        typical REST API, this function does not in general guarantee that the
+        urls returned actually correspond to existing repos.
+
+        If the ``org_name`` argument is supplied, urls are computed relative to
+        that organization. If it is not supplied, the target organization is
+        used.
+
+        If the `teams` argument is supplied, student repo urls are
+        computed instead of master repo urls.
+
+        Args:
+            master_repo_names: A list of master repository names.
+            org_name: Organization in which repos are expected. Defaults to the
+                target organization of the API instance.
+            teams: A list of teams specifying student groups. Defaults to None.
+        Returns:
+            a list of urls corresponding to the repo names.
+        """
         _not_implemented()
 
     def get_issues(self, repo_names, state, title_regex):

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -20,6 +20,7 @@ NotImplementedError) for any unimplemented API methods.
 """
 import inspect
 import collections
+from typing import List
 
 import daiquiri
 
@@ -121,7 +122,12 @@ class APISpec:
     def ensure_teams_and_members(self, teams, permission):
         _not_implemented()
 
-    def get_teams(self):
+    def get_teams(self) -> List[Team]:
+        """Get all teams related to the target organization.
+
+        Returns:
+            A list of Team API object.
+        """
         _not_implemented()
 
     def create_repos(self, repos):

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -127,11 +127,10 @@ class APISpec:
 
         Teams that do not exist are created, teams that already exist are
         fetched. Members that are not in their teams are added, members that do
-        not exist or are already in their teams are ignored.
+        not exist or are already in their teams are skipped.
 
         Args:
             teams: A list of teams specifying student groups.
-
         Returns:
             A list of Team API objects of the teams provided to the function,
             both those that were created and those that already existed.
@@ -146,7 +145,16 @@ class APISpec:
         """
         _not_implemented()
 
-    def create_repos(self, repos):
+    def create_repos(self, repos: Iterable[Repo]) -> List[str]:
+        """Create repos in the target organization according the those specced
+        by the ``repos`` argument. Repos that already exist are skipped.
+
+        Args:
+            repos: Repos to be created.
+        Returns:
+            A list of urls to the repos specified by the ``repos`` argument,
+            both those that were created and those that already existed.
+        """
         _not_implemented()
 
     def get_repo_urls(self, master_repo_names, org_name, teams):

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -219,7 +219,14 @@ class APISpec:
         """
         _not_implemented()
 
-    def close_issue(self, title_regex, repo_names):
+    def close_issue(self, title_regex: str, repo_names: Iterable[str]) -> None:
+        """Close any issues in the given repos in the target organization,
+        whose titles match the title_regex.
+
+        Args:
+            title_regex: A regex to match against issue titles.
+            repo_names: Names of repositories to close issues in.
+        """
         _not_implemented()
 
     def add_repos_to_review_teams(self, team_to_repos, issue):

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -25,6 +25,7 @@ from typing import List, Iterable, Optional, Generator, Tuple, Mapping
 import daiquiri
 
 from repobee import exception
+from repobee import tuples
 
 LOGGER = daiquiri.getLogger(__file__)
 
@@ -244,8 +245,32 @@ class APISpec:
             issue: An optional Issue tuple to override the default issue.
         """
 
-    def get_review_progress(self, review_team_names, teams, title_regex):
-        _not_implemented()
+    def get_review_progress(
+        self,
+        review_team_names: Iterable[str],
+        teams: Iterable[Team],
+        title_regex: str,
+    ) -> Mapping[str, List[tuples.Review]]:
+        """Get the peer review progress for the specified review teams and
+        student teams by checking which review team members have opened issues
+        in their assigned repos. Only issues matching the title regex will be
+        considered peer review issues. If a reviewer has opened an issue in the
+        assigned repo with a title matching the regex, the review will be
+        considered done.
+
+        Note that reviews only count if the student is in the review team for
+        that repo. Review teams must only have one associated repo, or the
+        repo is skipped.
+
+        Args:
+            review_team_names: Names of review teams.
+            teams: Team API objects specifying student groups.
+            title_regex: If an issue title matches this regex, the issue is
+                considered a potential peer review issue.
+        Returns:
+            a mapping (reviewer -> assigned_repos), where reviewer is a str and
+            assigned_repos is a :py:class:`repobee.tuples.Review`.
+        """
 
     def delete_teams(self, team_names):
         _not_implemented()

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -206,7 +206,17 @@ class APISpec:
         """
         _not_implemented()
 
-    def open_issue(self, title, body, repo_names):
+    def open_issue(
+        self, title: str, body: str, repo_names: Iterable[str]
+    ) -> None:
+        """Open the specified issue in all repos with the given names, in the
+        target organization.
+
+        Args:
+            title: Title of the issue.
+            body: Body of the issue.
+            repo_names: Names of repos to open the issue in.
+        """
         _not_implemented()
 
     def close_issue(self, title_regex, repo_names):

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -244,6 +244,7 @@ class APISpec:
                 names.
             issue: An optional Issue tuple to override the default issue.
         """
+        _not_implemented()
 
     def get_review_progress(
         self,
@@ -271,6 +272,7 @@ class APISpec:
             a mapping (reviewer -> assigned_repos), where reviewer is a str and
             assigned_repos is a :py:class:`repobee.tuples.Review`.
         """
+        _not_implemented()
 
     def delete_teams(self, team_names: Iterable[str]) -> None:
         """Delete all teams in the target organizatoin that exactly match one

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -20,7 +20,7 @@ NotImplementedError) for any unimplemented API methods.
 """
 import inspect
 import collections
-from typing import List, Iterable, Optional, Generator, Tuple
+from typing import List, Iterable, Optional, Generator, Tuple, Mapping
 
 import daiquiri
 
@@ -229,8 +229,20 @@ class APISpec:
         """
         _not_implemented()
 
-    def add_repos_to_review_teams(self, team_to_repos, issue):
-        _not_implemented()
+    def add_repos_to_review_teams(
+        self,
+        team_to_repos: Mapping[str, Iterable[str]],
+        issue: Optional[Issue] = None,
+    ) -> None:
+        """Add repos to review teams. For each repo, an issue is opened, and
+        every user in the review team is assigned to it. If no issue is
+        specified, sensible defaults for title and body are used.
+
+        Args:
+            team_to_repos: A mapping from a team name to an iterable of repo
+                names.
+            issue: An optional Issue tuple to override the default issue.
+        """
 
     def get_review_progress(self, review_team_names, teams, title_regex):
         _not_implemented()

--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -20,7 +20,7 @@ NotImplementedError) for any unimplemented API methods.
 """
 import inspect
 import collections
-from typing import List, Iterable, Optional
+from typing import List, Iterable, Optional, Generator, Tuple
 
 import daiquiri
 
@@ -185,7 +185,25 @@ class APISpec:
         """
         _not_implemented()
 
-    def get_issues(self, repo_names, state, title_regex):
+    def get_issues(
+        self,
+        repo_names: Iterable[str],
+        state: str = "open",
+        title_regex: str = "",
+    ) -> Generator[Tuple[str, Generator[Issue, None, None]], None, None]:
+        """Get all issues for the repos in repo_names an return a generator
+        that yields (repo_name, issue generator) tuples. Will by default only
+        get open issues.
+
+        Args:
+            repo_names: An iterable of repo names.
+            state: Specifying the state of the issue ('open', 'closed' or
+            'all'). Defaults to 'open'.
+            title_regex: If specified, only issues matching this regex are
+            returned. Defaults to the empty string (which matches anything).
+        Returns:
+            A generator that yields (repo_name, issue_generator) tuples.
+        """
         _not_implemented()
 
     def open_issue(self, title, body, repo_names):

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -338,22 +338,7 @@ class GitHubAPI(apimeta.API):
         org_name: Optional[str] = None,
         teams: Optional[List[apimeta.Team]] = None,
     ) -> List[str]:
-        """Get repo urls for all specified repo names in organization. Assumes
-        that the repos exist, there is no guarantee that they actually do as
-        checking this with the REST API takes too much time.
-
-        If the `teams` argument is supplied, student repo urls are
-        computed instead of master repo urls.
-
-        Args:
-            master_repo_names: A list of master repository names.
-            org_name: Organization in which repos are expected. Defaults to the
-                target organization of the API instance.
-            teams: A list of teams specifying student groups.
-
-        Returns:
-            a list of urls corresponding to the repo names.
-        """
+        """See :py:func:`repobee.apimeta.APISpec.get_repo_urls`."""
         with _try_api_request():
             org = (
                 self._org

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -427,12 +427,7 @@ class GitHubAPI(apimeta.API):
             )
 
     def close_issue(self, title_regex: str, repo_names: Iterable[str]) -> None:
-        """Close any issues in the given repos whose titles match the title_regex.
-
-        Args:
-            title_regex: A regex to match against issue titles.
-            repo_names: Names of repositories to close issues in.
-        """
+        """See :py:func:`repobee.apimeta.APISpec.close_issue`."""
         repo_names_set = set(repo_names)
         repos = list(self._get_repos_by_name(repo_names_set))
 

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -215,16 +215,7 @@ class GitHubAPI(apimeta.API):
     def ensure_teams_and_members(
         self, teams: Iterable[apimeta.Team], permission: str = "push"
     ) -> List[apimeta.Team]:
-        """Create teams that do not exist and add members not in their
-        specified teams (if they exist as users).
-
-        Args:
-            teams: A list of teams specifying student groups.
-
-        Returns:
-            A list of Team namedtuples of the teams corresponding to the keys
-            of the member_lists mapping.
-        """
+        """See :py:class:`repobee.apimeta.APISpec.ensure_teams_and_members`."""
         member_lists = {team.name: team.members for team in teams}
         raw_teams = self._ensure_teams_exist(
             [team_name for team_name in member_lists.keys()],

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -472,27 +472,12 @@ class GitHubAPI(apimeta.API):
             )
 
     def get_review_progress(
-        self, review_team_names, teams, title_regex
+        self,
+        review_team_names: Iterable[str],
+        teams: Iterable[apimeta.Team],
+        title_regex: str,
     ) -> Mapping[str, List[tuples.Review]]:
-        """Get the peer review progress for the specified review teams and
-        students. Only issues matching the title regex will be considered peer
-        review issues. If a reviewer has opened an issue in the assigned repo
-        with a title matching the regex, the review will be considered done.
-
-        Note that reviews only count if the student is in the review team for
-        that repo. Review teams must only have one associated repo, or the
-        repo is skipped. This could potentially be relaxed if there is reason
-        to, because it is not critical to the functionality of the algorithm.
-
-        Args:
-            review_team_names: Names of review teams.
-            teams: A list of teams specifying student groups.
-            title_regex: If an issue title matches this regex, the issue is
-                considered a potential peer review issue.
-        Returns:
-            a mapping (reviewer -> assigned_repos), where reviewer is a str and
-            assigned_repos is a :py:class:`~repobee.tuples.Review`.
-        """
+        """See :py:func:`repobee.apimeta.APISpec.get_review_progress`."""
         reviews = collections.defaultdict(list)
         review_teams = self._get_teams_in(review_team_names)
         for review_team in review_teams:

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -308,15 +308,7 @@ class GitHubAPI(apimeta.API):
                 team.add_membership(user)
 
     def create_repos(self, repos: Iterable[apimeta.Repo]):
-        """Create repositories in the given organization according to the Repos.
-        Repos that already exist are skipped.
-
-        Args:
-            repos: An iterable of Repo namedtuples.
-
-        Returns:
-            A list of urls to all repos corresponding to the Repos.
-        """
+        """See :py:class:`repobee.apimeta.APISpec.create_repos`."""
         repo_urls = []
         for info in repos:
             created = False

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -215,7 +215,7 @@ class GitHubAPI(apimeta.API):
     def ensure_teams_and_members(
         self, teams: Iterable[apimeta.Team], permission: str = "push"
     ) -> List[apimeta.Team]:
-        """See :py:class:`repobee.apimeta.APISpec.ensure_teams_and_members`."""
+        """See :py:func:`repobee.apimeta.APISpec.ensure_teams_and_members`."""
         member_lists = {team.name: team.members for team in teams}
         raw_teams = self._ensure_teams_exist(
             [team_name for team_name in member_lists.keys()],
@@ -308,7 +308,7 @@ class GitHubAPI(apimeta.API):
                 team.add_membership(user)
 
     def create_repos(self, repos: Iterable[apimeta.Repo]):
-        """See :py:class:`repobee.apimeta.APISpec.create_repos`."""
+        """See :py:func:`repobee.apimeta.APISpec.create_repos`."""
         repo_urls = []
         for info in repos:
             created = False

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -14,8 +14,9 @@ import re
 from typing import List, Iterable, Mapping, Optional, Generator, Tuple
 from socket import gaierror
 import collections
-import daiquiri
 import contextlib
+
+import daiquiri
 import github
 
 from repobee import exception
@@ -157,7 +158,8 @@ class GitHubAPI(apimeta.API):
                 if team.name in team_names
             )
 
-    def get_teams(self):
+    def get_teams(self) -> List[apimeta.Team]:
+        """See :py:func:`repobee.apimeta.APISpec.get_teams`."""
         return [
             apimeta.Team(
                 name=t.name,

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -414,13 +414,7 @@ class GitHubAPI(apimeta.API):
     def open_issue(
         self, title: str, body: str, repo_names: Iterable[str]
     ) -> None:
-        """Open the specified issue in all repos with the given names.
-
-        Args:
-            title: Title of the issue.
-            body: Body of the issue.
-            repo_names: Names of repos to open the issue in.
-        """
+        """See :py:func:`repobee.apimeta.APISpec.open_issue`."""
         repo_names_set = set(repo_names)
         repos = list(self._get_repos_by_name(repo_names_set))
         for repo in repos:

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -453,17 +453,9 @@ class GitHubAPI(apimeta.API):
     def add_repos_to_review_teams(
         self,
         team_to_repos: Mapping[str, Iterable[str]],
-        issue: Optional[apimeta.Issue],
+        issue: Optional[apimeta.Issue] = None,
     ) -> None:
-        """Add repos to review teams. For each repo, an issue is opened, and
-        every user in the review team is assigned to it. If no issue is
-        specified, sensible defaults for title and body are used.
-
-        Args:
-            team_to_repos: A mapping from a team name to a sequence of repo
-                names.
-            issue: An an optional Issue tuple to override the default issue.
-        """
+        """See :py:func:`repobee.apimeta.APISpec.add_repos_to_review_teams`."""
         issue = issue or DEFAULT_REVIEW_ISSUE
         for team, repo in self._add_repos_to_teams(team_to_repos):
             # TODO team.get_members() api request is a bit redundant, it

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -171,12 +171,7 @@ class GitHubAPI(apimeta.API):
         ]
 
     def delete_teams(self, team_names: Iterable[str]) -> None:
-        """Delete all teams that match any of the team names. Skip any team
-        name for which no team can be found.
-
-        Args:
-            team_names: A list of team names for teams to be deleted.
-        """
+        """See :py:func:`repobee.apimeta.APISpec.delete_teams`."""
         deleted = set()  # only for logging
         for team in self._get_teams_in(team_names):
             team.delete()
@@ -574,32 +569,8 @@ class GitHubAPI(apimeta.API):
         base_url: str,
         token: str,
         master_org_name: Optional[str] = None,
-    ):
-        """Verify the following:
-
-        .. code-block: markdown
-
-            1. Base url is correct (verify by fetching user).
-            2. The token has correct access privileges (verify by getting oauth
-               scopes)
-            3. Organization exists (verify by getting the org)
-                - If master_org_name is supplied, this is also checked to
-                  exist.
-            4. User is owner in organization (verify by getting
-                - If master_org_name is supplied, user is also checked to be an
-                  owner of it.
-            organization member list and checking roles)
-
-            Raises exceptions if something goes wrong.
-
-        Args:
-            user: The username to try to fetch.
-            org_name: Name of an organization.
-            base_url: A base url to a github API.
-            token: A secure OAUTH2 token.
-        Returns:
-            True if the connection is well formed.
-        """
+    ) -> None:
+        """See :py:func:`repobee.apimeta.APISpec.verify_settings`."""
         LOGGER.info("verifying settings ...")
         if not token:
             raise exception.BadCredentials(

--- a/repobee/github_api.py
+++ b/repobee/github_api.py
@@ -387,17 +387,7 @@ class GitHubAPI(apimeta.API):
         state: str = "open",
         title_regex: str = "",
     ) -> Generator[Tuple[str, ISSUE_GENERATOR], None, None]:
-        """Get all issues for the repos in repo_names an return a generator
-        that yields (repo_name, issue generator) tuples.
-
-        Args:
-            repo_names: An iterable of repo names.
-            state: Specifying the state of the issue ('open' or 'closed').
-            title_regex: If specified, only issues matching this regex are
-            returned. Defaults to the empty string (which matches anything).
-        Returns:
-            A generator that yields (repo_name, issue generator) tuples.
-        """
+        """See :py:func:`repobee.apimeta.APISpec.get_issues`."""
         repos = self._get_repos_by_name(repo_names)
 
         with _try_api_request():

--- a/repobee/gitlab_api.py
+++ b/repobee/gitlab_api.py
@@ -233,15 +233,7 @@ class GitLabAPI(apimeta.API):
         return teams
 
     def create_repos(self, repos: Iterable[apimeta.Repo]) -> List[str]:
-        """Create repositories in the given organization according to the Repos.
-        Repos that already exist are skipped.
-
-        Args:
-            repos: An iterable of Repo API objects.
-
-        Returns:
-            A list of urls to all repos corresponding to the Repos.
-        """
+        """See :py:class:`repobee.apimeta.APISpec.create_repos`."""
         repo_urls = []
         for repo in repos:
             created = False

--- a/repobee/gitlab_api.py
+++ b/repobee/gitlab_api.py
@@ -103,16 +103,7 @@ class GitLabAPI(apimeta.API):
     def ensure_teams_and_members(
         self, teams: Iterable[apimeta.Team], permission: str = "push"
     ) -> List[apimeta.Team]:
-        """Create teams that do not exist and add members not in their
-        specified teams (if they exist as users).
-
-        Args:
-            member_list: A mapping of (team_name, member_list).
-
-        Returns:
-            A list of Team namedtuples of the teams corresponding to the keys
-            of the member_lists mapping.
-        """
+        """See :py:class:`repobee.apimeta.APISpec.ensure_teams_and_members`."""
         member_lists = {team.name: team.members for team in teams}
         raw_teams = self._ensure_teams_exist(
             [str(team_name) for team_name in member_lists.keys()],

--- a/repobee/gitlab_api.py
+++ b/repobee/gitlab_api.py
@@ -276,22 +276,7 @@ class GitLabAPI(apimeta.API):
         org_name: Optional[str] = None,
         teams: Optional[List[apimeta.Team]] = None,
     ) -> List[str]:
-        """Get repo urls for all specified repo names in organization. Assumes
-        that the repos exist, there is no guarantee that they actually do as
-        checking this with the REST API takes too much time.
-
-        If the `teams` argument is supplied, student repo urls are
-        computed instead of master repo urls.
-
-        Args:
-            master_repo_names: A list of master repository names.
-            org_name: Organization in which repos are expected. Defaults to the
-                target organization of the API instance.
-            teams: A list of teams specifying student groups.
-
-        Returns:
-            a list of urls corresponding to the repo names.
-        """
+        """See :py:func:`repobee.apimeta.APISpec.get_repo_urls`."""
         group_name = org_name if org_name else self._group_name
         group_url = "{}/{}".format(self._base_url, group_name)
         repo_urls = (

--- a/repobee/gitlab_api.py
+++ b/repobee/gitlab_api.py
@@ -167,7 +167,8 @@ class GitLabAPI(apimeta.API):
     def _get_members(self, group):
         return [self._User(m.id, m.username) for m in group.members.list()]
 
-    def get_teams(self):
+    def get_teams(self) -> List[apimeta.Team]:
+        """See :py:class:`repobee.apimeta.Team`."""
         return [
             apimeta.Team(
                 name=t.name,

--- a/repobee/gitlab_api.py
+++ b/repobee/gitlab_api.py
@@ -103,7 +103,7 @@ class GitLabAPI(apimeta.API):
     def ensure_teams_and_members(
         self, teams: Iterable[apimeta.Team], permission: str = "push"
     ) -> List[apimeta.Team]:
-        """See :py:class:`repobee.apimeta.APISpec.ensure_teams_and_members`."""
+        """See :py:func:`repobee.apimeta.APISpec.ensure_teams_and_members`."""
         member_lists = {team.name: team.members for team in teams}
         raw_teams = self._ensure_teams_exist(
             [str(team_name) for team_name in member_lists.keys()],
@@ -159,7 +159,7 @@ class GitLabAPI(apimeta.API):
         return [self._User(m.id, m.username) for m in group.members.list()]
 
     def get_teams(self) -> List[apimeta.Team]:
-        """See :py:class:`repobee.apimeta.Team`."""
+        """See :py:func:`repobee.apimeta.Team`."""
         return [
             apimeta.Team(
                 name=t.name,
@@ -233,7 +233,7 @@ class GitLabAPI(apimeta.API):
         return teams
 
     def create_repos(self, repos: Iterable[apimeta.Repo]) -> List[str]:
-        """See :py:class:`repobee.apimeta.APISpec.create_repos`."""
+        """See :py:func:`repobee.apimeta.APISpec.create_repos`."""
         repo_urls = []
         for repo in repos:
             created = False

--- a/tests/test_apimeta.py
+++ b/tests/test_apimeta.py
@@ -9,7 +9,12 @@ def api_methods():
     return methods.items()
 
 
-@pytest.mark.parametrize("method", api_methods())
+def api_method_ids():
+    methods = apimeta.methods(apimeta.APISpec.__dict__)
+    return list(methods.keys())
+
+
+@pytest.mark.parametrize("method", api_methods(), ids=api_method_ids())
 def test_raises_when_unimplemented_method_called(method):
     """Test that get_teams method raises NotImplementedError when called if
     left undefined.


### PR DESCRIPTION
APISpec methods properly documented, and API implementations (GitHubAPI and GitLabAPI) now just refer to the APISpec documentation.

Fix #191 