### PR TITLE
[feat] Order CLI arguments

### DIFF
--- a/repobee/config.py
+++ b/repobee/config.py
@@ -30,17 +30,16 @@ DEFAULT_CONFIG_FILE = CONFIG_DIR / "config.cnf"
 assert DEFAULT_CONFIG_FILE.is_absolute()
 
 # arguments that can be configured via config file
-CONFIGURABLE_ARGS = set(
-    (
-        "user",
-        "org_name",
-        "github_base_url",
-        "students_file",
-        "plugins",
-        "master_org_name",
-        "token",
-    )
+ORDERED_CONFIGURABLE_ARGS = (
+    "user",
+    "org_name",
+    "github_base_url",
+    "students_file",
+    "plugins",
+    "master_org_name",
+    "token",
 )
+CONFIGURABLE_ARGS = set(ORDERED_CONFIGURABLE_ARGS)
 
 
 def get_configured_defaults(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,6 +289,30 @@ class TestDispatchCommand:
         )
 
 
+@pytest.mark.parametrize("parser", cli.PARSER_NAMES)
+def test_help_calls_add_arguments(monkeypatch, parser):
+    """Test that the --help command causes _OrderedFormatter.add_arguments to
+    be called. The reason this may not be the case is that
+    HelpFormatter.add_arguments is not technically public, and so it could be
+    removed or changed in future versions of Python.
+    """
+    called = False
+    add_arguments = cli._OrderedFormatter.add_arguments
+
+    def wrapper(self, *args, **kwargs):
+        nonlocal called
+        called = True
+        add_arguments(self, *args, **kwargs)
+
+    monkeypatch.setattr("repobee.cli._OrderedFormatter.add_arguments", wrapper)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.parse_args([parser, "--help"])
+
+    assert exc_info.value.code == 0
+    assert called
+
+
 class TestBaseParsing:
     """Test the basic functionality of parsing."""
 


### PR DESCRIPTION
Order arguments such that the configurable ones and debug arguments (`--traceback`) come last, and non-configurable arguments (i.e. the ones that probably matter most for that command).

The configurable arguments are inherently ordered (maybe they should be), but the non-configurable ones aren't. In any case, this is a large improvement for consistency. Small caveat is that **non-public APIs are used in the argparse module, see the `_OrderedFormatter` class for details**

Fix #168 