### PR TITLE
[fix] Fix problems with failed pulls and name conflicts

### DIFF
--- a/repobee/apimeta.py
+++ b/repobee/apimeta.py
@@ -260,6 +260,16 @@ class APISpec:
         """
         _not_implemented()
 
+    def extract_repo_name(self, repo_url: str) -> str:
+        """Extract a repo name from the provided url.
+
+        Args:
+            repo_url: A URL to a repository.
+        Returns:
+            The name of the repository corresponding to the url.
+        """
+        _not_implemented()
+
     def get_issues(
         self,
         repo_names: Iterable[str],

--- a/repobee/ext/github.py
+++ b/repobee/ext/github.py
@@ -11,6 +11,7 @@ GitHubAPI are mostly high-level bulk operations.
 .. moduleauthor:: Simon Larsén
 """
 import re
+import pathlib
 from typing import List, Iterable, Mapping, Optional, Generator, Tuple
 from socket import gaierror
 import collections
@@ -368,6 +369,10 @@ class GitHubAPI(apimeta.API):
                 for repo_name in list(repo_names)
             )
         ]
+
+    def extract_repo_name(self, repo_url: str) -> str:
+        """See :py:func:`repobee.apimeta.APISpec.extract_repo_names`."""
+        return pathlib.Path(repo_url).stem
 
     def _insert_auth(self, repo_url: str):
         """Insert an authentication token into the url.

--- a/repobee/ext/gitlab.py
+++ b/repobee/ext/gitlab.py
@@ -12,10 +12,11 @@ GitLabAPI are mostly high-level bulk operations.
 """
 import os
 import re
-from typing import List, Iterable, Optional, Generator, Tuple
-from socket import gaierror
 import collections
 import contextlib
+import pathlib
+from typing import List, Iterable, Optional, Generator, Tuple
+from socket import gaierror
 
 import daiquiri
 import gitlab
@@ -326,6 +327,10 @@ class GitLabAPI(apimeta.API):
             ]
         )
         return [self._insert_auth(url) for url in repo_urls]
+
+    def extract_repo_name(self, repo_url: str) -> str:
+        """See :py:func:`repobee.apimeta.APISpec.extract_repo_names`."""
+        return pathlib.Path(repo_url).stem
 
     def _insert_auth(self, repo_url: str):
         """Insert an authentication token into the url.

--- a/repobee/util.py
+++ b/repobee/util.py
@@ -9,7 +9,7 @@
 import os
 import sys
 import pathlib
-from typing import Iterable, Generator, Union
+from typing import Iterable, Generator, Union, Set
 
 from repobee import apimeta
 
@@ -35,6 +35,20 @@ def generate_repo_name(team_name: str, master_repo_name: str) -> str:
         master_repo_name: Name of the template repository.
     """
     return "{}-{}".format(team_name, master_repo_name)
+
+
+def conflicting_files(filenames: Iterable[str], cwd: str = ".") -> Set[str]:
+    """Return a list of files (any kind of file, including directories, pipes
+    etc) in cwd that conflict with any of the given repo names.
+
+    Args:
+        repo_names: A list of filenames.
+        cwd: Directory to operate in.
+    Returns:
+        A set of conflicting filenames.
+    """
+    existing_filenames = set(os.listdir(cwd))
+    return set(filenames).intersection(existing_filenames)
 
 
 def generate_repo_names(

--- a/tests/integration_tests/integration_tests.py
+++ b/tests/integration_tests/integration_tests.py
@@ -325,6 +325,67 @@ class TestClone:
         assert second_result.returncode == 0
         assert_cloned_repos(STUDENT_REPO_NAMES, tmpdir)
 
+    def test_clone_does_not_create_dirs_on_fail(
+        self, with_student_repos, tmpdir, tmpdir_volume_arg
+    ):
+        """Test that no local directories are created for repos that RepoBee
+        fails to pull.
+        """
+        non_existing_master_repo_names = ["non-existing-1", "non-existing-2"]
+        command = " ".join(
+            [
+                REPOBEE_GITLAB,
+                repobee.cli.CLONE_PARSER,
+                *BASE_ARGS,
+                *STUDENTS_ARG,
+                "-mn",
+                " ".join(non_existing_master_repo_names),
+            ]
+        )
+
+        result = run_in_docker(command, extra_args=tmpdir_volume_arg)
+
+        assert result.returncode == 0
+        assert os.listdir(str(tmpdir)) == ["repobee.log"]
+
+    def test_clone_does_not_alter_existing_dirs(
+        self, with_student_repos, tmpdir, tmpdir_volume_arg
+    ):
+        """Test that clone does not clobber existing directories."""
+        team_with_local_repos = STUDENT_TEAMS[0]
+        teams_without_local_repos = STUDENT_TEAMS[1:]
+        pre_existing_dirnames = util.generate_repo_names(
+            [team_with_local_repos], MASTER_REPO_NAMES
+        )
+        non_pre_existing_dirnames = util.generate_repo_names(
+            teams_without_local_repos, MASTER_REPO_NAMES
+        )
+
+        expected_dir_hashes = dict()
+        for dirname in pre_existing_dirnames:
+            new_dir = tmpdir.mkdir(dirname)
+            new_file = new_dir.join("file")
+            new_file.write_text(dirname, encoding="utf-8")
+            expected_dir_hashes[dirname] = hash_directory(new_dir)
+
+        command = " ".join(
+            [
+                REPOBEE_GITLAB,
+                repobee.cli.CLONE_PARSER,
+                *BASE_ARGS,
+                *MASTER_REPOS_ARG,
+                *STUDENTS_ARG,
+            ]
+        )
+
+        result = run_in_docker(command, extra_args=tmpdir_volume_arg)
+
+        assert result.returncode == 0
+        assert_cloned_repos(non_pre_existing_dirnames, tmpdir)
+        for dirname in pre_existing_dirnames:
+            dirhash = hash_directory(pathlib.Path(str(tmpdir)) / dirname)
+            assert dirhash == expected_dir_hashes[dirname]
+
 
 @pytest.mark.filterwarnings("ignore:.*Unverified HTTPS request.*")
 class TestSetup:

--- a/tests/integration_tests/integration_tests.py
+++ b/tests/integration_tests/integration_tests.py
@@ -305,6 +305,26 @@ class TestClone:
         assert result.returncode == 0
         assert_cloned_repos(STUDENT_REPO_NAMES, tmpdir)
 
+    def test_clone_twice(self, with_student_repos, tmpdir, tmpdir_volume_arg):
+        """Cloning twice in a row should have the same effect as cloning once.
+        """
+        command = " ".join(
+            [
+                REPOBEE_GITLAB,
+                repobee.cli.CLONE_PARSER,
+                *BASE_ARGS,
+                *MASTER_REPOS_ARG,
+                *STUDENTS_ARG,
+            ]
+        )
+
+        first_result = run_in_docker(command, extra_args=tmpdir_volume_arg)
+        second_result = run_in_docker(command, extra_args=tmpdir_volume_arg)
+
+        assert first_result.returncode == 0
+        assert second_result.returncode == 0
+        assert_cloned_repos(STUDENT_REPO_NAMES, tmpdir)
+
 
 @pytest.mark.filterwarnings("ignore:.*Unverified HTTPS request.*")
 class TestSetup:

--- a/tests/unit_tests/test_command.py
+++ b/tests/unit_tests/test_command.py
@@ -529,15 +529,20 @@ class TestCloneRepos:
             "repobee.config.get_plugin_names", return_value=PLUGINS
         )
 
-    def test_happy_path(self, api_mock, git_mock, master_names, students):
+    def test_happy_path(
+        self, api_mock, git_mock, master_names, students, tmpdir
+    ):
         """Tests that the correct calls are made when there are no errors."""
         expected_urls = [
             generate_repo_url(name)
             for name in util.generate_repo_names(students, master_names)
         ]
+
         command.clone_repos(master_names, students, api_mock)
 
-        git_mock.clone.assert_called_once_with(expected_urls)
+        # note that the tmpdir_mock fixture sets the return value of
+        # tmpdir.TemporaryDirectory to tmpdir!
+        git_mock.clone.assert_called_once_with(expected_urls, cwd=str(tmpdir))
 
     def test_executes_act_hooks(
         self, api_mock, git_mock, master_names, students, act_hook_mocks


### PR DESCRIPTION
Fix some issues related to the clone command. Most notably:

* `clone` now skips any repos that are already present in the current directory
* `clone` does not create local directories for repos which fail to be cloned

Also adds the `extract_repo_name` function to the APISpec, and implementations in `GitHubAPI` and `GitLabAPI`

It's mostly system tested. The old unit tests still run over the changed code but they don't test these specific aspects.

Fix #203 