### PR TITLE
Revert "[misc] Temporarily don't call `all` in asserts (#224)"

### DIFF
--- a/tests/plugin_tests/test_defaults.py
+++ b/tests/plugin_tests/test_defaults.py
@@ -61,13 +61,7 @@ class TestGenerateReviewAllocations:
         counts = collections.Counter(peer_reviewers)
 
         assert len(peer_reviewers) == num_reviews * num_students
-
-        # call all outside of assert, workaround for bug in pytest 4.6.0
-        # https://github.com/pytest-dev/pytest/issues/5358
-        all_correct_num_reviews = all(
-            map(lambda freq: freq == num_reviews, counts.values())
-        )
-        assert all_correct_num_reviews
+        assert all(map(lambda freq: freq == num_reviews, counts.values()))
 
     @pytest.mark.parametrize(
         "num_students, num_reviews", [(10, 4), (50, 3), (10, 1)]

--- a/tests/plugin_tests/test_pairwise.py
+++ b/tests/plugin_tests/test_pairwise.py
@@ -42,11 +42,7 @@ class TestGenerateReviewAllocations:
         counts = collections.Counter(peer_reviewers)
 
         assert len(peer_reviewers) == num_students
-
-        # call all outside of assert, workaround for bug in pytest 4.6.0
-        # https://github.com/pytest-dev/pytest/issues/5358
-        all_one_review = all(map(lambda freq: freq == 1, counts.values()))
-        assert all_one_review
+        assert all(map(lambda freq: freq == 1, counts.values()))
 
     @pytest.mark.parametrize(
         "num_students, num_reviews",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -371,15 +371,12 @@ class TestBaseParsing:
             ]
         )
 
-        # call all outside of assert, workaround for bug in pytest 4.6.0
-        # https://github.com/pytest-dev/pytest/issues/5358
-        all_urls_contain_master_org = all(
+        assert all(
             [
                 "/" + MASTER_ORG_NAME + "/" in url
                 for url in parsed_args.master_repo_urls
             ]
         )
-        assert all_urls_contain_master_org
 
     @pytest.mark.parametrize("parser", [cli.SETUP_PARSER, cli.UPDATE_PARSER])
     def test_master_org_name_defaults_to_org_name(
@@ -389,15 +386,12 @@ class TestBaseParsing:
             [parser, *COMPLETE_PUSH_ARGS, "-sf", str(students_file)]
         )
 
-        # call all outside of assert, workaround for bug in pytest 4.6.0
-        # https://github.com/pytest-dev/pytest/issues/5358
-        all_urls_contain_org_name = all(
+        assert all(
             [
                 "/" + ORG_NAME + "/" in url
                 for url in parsed_args.master_repo_urls
             ]
         )
-        assert all_urls_contain_org_name
 
     @pytest.mark.parametrize("parser", [cli.SETUP_PARSER, cli.UPDATE_PARSER])
     def test_token_env_variable_picked_up(

--- a/tests/test_github_api.py
+++ b/tests/test_github_api.py
@@ -785,11 +785,8 @@ class TestDeleteTeams:
         team_names = [team.name for team in teams]
 
         api.delete_teams(team_names)
-    
-        # call all outside of assert, workaround for bug in pytest 4.6.0
-        # https://github.com/pytest-dev/pytest/issues/5358
-        all_called = all(map(lambda t: t.delete.called, teams))
-        assert all_called
+
+        assert all(map(lambda t: t.delete.called, teams))
 
 
 @pytest.fixture(params=["get_user", "get_organization"])


### PR DESCRIPTION
This reverts commit 6d643bd78e9f3be1b0e28e135400bb01f09e9e89.

Fix #223 