### PR TITLE
[fix] Make config-wizard create missing directories

### DIFF
--- a/src/_repobee/ext/configwizard.py
+++ b/src/_repobee/ext/configwizard.py
@@ -40,7 +40,7 @@ def callback(args: argparse.Namespace, api: apimeta.API) -> None:
         parser.read(str(constants.DEFAULT_CONFIG_FILE))
 
     os.makedirs(
-        str(constants.DEFAULT_CONFIG_FILE.parent), mode=600, exist_ok=True
+        str(constants.DEFAULT_CONFIG_FILE.parent), mode=0o700, exist_ok=True
     )
     if constants.DEFAULTS_SECTION_HDR not in parser:
         parser.add_section(constants.DEFAULTS_SECTION_HDR)

--- a/src/_repobee/ext/configwizard.py
+++ b/src/_repobee/ext/configwizard.py
@@ -9,6 +9,7 @@ a short configuration wizard that lets the user set RepoBee's defaults.
 import argparse
 import configparser
 import sys
+import os
 
 import daiquiri
 import repobee_plug as plug
@@ -38,6 +39,9 @@ def callback(args: argparse.Namespace, api: apimeta.API) -> None:
             return
         parser.read(str(constants.DEFAULT_CONFIG_FILE))
 
+    os.makedirs(
+        str(constants.DEFAULT_CONFIG_FILE.parent), mode=600, exist_ok=True
+    )
     if constants.DEFAULTS_SECTION_HDR not in parser:
         parser.add_section(constants.DEFAULTS_SECTION_HDR)
 

--- a/tests/unit_tests/plugin_tests/test_configwizard.py
+++ b/tests/unit_tests/plugin_tests/test_configwizard.py
@@ -1,5 +1,6 @@
 import string
 import sys
+import os
 import collections
 import builtins  # noqa: F401
 import configparser
@@ -163,3 +164,16 @@ def test_retains_values_that_are_not_specified(config_mock, defaults_options):
         assert parser[_repobee.constants.DEFAULTS_SECTION_HDR][option] == value
     for option, value in plugin_options.items():
         assert parser[plugin_section][option] == value
+
+
+def test_creates_directory(config_mock, tmpdir, defaults_options):
+    with patch(
+        "builtins.input", side_effect=["yes"] + list(defaults_options.values())
+    ), patch("os.makedirs", autospec=True) as makedirs_mock, patch(
+        "pathlib.Path.exists", autospec=True, return_value=False
+    ):
+        configwizard.callback(None, None)
+
+    makedirs_mock.assert_called_once_with(
+        os.path.dirname(str(config_mock)), mode=600, exist_ok=True
+    )

--- a/tests/unit_tests/plugin_tests/test_configwizard.py
+++ b/tests/unit_tests/plugin_tests/test_configwizard.py
@@ -175,5 +175,5 @@ def test_creates_directory(config_mock, tmpdir, defaults_options):
         configwizard.callback(None, None)
 
     makedirs_mock.assert_called_once_with(
-        os.path.dirname(str(config_mock)), mode=600, exist_ok=True
+        os.path.dirname(str(config_mock)), mode=0o700, exist_ok=True
     )


### PR DESCRIPTION
If the config directory doesn't exist, config-wizard creates it with 700 permissions.

Fix #297 