### PR TITLE
[feat] Make arguments not required by platform API optional

### DIFF
--- a/repobee/cli.py
+++ b/repobee/cli.py
@@ -713,8 +713,11 @@ def _create_base_parsers():
             else None
         )
 
-    def is_required(arg_name):
-        return arg_name not in configured_defaults
+    def configured(arg_name):
+        return arg_name in configured_defaults
+
+    def api_requires(arg_name):
+        return arg_name in plug.manager.hook.api_init_requires()
 
     base_parser = argparse.ArgumentParser(add_help=False)
     base_parser.add_argument(
@@ -722,7 +725,7 @@ def _create_base_parsers():
         "--org-name",
         help="Name of the target organization",
         type=str,
-        required=is_required("org_name"),
+        required=not configured("org_name") and api_requires("org_name"),
         default=default("org_name"),
     )
     base_parser.add_argument(
@@ -734,7 +737,7 @@ def _create_base_parsers():
             "GitHub enterprise, the url is https://<ENTERPRISE_HOST>/api/v3"
         ),
         type=str,
-        required=is_required("base_url"),
+        required=not configured("base_url") and api_requires("base_url"),
         default=default("base_url"),
     )
     base_parser.add_argument(
@@ -755,7 +758,7 @@ def _create_base_parsers():
     # base parser for when student lists are involved
     base_student_parser = argparse.ArgumentParser(add_help=False)
     students = base_student_parser.add_mutually_exclusive_group(
-        required=is_required("students_file")
+        required=not configured("students_file")
     )
     students.add_argument(
         "-sf",
@@ -781,7 +784,7 @@ def _create_base_parsers():
         "--user",
         help=("Your username."),
         type=str,
-        required=is_required("user"),
+        required=not configured("user") and api_requires("user"),
         default=default("user"),
     )
 

--- a/tests/integration_tests/integration_tests.py
+++ b/tests/integration_tests/integration_tests.py
@@ -168,10 +168,8 @@ def with_student_repos(restore):
     it runs before this fixture.
     """
     command = (
-        "repobee -p gitlab "
-        "setup -u {} -bu {} -o {} -mo {} -mn {} -s {} -t {} -tb"
+        "repobee -p gitlab " "setup -bu {} -o {} -mo {} -mn {} -s {} -t {} -tb"
     ).format(
-        OAUTH_USER,
         BASE_URL,
         ORG_NAME,
         MASTER_ORG_NAME,
@@ -241,9 +239,8 @@ class TestSetup:
         """Test a first-time setup with master repos in the master org."""
         command = (
             "repobee -p gitlab "
-            "setup -u {} -bu {} -o {} -mo {} -mn {} -s {} -t {} -tb"
+            "setup -bu {} -o {} -mo {} -mn {} -s {} -t {} -tb"
         ).format(
-            OAUTH_USER,
             BASE_URL,
             ORG_NAME,
             MASTER_ORG_NAME,
@@ -261,9 +258,8 @@ class TestSetup:
         """Setting up twice should have the same effect as setting up once."""
         command = (
             "repobee -p gitlab "
-            "setup -u {} -bu {} -o {} -mo {} -mn {} -s {} -t {} -tb"
+            "setup -bu {} -o {} -mo {} -mn {} -s {} -t {} -tb"
         ).format(
-            OAUTH_USER,
             BASE_URL,
             ORG_NAME,
             MASTER_ORG_NAME,
@@ -295,10 +291,8 @@ class TestMigrate:
         # clone the master repos to disk first first
         git_commands = ["git clone {}".format(url) for url in master_repo_urls]
         repobee_command = (
-            "repobee -p gitlab " "migrate -u {} -bu {} -o {} -mn {} -t {} -tb"
-        ).format(
-            OAUTH_USER, BASE_URL, ORG_NAME, " ".join(MASTER_REPO_NAMES), TOKEN
-        )
+            "repobee -p gitlab migrate -bu {} -o {} -mn {} -t {} -tb"
+        ).format(BASE_URL, ORG_NAME, " ".join(MASTER_REPO_NAMES), TOKEN)
         command = " && ".join(git_commands + [repobee_command])
 
         result = run_in_docker(command)

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 from unittest.mock import MagicMock
 from unittest import mock
+
 import pytest
 
 import repobee

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -7,6 +7,7 @@ from functions import raise_
 from repobee import cli
 from repobee import main
 from repobee import tuples
+from repobee import plugin
 
 import constants
 
@@ -30,15 +31,6 @@ PARSED_ARGS = tuples.Args(cli.SETUP_PARSER, **VALID_PARSED_ARGS)
 CLONE_ARGS = "clone -mn week-2 -s slarse".split()
 
 module = namedtuple("module", ("name",))
-
-
-@pytest.fixture(autouse=True)
-def register_plugins_mock(mocker):
-    """As initialize_plugins is called multiple times, we need to mock out the
-    register_plugins method. Otherwise, it raises when trying to load the same
-    plugin twice.
-    """
-    return mocker.patch("repobee.plugin.register_plugins", autospec=True)
 
 
 @pytest.fixture
@@ -171,8 +163,16 @@ def test_plug_arg_incompatible_with_no_plugins(
 
 
 def test_invalid_plug_options(dispatch_command_mock, init_plugins_mock):
-    # -f is not a valid option for plugins and should be bumped to the
-    # main parser
+    """-f is not a valid option for plugins and should be bumped to the
+    main parser
+
+    Note that the default plugins must be loaded for this test to work.
+    """
+    # load default plugins
+    loaded = plugin.load_plugin_modules()
+    print(loaded)
+    plugin.register_plugins(loaded)
+
     sys_args = ["repobee", "-p", "javac", "-f", *CLONE_ARGS]
 
     with pytest.raises(SystemExit):


### PR DESCRIPTION
Most notably, when using the `gitlab` plugin, `user` no longer needs to be specified.

Fix #274 