### PR TITLE
[misc] Fix base url names

### DIFF
--- a/docs/clone.rst
+++ b/docs/clone.rst
@@ -28,7 +28,7 @@ about it in the :ref:`plugins` section.
 .. note::
 
    `For security reasons
-   <https://github.blog/2012-09-21-easier-builds-and-deployments-using-git-over-https-and-oauth/>`_,
+   <https://github.blog/2012-09-21-easier-builds-and-deployments-using-buit-over-https-and-oauth/>`_,
    RepoBee doesn't actually use ``git clone`` to clone repositories. Instead,
    RepoBee clones by initializing the repository and running ``git pull``. The
    practical implication is that you can't simply enter a repository that's

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -37,7 +37,7 @@ consequence, a single organization).
 .. code-block:: bash
 
     [DEFAULTS]
-    github_base_url = https://some-api-v3-url
+    base_url = https://some-api-v3-url
     user = YOUR_USERNAME
     org_name = ORGANIZATION_NAME
     master_org_name = MASTER_ORGANIZATION_NAME

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -69,7 +69,7 @@ should look something like this:
 .. code-block:: bash
 
     [DEFAULTS]
-    github_base_url = https://some-enterprise-host/api/v3
+    base_url = https://some-enterprise-host/api/v3
     user = slarse
     org_name = repobee-demo
     master_org_name = master-repos
@@ -108,7 +108,7 @@ and parsed by running ``show-config`` again:
     [INFO]
     ----------------BEGIN CONFIG FILE-----------------
     [DEFAULTS]
-    github_base_url = https://some-enterprise-host/api/v3
+    base_url = https://some-enterprise-host/api/v3
     user = slarse
     org_name = repobee-demo
     master_org_name = master-repos

--- a/docs/gitlab.rst
+++ b/docs/gitlab.rst
@@ -63,16 +63,14 @@ differences and similarities in this `GitLab blog post`_.
 How to use RepoBee with GitLab
 ==============================
 Provide the url to a GitLab instance host (*not* to the api endpoint, just to
-the host) as an argument to ``-g|--github-base-url`` (yes, it's a bit weird as
-it says ``github`` in the option, but that will be changed in v2.0.0), or put
-it in the config file as the value for option ``github_base_url``. Other than
-that, there are a few important differences between GitHub and GitLab that the
-user should be aware of.
+the host) as an argument to ``-bu|--base-url``, or put it in the config file as
+the value for option ``base_url``. Other than that, there are a few important
+differences between GitHub and GitLab that the user should be aware of.
 
 * As noted, the base url should be provided to the host of the GitLab instance,
   and not to any specific endpoint (as is the case when using GitHub). When
   using ``github.com`` for example, the url should be provided as
-  ``github_base_url = https://gitlab.com`` in the config.
+  ``base_url = https://gitlab.com`` in the config.
 * The ``org-name`` and ``master-org-name`` arguments should be given the *path*
   of the respective groups. If you create a group with a long name, GitLab may
   shorten the path automatically. For example, I created the group

--- a/docs/peer.rst
+++ b/docs/peer.rst
@@ -34,7 +34,7 @@ look at the help message (i.e. run ``repobee assign-reviews -h``):
     $ repobee assign-reviews -h
     usage: repobee assign-reviews [-h]
                                    (-sf STUDENTS_FILE | -s STUDENTS [STUDENTS ...])
-                                   [-o ORG_NAME] [-g GITHUB_BASE_URL] [-t TOKEN]
+                                   [-o ORG_NAME] [-bu BASE_URL] [-t TOKEN]
                                    [-tb] -mn MASTER_REPO_NAMES
                                    [MASTER_REPO_NAMES ...] [-n N] [-i ISSUE]
 
@@ -52,7 +52,7 @@ look at the help message (i.e. run ``repobee assign-reviews -h``):
                             One or more whitespace separated student usernames.
       -o ORG_NAME, --org-name ORG_NAME
                             Name of the target organization
-      -g GITHUB_BASE_URL, --github-base-url GITHUB_BASE_URL
+      -bu BASE_URL, --base-url BASE_URL
                             Base url to a GitHub v3 API. For enterprise, this is
                             usually `https://<HOST>/api/v3`
       -t TOKEN, --token TOKEN
@@ -78,7 +78,7 @@ look at the help message (i.e. run ``repobee assign-reviews -h``):
 Most of this, we've seen before. The only non-standard arguments are
 ``--issue`` and ``--num-reviews``, the former of which we've actually already
 seen in the ``open-issues`` command (see :ref:`open`). I will assume that both
-``--github-base-url`` and ``--org-name`` are already configured in the
+``--base-url`` and ``--org-name`` are already configured in the
 configuration file (if you don't know what this mean, have a look at
 :ref:`config`). Thus, the only things we must specify are
 ``--students/--students-file`` and ``--num-reviews`` (``--issue`` is optional,

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -130,7 +130,7 @@ def empty_config_mock(mocker, isfile_mock, tmpdir):
 
 
 _config_user = "user = {}".format(constants.USER)
-_config_base = "base_url = {}".format(constants.GITHUB_BASE_URL)
+_config_base = "base_url = {}".format(constants.BASE_URL)
 _config_org = "org_name = {}".format(constants.ORG_NAME)
 _config_master_org = "master_org_name = {}".format(constants.MASTER_ORG_NAME)
 
@@ -162,7 +162,7 @@ def config_mock(empty_config_mock, students_file):
     config_contents = os.linesep.join(
         [
             "[DEFAULTS]",
-            "base_url = {}".format(constants.GITHUB_BASE_URL),
+            "base_url = {}".format(constants.BASE_URL),
             "user = {}".format(constants.USER),
             "org_name = {}".format(constants.ORG_NAME),
             "master_org_name = {}".format(constants.MASTER_ORG_NAME),

--- a/tests/unit_tests/constants.py
+++ b/tests/unit_tests/constants.py
@@ -10,7 +10,7 @@ USER = "slarse"
 ORG_NAME = "test-org"
 MASTER_ORG_NAME = "test-master-org"
 HOST_URL = "https://some_enterprise_host"
-GITHUB_BASE_URL = "{}/api/v3".format(HOST_URL)
+BASE_URL = "{}/api/v3".format(HOST_URL)
 
 # 5! = 120 different students
 STUDENTS = tuple(

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -15,7 +15,7 @@ import functions
 
 USER = constants.USER
 ORG_NAME = constants.ORG_NAME
-GITHUB_BASE_URL = constants.GITHUB_BASE_URL
+BASE_URL = constants.BASE_URL
 STUDENTS = constants.STUDENTS
 STUDENTS_STRING = " ".join([str(s) for s in STUDENTS])
 ISSUE_PATH = constants.ISSUE_PATH
@@ -27,14 +27,14 @@ TOKEN = constants.TOKEN
 REPO_NAMES = ("week-1", "week-2", "week-3")
 REPO_URLS = tuple(map(lambda rn: generate_repo_url(rn, ORG_NAME), REPO_NAMES))
 
-BASE_ARGS = ["-bu", GITHUB_BASE_URL, "-o", ORG_NAME]
+BASE_ARGS = ["-bu", BASE_URL, "-o", ORG_NAME]
 BASE_PUSH_ARGS = ["-u", USER, "-mn", *REPO_NAMES]
 COMPLETE_PUSH_ARGS = [*BASE_ARGS, *BASE_PUSH_ARGS]
 
 # parsed args without subparser
 VALID_PARSED_ARGS = dict(
     org_name=ORG_NAME,
-    base_url=GITHUB_BASE_URL,
+    base_url=BASE_URL,
     user=USER,
     master_repo_urls=REPO_URLS,
     master_repo_names=REPO_NAMES,
@@ -257,7 +257,7 @@ class TestDispatchCommand:
         args = tuples.Args(
             cli.VERIFY_PARSER,
             user=USER,
-            base_url=GITHUB_BASE_URL,
+            base_url=BASE_URL,
             token=TOKEN,
             org_name=ORG_NAME,
         )
@@ -272,7 +272,7 @@ class TestDispatchCommand:
         args = tuples.Args(
             cli.VERIFY_PARSER,
             user=USER,
-            base_url=GITHUB_BASE_URL,
+            base_url=BASE_URL,
             org_name=ORG_NAME,
             token=TOKEN,
             master_org_name=MASTER_ORG_NAME,
@@ -445,7 +445,7 @@ class TestBaseParsing:
     @pytest.mark.parametrize(
         "url",
         [
-            GITHUB_BASE_URL.replace("https://", non_tls_protocol)
+            BASE_URL.replace("https://", non_tls_protocol)
             for non_tls_protocol in ("http://", "ftp://", "")
         ],
     )
@@ -652,18 +652,18 @@ def assert_base_push_args(parsed_args, api):
     BASE_PUSH_ARGS.
     """
     assert parsed_args.org_name == ORG_NAME
-    assert parsed_args.base_url == GITHUB_BASE_URL
+    assert parsed_args.base_url == BASE_URL
     assert parsed_args.user == USER
     assert parsed_args.master_repo_names == list(REPO_NAMES)
     assert parsed_args.master_repo_urls == [
         generate_repo_url(rn, ORG_NAME) for rn in REPO_NAMES
     ]
-    api.assert_called_once_with(GITHUB_BASE_URL, TOKEN, ORG_NAME, USER)
+    api.assert_called_once_with(BASE_URL, TOKEN, ORG_NAME, USER)
 
 
 def assert_config_args(parser, parsed_args):
     """Asserts that the configured arguments are correct."""
-    assert parsed_args.base_url == GITHUB_BASE_URL
+    assert parsed_args.base_url == BASE_URL
     assert parsed_args.students == list(STUDENTS)
     assert parsed_args.org_name == ORG_NAME
 
@@ -721,7 +721,7 @@ class TestConfig:
         if config_missing_option == "-sf":  # must be file
             missing_arg = str(students_file)
         elif config_missing_option == "-bu":  # must be https url
-            missing_arg = GITHUB_BASE_URL
+            missing_arg = BASE_URL
         else:
             missing_arg = "whatever"
 
@@ -803,7 +803,7 @@ class TestMigrateParser:
     def assert_migrate_args(self, parsed_args) -> bool:
         assert parsed_args.user == USER
         assert parsed_args.org_name == ORG_NAME
-        assert parsed_args.base_url == GITHUB_BASE_URL
+        assert parsed_args.base_url == BASE_URL
         assert parsed_args.master_repo_names == self.NAMES
         assert parsed_args.master_repo_urls == self.LOCAL_URIS
 
@@ -832,7 +832,7 @@ class TestVerifyParser:
 
         assert args.subparser == cli.VERIFY_PARSER
         assert args.org_name == ORG_NAME
-        assert args.base_url == GITHUB_BASE_URL
+        assert args.base_url == BASE_URL
         assert args.user == USER
 
 
@@ -853,7 +853,7 @@ class TestCloneParser:
 
         assert args.subparser == cli.CLONE_PARSER
         assert args.org_name == ORG_NAME
-        assert args.base_url == GITHUB_BASE_URL
+        assert args.base_url == BASE_URL
         assert args.students == list(STUDENTS)
         # TODO assert with actual value
         plugin_manager_mock.hook.clone_parser_hook.assert_called_once_with(

--- a/tests/unit_tests/test_command.py
+++ b/tests/unit_tests/test_command.py
@@ -53,7 +53,7 @@ CLOSED_ISSUES = [
 ]
 
 ORG_NAME = "test-org"
-GITHUB_BASE_URL = "https://some_enterprise_host/api/v3"
+BASE_URL = "https://some_enterprise_host/api/v3"
 ISSUE = apimeta.Issue(
     "Oops, something went wrong!", "This is the body **with some formatting**."
 )
@@ -240,7 +240,7 @@ def assert_raises_on_duplicate_master_urls(function, master_urls, students):
     master_urls.append(master_urls[0])
 
     with pytest.raises(ValueError) as exc_info:
-        function(master_urls, students, ORG_NAME, GITHUB_BASE_URL)
+        function(master_urls, students, ORG_NAME, BASE_URL)
     assert str(exc_info.value) == "master_repo_urls contains duplicates"
 
 
@@ -302,7 +302,7 @@ class TestUpdateStudentRepos:
 
     @staticmethod
     def generate_url(repo_name):
-        return "{}/{}/{}".format(GITHUB_BASE_URL, ORG_NAME, repo_name)
+        return "{}/{}/{}".format(BASE_URL, ORG_NAME, repo_name)
 
     def test_raises_on_duplicate_master_urls(
         self, mocker, master_urls, students, api_mock

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -8,7 +8,7 @@ import constants
 
 STUDENTS = constants.STUDENTS
 USER = constants.USER
-GITHUB_BASE_URL = constants.GITHUB_BASE_URL
+BASE_URL = constants.BASE_URL
 ORG_NAME = constants.ORG_NAME
 MASTER_ORG_NAME = constants.MASTER_ORG_NAME
 PLUGINS = constants.PLUGINS
@@ -34,7 +34,7 @@ class TestGetConfiguredDefaults:
     ):
         defaults = config.get_configured_defaults()
         assert defaults["user"] == USER
-        assert defaults["base_url"] == GITHUB_BASE_URL
+        assert defaults["base_url"] == BASE_URL
         assert defaults["org_name"] == ORG_NAME
         assert defaults["students_file"] == str(students_file)
         assert defaults["plugins"] == ",".join(PLUGINS)
@@ -48,7 +48,7 @@ class TestGetConfiguredDefaults:
         config_contents = os.linesep.join(
             [
                 "[{}]".format(config.DEFAULTS_SECTION_HDR),
-                "base_url = {}".format(GITHUB_BASE_URL),
+                "base_url = {}".format(BASE_URL),
                 "user = {}".format(USER),
                 "org_name = {}".format(ORG_NAME),
                 "master_org_name = {}".format(MASTER_ORG_NAME),
@@ -70,7 +70,7 @@ class TestGetConfiguredDefaults:
     ):
         config_contents = os.linesep.join(
             [
-                "base_url = {}".format(GITHUB_BASE_URL),
+                "base_url = {}".format(BASE_URL),
                 "user = {}".format(USER),
                 "org_name = {}".format(ORG_NAME),
                 "students_file = {!s}".format(students_file),

--- a/tests/unit_tests/test_github_api.py
+++ b/tests/unit_tests/test_github_api.py
@@ -33,7 +33,7 @@ SERVER_ERROR = GithubException(msg=None, status=500)
 USER = constants.USER
 NOT_OWNER = "notanowner"
 ORG_NAME = constants.ORG_NAME
-GITHUB_BASE_URL = constants.GITHUB_BASE_URL
+BASE_URL = constants.BASE_URL
 ISSUE = constants.ISSUE
 TOKEN = constants.TOKEN
 
@@ -307,7 +307,7 @@ def issues(repos):
 def api(happy_github, organization, no_teams):
     from repobee import github_api
 
-    return github_api.GitHubAPI(GITHUB_BASE_URL, TOKEN, ORG_NAME)
+    return github_api.GitHubAPI(BASE_URL, TOKEN, ORG_NAME)
 
 
 class TestEnsureTeamsAndMembers:
@@ -807,24 +807,20 @@ class TestVerifySettings:
 
     def test_happy_path(self, happy_github, organization, api):
         """Tests that no exceptions are raised when all info is correct."""
-        github_api.GitHubAPI.verify_settings(
-            USER, ORG_NAME, GITHUB_BASE_URL, TOKEN
-        )
+        github_api.GitHubAPI.verify_settings(USER, ORG_NAME, BASE_URL, TOKEN)
 
     def test_empty_token_raises_bad_credentials(
         self, happy_github, monkeypatch, api
     ):
         with pytest.raises(exception.BadCredentials) as exc_info:
-            github_api.GitHubAPI.verify_settings(
-                USER, ORG_NAME, GITHUB_BASE_URL, ""
-            )
+            github_api.GitHubAPI.verify_settings(USER, ORG_NAME, BASE_URL, "")
 
         assert "token is empty" in str(exc_info.value)
 
     def test_incorrect_info_raises_not_found_error(self, github_bad_info, api):
         with pytest.raises(exception.NotFoundError):
             github_api.GitHubAPI.verify_settings(
-                USER, ORG_NAME, GITHUB_BASE_URL, TOKEN
+                USER, ORG_NAME, BASE_URL, TOKEN
             )
 
     def test_bad_token_scope_raises(self, happy_github, api):
@@ -832,14 +828,14 @@ class TestVerifySettings:
 
         with pytest.raises(exception.BadCredentials) as exc_info:
             github_api.GitHubAPI.verify_settings(
-                USER, ORG_NAME, GITHUB_BASE_URL, TOKEN
+                USER, ORG_NAME, BASE_URL, TOKEN
             )
         assert "missing one or more oauth scopes" in str(exc_info.value)
 
     def test_not_owner_raises(self, happy_github, organization, api):
         with pytest.raises(exception.BadCredentials) as exc_info:
             github_api.GitHubAPI.verify_settings(
-                NOT_OWNER, ORG_NAME, GITHUB_BASE_URL, TOKEN
+                NOT_OWNER, ORG_NAME, BASE_URL, TOKEN
             )
 
         assert "user {} is not an owner".format(NOT_OWNER) in str(
@@ -851,7 +847,7 @@ class TestVerifySettings:
     ):
         happy_github.get_user.side_effect = SERVER_ERROR
         with pytest.raises(exception.UnexpectedException):
-            api.verify_settings(USER, ORG_NAME, GITHUB_BASE_URL, TOKEN)
+            api.verify_settings(USER, ORG_NAME, BASE_URL, TOKEN)
 
     def test_none_user_raises(self, happy_github, organization, api):
         """If NamedUser.login is None, there should be an exception. Happens if
@@ -862,7 +858,7 @@ class TestVerifySettings:
 
         with pytest.raises(exception.UnexpectedException) as exc_info:
             github_api.GitHubAPI.verify_settings(
-                USER, ORG_NAME, GITHUB_BASE_URL, TOKEN
+                USER, ORG_NAME, BASE_URL, TOKEN
             )
 
         assert "Possible reasons: bad api url" in str(exc_info.value)
@@ -886,7 +882,7 @@ class TestVerifySettings:
 
         with pytest.raises(exception.UnexpectedException) as exc_info:
             github_api.GitHubAPI.verify_settings(
-                USER, ORG_NAME, GITHUB_BASE_URL, TOKEN
+                USER, ORG_NAME, BASE_URL, TOKEN
             )
 
         for msg in expected_messages:

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -11,12 +11,12 @@ from repobee import tuples
 import constants
 
 ORG_NAME = constants.ORG_NAME
-GITHUB_BASE_URL = constants.GITHUB_BASE_URL
+BASE_URL = constants.BASE_URL
 USER = constants.USER
 
 VALID_PARSED_ARGS = dict(
     org_name=ORG_NAME,
-    base_url=GITHUB_BASE_URL,
+    base_url=BASE_URL,
     user=USER,
     master_repo_urls="url-1 url-2 url-3".split(),
     master_repo_names="1 2 3".split(),


### PR DESCRIPTION
A few base url-related names were left with the GitHub prefix in tests and docs. This pr removes the GitHub prefix.