### PR TITLE
[fact] Let API inherit from APISpec

### DIFF
--- a/tests/test_apimeta.py
+++ b/tests/test_apimeta.py
@@ -51,7 +51,10 @@ def test_accepts_correctly_defined_method():
     expected = 42
 
     class API(apimeta.API):
+        def __init__(self, base_url, token, org_name, user):
+            pass
+
         def get_teams(self):
             return expected
 
-    assert API().get_teams() == expected
+    assert API(None, None, None, None).get_teams() == expected


### PR DESCRIPTION
Fix #231 

This is possibly not the absolutely best solution, but it works fine and let's type checkers/autocompletion engines inspect the apimeta.API class and actually find the methods that are used in command.py and the tests. It also simplifies letting inheriting classes get the base implementations, as they simply inherit them. Works for now, at least!