### PR TITLE
[fact] Replace use of tuples.Args with argparse.Namespace

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
 
+    brew update --force
     brew upgrade pyenv
     eval "$(pyenv init -)"
     pyenv install 3.5.4 --skip-existing

--- a/src/_repobee/cli.py
+++ b/src/_repobee/cli.py
@@ -123,21 +123,21 @@ PRE_PARSER_FLAGS = [PRE_PARSER_NO_PLUGS, PRE_PARSER_SHOW_ALL_OPTS]
 
 def parse_args(
     sys_args: Iterable[str], show_all_opts=False
-) -> (tuples.Args, Optional[apimeta.API]):
+) -> (argparse.Namespace, Optional[apimeta.API]):
     """Parse the command line arguments and initialize an API.
 
     Args:
         sys_args: A list of command line arguments.
 
     Returns:
-        a tuples.Args namedtuple with the arguments, and an initialized
+        a argparse.Namespace namedtuple with the arguments, and an initialized
         apimeta.API instance (or None of testing connection).
     """
     parser = _create_parser(show_all_opts)
     args = parser.parse_args(_handle_deprecation(sys_args))
 
     if getattr(args, SUB) == SHOW_CONFIG_PARSER:
-        return tuples.Args(subparser=SHOW_CONFIG_PARSER), None
+        return argparse.Namespace(subparser=SHOW_CONFIG_PARSER), None
 
     _validate_tls_url(args.base_url)
 
@@ -149,7 +149,7 @@ def parse_args(
     if getattr(args, SUB) == VERIFY_PARSER:
         # quick parse for verify connection
         return (
-            tuples.Args(
+            argparse.Namespace(
                 subparser=VERIFY_PARSER,
                 org_name=args.org_name,
                 base_url=args.base_url,
@@ -191,30 +191,23 @@ def parse_args(
             "review commands do not currently support groups of students"
         )
 
-    parsed_args = tuples.Args(
-        subparser=subparser,
-        org_name=args.org_name,
-        master_org_name=args.master_org_name
-        if "master_org_name" in args
-        else None,
-        base_url=args.base_url,
-        user=args.user if "user" in args else None,
-        master_repo_urls=master_urls,
-        master_repo_names=master_names,
-        students=_extract_groups(args),
-        issue=util.read_issue(args.issue)
-        if "issue" in args and args.issue
-        else None,
-        title_regex=args.title_regex if "title_regex" in args else None,
-        traceback=args.traceback,
-        state=args.state if "state" in args else None,
-        show_body=args.show_body if "show_body" in args else None,
-        author=args.author if "author" in args else None,
-        num_reviews=args.num_reviews if "num_reviews" in args else None,
-        token=token,
-    )
+    args_dict = vars(args)
+    args_dict.setdefault("master_org_name", None)
+    args_dict.setdefault("title_regex", None)
+    args_dict.setdefault("state", None)
+    args_dict.setdefault("show_body", None)
+    args_dict.setdefault("author", None)
+    args_dict.setdefault("num_reviews", None)
 
-    return parsed_args, api
+    args_dict["issue"] = (
+        util.read_issue(args.issue) if "issue" in args and args.issue else None
+    )
+    args_dict["students"] = _extract_groups(args)
+    args_dict["master_repo_urls"] = master_urls
+    args_dict["master_repo_names"] = master_names
+    args_dict["token"] = token
+
+    return argparse.Namespace(**args_dict), api
 
 
 def _validate_tls_url(url):
@@ -251,13 +244,13 @@ def _handle_deprecation(sys_args: List[str]) -> List[str]:
     return list(sys_args)
 
 
-def dispatch_command(args: tuples.Args, api: apimeta.API):
+def dispatch_command(args: argparse.Namespace, api: apimeta.API):
     """Handle parsed CLI arguments and dispatch commands to the appropriate
     functions. Expected exceptions are caught and turned into SystemExit
     exceptions, while unexpected exceptions are allowed to propagate.
 
     Args:
-        args: A namedtuple containing parsed command line arguments.
+        args: A namespace of parsed command line arguments.
         api: An initialized apimeta.API instance.
     """
     if args.subparser == SETUP_PARSER:

--- a/src/_repobee/tuples.py
+++ b/src/_repobee/tuples.py
@@ -12,28 +12,6 @@ the goal is to collect all container types in this module.
 """
 from collections import namedtuple
 
-Args = namedtuple(
-    "Args",
-    (
-        "subparser",
-        "org_name",
-        "base_url",
-        "user",
-        "master_repo_urls",
-        "master_repo_names",
-        "students",
-        "issue",
-        "title_regex",
-        "traceback",
-        "state",
-        "show_body",
-        "author",
-        "num_reviews",
-        "master_org_name",
-        "token",
-    ),
-)
-Args.__new__.__defaults__ = (None,) * len(Args._fields)
 
 Review = namedtuple("Review", ["repo", "done"])
 

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 import pathlib
 from unittest.mock import MagicMock
 from unittest import mock
@@ -9,7 +10,6 @@ import _repobee
 import _repobee.ext
 import _repobee.ext.github
 from _repobee import cli
-from _repobee import tuples
 from _repobee import exception
 from _repobee import apimeta
 from _repobee import plugin
@@ -38,6 +38,7 @@ COMPLETE_PUSH_ARGS = [*BASE_ARGS, *BASE_PUSH_ARGS]
 # parsed args without subparser
 VALID_PARSED_ARGS = dict(
     org_name=ORG_NAME,
+    master_org_name=MASTER_ORG_NAME,
     base_url=BASE_URL,
     user=USER,
     master_repo_urls=REPO_URLS,
@@ -50,6 +51,7 @@ VALID_PARSED_ARGS = dict(
     show_body=True,
     author=None,
     token=TOKEN,
+    num_reviews=1,
 )
 
 
@@ -108,11 +110,11 @@ def git_mock(mocker):
 
 @pytest.fixture(scope="function", params=cli.PARSER_NAMES)
 def parsed_args_all_subparsers(request):
-    """Parametrized fixture which returns a tuples.Args for each of the
+    """Parametrized fixture which returns a namespace for each of the
     subparsers. These arguments are valid for all subparsers, even though
     many will only use some of the arguments.
     """
-    return tuples.Args(subparser=request.param, **VALID_PARSED_ARGS)
+    return argparse.Namespace(subparser=request.param, **VALID_PARSED_ARGS)
 
 
 @pytest.fixture(
@@ -152,7 +154,7 @@ class TestDispatchCommand:
 
     def test_raises_on_invalid_subparser_value(self, api_instance_mock):
         parser = "DOES_NOT_EXIST"
-        args = tuples.Args(parser, **VALID_PARSED_ARGS)
+        args = argparse.Namespace(subparser=parser, **VALID_PARSED_ARGS)
 
         with pytest.raises(exception.ParseError) as exc_info:
             cli.dispatch_command(args, api_instance_mock)
@@ -180,7 +182,9 @@ class TestDispatchCommand:
     def test_setup_student_repos_called_with_correct_args(
         self, command_mock, api_instance_mock
     ):
-        args = tuples.Args(cli.SETUP_PARSER, **VALID_PARSED_ARGS)
+        args = argparse.Namespace(
+            subparser=cli.SETUP_PARSER, **VALID_PARSED_ARGS
+        )
 
         cli.dispatch_command(args, api_instance_mock)
 
@@ -191,7 +195,9 @@ class TestDispatchCommand:
     def test_update_student_repos_called_with_correct_args(
         self, command_mock, api_instance_mock
     ):
-        args = tuples.Args(cli.UPDATE_PARSER, **VALID_PARSED_ARGS)
+        args = argparse.Namespace(
+            subparser=cli.UPDATE_PARSER, **VALID_PARSED_ARGS
+        )
 
         cli.dispatch_command(args, api_instance_mock)
 
@@ -205,7 +211,9 @@ class TestDispatchCommand:
     def test_open_issue_called_with_correct_args(
         self, command_mock, api_instance_mock
     ):
-        args = tuples.Args(cli.OPEN_ISSUE_PARSER, **VALID_PARSED_ARGS)
+        args = argparse.Namespace(
+            subparser=cli.OPEN_ISSUE_PARSER, **VALID_PARSED_ARGS
+        )
 
         cli.dispatch_command(args, api_instance_mock)
 
@@ -219,7 +227,9 @@ class TestDispatchCommand:
     def test_close_issue_called_with_correct_args(
         self, command_mock, api_instance_mock
     ):
-        args = tuples.Args(cli.CLOSE_ISSUE_PARSER, **VALID_PARSED_ARGS)
+        args = argparse.Namespace(
+            subparser=cli.CLOSE_ISSUE_PARSER, **VALID_PARSED_ARGS
+        )
 
         cli.dispatch_command(args, api_instance_mock)
 
@@ -233,7 +243,9 @@ class TestDispatchCommand:
     def test_migrate_repos_called_with_correct_args(
         self, command_mock, api_instance_mock
     ):
-        args = tuples.Args(cli.MIGRATE_PARSER, **VALID_PARSED_ARGS)
+        args = argparse.Namespace(
+            subparser=cli.MIGRATE_PARSER, **VALID_PARSED_ARGS
+        )
 
         cli.dispatch_command(args, api_instance_mock)
 
@@ -244,7 +256,9 @@ class TestDispatchCommand:
     def test_clone_repos_called_with_correct_args(
         self, command_mock, api_instance_mock
     ):
-        args = tuples.Args(cli.CLONE_PARSER, **VALID_PARSED_ARGS)
+        args = argparse.Namespace(
+            subparser=cli.CLONE_PARSER, **VALID_PARSED_ARGS
+        )
 
         cli.dispatch_command(args, api_instance_mock)
 
@@ -255,12 +269,13 @@ class TestDispatchCommand:
     def test_verify_settings_called_with_correct_args(self, api_class_mock):
         # regular mockaing is broken for static methods, it seems, produces
         # non-callable so using monkeypatch instead
-        args = tuples.Args(
-            cli.VERIFY_PARSER,
+        args = argparse.Namespace(
+            subparser=cli.VERIFY_PARSER,
             user=USER,
             base_url=BASE_URL,
             token=TOKEN,
             org_name=ORG_NAME,
+            master_org_name=None,
         )
 
         cli.dispatch_command(args, None)
@@ -270,8 +285,8 @@ class TestDispatchCommand:
         )
 
     def test_verify_settings_called_with_master_org_name(self, api_class_mock):
-        args = tuples.Args(
-            cli.VERIFY_PARSER,
+        args = argparse.Namespace(
+            subparser=cli.VERIFY_PARSER,
             user=USER,
             base_url=BASE_URL,
             org_name=ORG_NAME,

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -7,7 +7,6 @@ import pytest
 from functions import raise_
 from _repobee import cli
 from _repobee import main
-from _repobee import tuples
 from _repobee import plugin
 
 import constants
@@ -25,9 +24,12 @@ VALID_PARSED_ARGS = dict(
     students=constants.STUDENTS,
     issue=constants.ISSUE,
     title_regex="some regex",
+    traceback=False,
 )
 
-PARSED_ARGS = tuples.Args(cli.SETUP_PARSER, **VALID_PARSED_ARGS)
+PARSED_ARGS = argparse.Namespace(
+    subparser=cli.SETUP_PARSER, **VALID_PARSED_ARGS
+)
 
 CLONE_ARGS = "clone -mn week-2 -s slarse".split()
 
@@ -204,7 +206,9 @@ def test_logs_traceback_on_exception_in_dispatch_if_traceback(
     logger_exception_mock,
 ):
     msg = "oh this is bad!!"
-    parsed_args = tuples.Args(**VALID_PARSED_ARGS, traceback=True)
+    args_with_traceback = dict(VALID_PARSED_ARGS)
+    args_with_traceback["traceback"] = True
+    parsed_args = argparse.Namespace(**args_with_traceback)
     parse_args_mock.return_value = parsed_args, api_instance_mock
 
     def raise_():


### PR DESCRIPTION
Fix #292 

Force-updating brew also seems to have solved the macOS problem, so fix #294 