### PR TITLE
[fact] Refactor generate_review_allocations implementations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ daiquiri
 pluggy>=0.8.0
 pygithub
 python-gitlab==1.8.0
-repobee-plug==0.7.0
+repobee-plug==0.8.0a1

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ required = [
     "daiquiri",
     "pygithub",
     "colored",
-    "repobee-plug==0.8.0a0",
+    "repobee-plug==0.8.0a1",
     "python-gitlab==1.8.0",
 ]
 

--- a/src/_repobee/command.py
+++ b/src/_repobee/command.py
@@ -27,7 +27,6 @@ import repobee_plug as plug
 
 from _repobee import git
 from _repobee import util
-from repobee_plug import apimeta
 from _repobee import exception
 from _repobee import config
 from _repobee import constants
@@ -38,9 +37,7 @@ LOGGER = daiquiri.getLogger(__file__)
 
 
 def setup_student_repos(
-    master_repo_urls: Iterable[str],
-    teams: Iterable[apimeta.Team],
-    api: apimeta.API,
+    master_repo_urls: Iterable[str], teams: Iterable[plug.Team], api: plug.API
 ) -> None:
     """Setup student repositories based on master repo templates. Performs three
     primary tasks:
@@ -61,7 +58,7 @@ def setup_student_repos(
     Args:
         master_repo_urls: URLs to master repos.
         teams: An iterable of student teams specifying the teams to be setup.
-        api: An implementation of :py:class:`apimeta.API` used to interface
+        api: An implementation of :py:class:`plug.API` used to interface
             with the platform (e.g. GitHub or GitLab) instance.
     """
     urls = list(master_repo_urls)  # safe copy
@@ -79,8 +76,8 @@ def setup_student_repos(
 
 
 def _add_students_to_teams(
-    teams: Iterable[apimeta.Team], api: apimeta.API
-) -> List[apimeta.Team]:
+    teams: Iterable[plug.Team], api: plug.API
+) -> List[plug.Team]:
     """Create the specified teams on the target platform,
     and add the specified members to their teams. If a team already exists, it
     is not created. If a student is already in his/her team, that student is
@@ -97,9 +94,7 @@ def _add_students_to_teams(
 
 
 def _create_student_repos(
-    master_repo_urls: Iterable[str],
-    teams: Iterable[apimeta.Team],
-    api: apimeta.API,
+    master_repo_urls: Iterable[str], teams: Iterable[plug.Team], api: plug.API
 ) -> List[str]:
     """Create student repos. Each team is assigned a single repo per master
     repo. Repos that already exist are not created, but their urls are returned
@@ -108,7 +103,7 @@ def _create_student_repos(
     Args:
         master_repo_urls: URLs to master repos.
         teams: An iterable of student teams specifying the teams to be setup.
-        api: An implementation of :py:class:`apimeta.API` used to interface
+        api: An implementation of :py:class:`plug.API` used to interface
             with the platform (e.g. GitHub or GitLab) instance.
     Returns:
         a list of urls to the repos
@@ -146,9 +141,9 @@ def _clone_all(urls: Iterable[str], cwd: str):
 
 def update_student_repos(
     master_repo_urls: Iterable[str],
-    teams: Iterable[apimeta.Team],
-    api: apimeta.API,
-    issue: Optional[apimeta.Issue] = None,
+    teams: Iterable[plug.Team],
+    api: plug.API,
+    issue: Optional[plug.Issue] = None,
 ) -> None:
     """Attempt to update all student repos related to one of the master repos.
 
@@ -186,7 +181,7 @@ def update_student_repos(
 
 
 def _open_issue_by_urls(
-    repo_urls: Iterable[str], issue: apimeta.Issue, api: apimeta.API
+    repo_urls: Iterable[str], issue: plug.Issue, api: plug.API
 ) -> None:
     """Open issues in the repos designated by the repo_urls.
 
@@ -202,8 +197,8 @@ def _open_issue_by_urls(
 
 def list_issues(
     master_repo_names: Iterable[str],
-    teams: Iterable[apimeta.Team],
-    api: apimeta.API,
+    teams: Iterable[plug.Team],
+    api: plug.API,
     state: str = "open",
     title_regex: str = "",
     show_body: bool = False,
@@ -239,7 +234,7 @@ def list_issues(
 
 
 def _log_repo_issues(
-    issues_per_repo: Tuple[str, Generator[apimeta.Issue, None, None]],
+    issues_per_repo: Tuple[str, Generator[plug.Issue, None, None]],
     show_body: bool,
     title_alignment: int,
 ) -> None:
@@ -309,10 +304,10 @@ def _limit_line_length(s: str, max_line_length: int = 100) -> str:
 
 
 def open_issue(
-    issue: apimeta.Issue,
+    issue: plug.Issue,
     master_repo_names: Iterable[str],
-    teams: Iterable[apimeta.Team],
-    api: apimeta.API,
+    teams: Iterable[plug.Team],
+    api: plug.API,
 ) -> None:
     """Open an issue in student repos.
 
@@ -330,8 +325,8 @@ def open_issue(
 def close_issue(
     title_regex: str,
     master_repo_names: Iterable[str],
-    teams: Iterable[apimeta.Team],
-    api: apimeta.API,
+    teams: Iterable[plug.Team],
+    api: plug.API,
 ) -> None:
     """Close issues whose titles match the title_regex in student repos.
 
@@ -347,9 +342,7 @@ def close_issue(
 
 
 def clone_repos(
-    master_repo_names: Iterable[str],
-    teams: Iterable[apimeta.Team],
-    api: apimeta.API,
+    master_repo_names: Iterable[str], teams: Iterable[plug.Team], api: plug.API
 ) -> None:
     """Clone all student repos related to the provided master repos and student
     teams.
@@ -407,7 +400,7 @@ def _clone_repos_no_check(repo_urls, dst_dirpath, api):
     return [repo.name for repo in cloned_repos]
 
 
-def _execute_post_clone_hooks(repo_names: List[str], api: apimeta.API):
+def _execute_post_clone_hooks(repo_names: List[str], api: plug.API):
     LOGGER.info("Executing post clone hooks on repos")
     local_repos = [name for name in os.listdir() if name in repo_names]
 
@@ -423,7 +416,7 @@ def _execute_post_clone_hooks(repo_names: List[str], api: apimeta.API):
     LOGGER.info("Post clone hooks done")
 
 
-def migrate_repos(master_repo_urls: Iterable[str], api: apimeta.API) -> None:
+def migrate_repos(master_repo_urls: Iterable[str], api: plug.API) -> None:
     """Migrate a repository from an arbitrary URL to the target organization.
     The new repository is added to the master_repos team, which is created if
     it does not already exist.
@@ -437,7 +430,7 @@ def migrate_repos(master_repo_urls: Iterable[str], api: apimeta.API) -> None:
     master_names = [util.repo_name(url) for url in master_repo_urls]
 
     infos = [
-        apimeta.Repo(
+        plug.Repo(
             name=master_name,
             description="Master repository {}".format(master_name),
             private=True,
@@ -465,10 +458,10 @@ def migrate_repos(master_repo_urls: Iterable[str], api: apimeta.API) -> None:
 
 def assign_peer_reviews(
     master_repo_names: Iterable[str],
-    teams: Iterable[apimeta.Team],
+    teams: Iterable[plug.Team],
     num_reviews: int,
-    issue: Optional[apimeta.Issue],
-    api: apimeta.API,
+    issue: Optional[plug.Issue],
+    api: plug.API,
 ) -> None:
     """Assign peer reviewers among the students to each student repo. Each
     student is assigned to review num_reviews repos, and consequently, each
@@ -493,30 +486,31 @@ def assign_peer_reviews(
     # currently only supports single student teams
     # TODO support groups of students
     assert all(map(lambda g: len(g.members) == 1, teams))
-    single_students = [t.members[0] for t in teams]
 
     for master_name in master_repo_names:
-        # TODO the returned allocations should be apimeta.Team instances
-        # but it can't be fixed until apimeta is moved to repobee_plug.
         allocations = plug.manager.hook.generate_review_allocations(
-            master_repo_name=master_name,
-            students=single_students,
-            num_reviews=num_reviews,
-            review_team_name_function=util.generate_review_team_name,
+            students=teams, num_reviews=num_reviews
         )
+        # adjust names of review teams
         review_teams = [
-            apimeta.Team(name=team_name, members=members)
-            for team_name, members in allocations.items()
+            plug.Team(
+                members=alloc.review_team,
+                name=util.generate_review_team_name(
+                    str(alloc.reviewed_team), master_name
+                ),
+            )
+            for alloc in allocations
         ]
         api.ensure_teams_and_members(
-            review_teams, permission=apimeta.TeamPermission.PULL
+            review_teams, permission=plug.TeamPermission.PULL
         )
+        # TODO finish up here, this is entirely broken!
         api.add_repos_to_review_teams(
             {
-                util.generate_review_team_name(student, master_name): [
-                    util.generate_repo_name(student, master_name)
-                ]
-                for student in single_students
+                util.generate_review_team_name(
+                    str(alloc.reviewed_team), master_name
+                ): [util.generate_repo_name("student", master_name)]
+                for alloc in allocations
             },
             issue=issue,
         )
@@ -524,8 +518,8 @@ def assign_peer_reviews(
 
 def purge_review_teams(
     master_repo_names: Iterable[str],
-    students: Iterable[apimeta.Team],
-    api: apimeta.API,
+    students: Iterable[plug.Team],
+    api: plug.API,
 ) -> None:
     """Delete all review teams associated with the given master repo names and
     students.
@@ -546,10 +540,10 @@ def purge_review_teams(
 
 def check_peer_review_progress(
     master_repo_names: Iterable[str],
-    students: Iterable[apimeta.Team],
+    students: Iterable[plug.Team],
     title_regex: str,
     num_reviews: int,
-    api: apimeta.API,
+    api: plug.API,
 ) -> None:
     """Check which students have opened peer review issues in their allotted
     review repos
@@ -584,8 +578,8 @@ def check_peer_review_progress(
 
 
 def _create_repo_infos(
-    urls: Iterable[str], teams: Iterable[apimeta.Team]
-) -> List[apimeta.Repo]:
+    urls: Iterable[str], teams: Iterable[plug.Team]
+) -> List[plug.Repo]:
     """Create Repo namedtuples for all combinations of url and team.
 
     Args:
@@ -599,7 +593,7 @@ def _create_repo_infos(
     for url in urls:
         repo_base_name = util.repo_name(url)
         repo_infos += [
-            apimeta.Repo(
+            plug.Repo(
                 name=util.generate_repo_name(team.name, repo_base_name),
                 description="{} created for {}".format(
                     repo_base_name, team.name

--- a/src/_repobee/ext/defaults.py
+++ b/src/_repobee/ext/defaults.py
@@ -16,76 +16,55 @@ default implementation.
 .. moduleauthor:: Simon Larsén
 """
 import random
-from typing import Callable, Iterable, Mapping, List
+import itertools
+from typing import List
 
-from repobee_plug import repobee_hook
+import repobee_plug as plug
 
 # import other default plugins
 from _repobee.ext.github import DefaultAPIHooks  # noqa: F401
 from _repobee.ext.configwizard import create_extension_command  # noqa: F401
 
 
-@repobee_hook
+@plug.repobee_hook
 def generate_review_allocations(
-    master_repo_name: str,
-    students: Iterable[str],
-    num_reviews: int,
-    review_team_name_function: Callable[[str, str], str],
-) -> Mapping[str, List[str]]:
-    """Generate a (peer_review_team -> reviewers) mapping for each student
-    repository (i.e. <student>-<master_repo_name>), where len(reviewers) =
-    num_reviews.
-
-    review_team_name_function should be used to generate review team names.
-    It should be called like:
-
-    .. code-block:: python
-
-        review_team_name_function(master_repo_name, student)
-
-    .. important::
-
-        There must be strictly more students than reviewers per repo
-        (`num_reviews`). Otherwise, allocation is impossible.
-
-    Args:
-        master_repo_name: Name of a master repository.
-        students: Students for which to generate peer review allocations.
-        num_reviews: Amount of reviews each student should perform (and
-        consequently amount of reviewers per repo)
-        review_team_name_function: A function that takes a master repo name
-        as its first argument, and a student username as its second, and
-        returns a review team name.
-    Returns:
-        a (peer_review_team -> reviewers) mapping for each student repository.
-    """
-    students = list(students)
-    if num_reviews >= len(students):
-        raise ValueError("num_reviews must be less than len(students)")
+    teams: List[plug.Team], num_reviews: int
+) -> List[plug.ReviewAllocation]:
+    if num_reviews >= len(teams):
+        raise ValueError("num_reviews must be less than len(teams)")
     if num_reviews <= 0:
         raise ValueError("num_reviews must be greater than 0")
-    if len(students) < 2:
+    if len(teams) < 2:
         raise ValueError(
-            "there must be at least 2 students for peer review, "
-            "but {} were provided".format(len(students))
+            "there must be at least 2 teams for peer review, "
+            "but {} were provided".format(len(teams))
         )
 
-    random.shuffle(students)
+    random.shuffle(teams)
 
     # create a list of lists, where each non-first list is a left-shifted
     # version of the previous list (lists wrap around)
-    # e.g. for students [4, 3, 1] and num_reviews = 2, the result is
+    # e.g. for teams [4, 3, 1] and num_reviews = 2, the result is
     # allocations = [[4, 3, 1], [3, 1, 4], [1, 4, 3]] and means that
     # student 4 gets reviewed by 3 and 1, 3 by 1 and 4 etc.
-    allocations = [students]
+    allocations = [teams]
     for _ in range(num_reviews):
         next_reviewers = list(allocations[-1])
         next_reviewers.append(next_reviewers.pop(0))  # shift list left
         allocations.append(next_reviewers)
 
-    review_allocations = {
-        review_team_name_function(reviewee, master_repo_name): reviewers
-        for reviewee, *reviewers in zip(*allocations)
-    }
+    def merge_teams(teams):
+        members = list(
+            itertools.chain.from_iterable([team.members for team in teams])
+        )
+        return plug.Team(members=members)
+
+    transposed_allocations = zip(*allocations)
+    review_allocations = [
+        plug.ReviewAllocation(
+            review_team=merge_teams(reviewers), reviewed_team=reviewed_team
+        )
+        for reviewed_team, *reviewers in transposed_allocations
+    ]
 
     return review_allocations

--- a/src/_repobee/main.py
+++ b/src/_repobee/main.py
@@ -77,7 +77,7 @@ def main(sys_args: List[str]):
         traceback = parsed_args.traceback
         pre_init = False
         cli.dispatch_command(parsed_args, api, ext_commands)
-    except (Exception, SystemExit) as exc:
+    except Exception as exc:
         # FileErrors can occur during pre-init because of reading the config
         # and we don't want tracebacks for those (afaik at this time)
         if traceback or (

--- a/src/_repobee/main.py
+++ b/src/_repobee/main.py
@@ -77,7 +77,7 @@ def main(sys_args: List[str]):
         traceback = parsed_args.traceback
         pre_init = False
         cli.dispatch_command(parsed_args, api, ext_commands)
-    except Exception as exc:
+    except (Exception, SystemExit) as exc:
         # FileErrors can occur during pre-init because of reading the config
         # and we don't want tracebacks for those (afaik at this time)
         if traceback or (

--- a/tests/unit_tests/plugin_tests/test_defaults.py
+++ b/tests/unit_tests/plugin_tests/test_defaults.py
@@ -1,43 +1,30 @@
 """Tests for the defaults plugin."""
-import string
 import itertools
 import collections
 
 import pytest
 
-from _repobee import util
 from _repobee.ext import defaults
+
+import constants
 
 
 class TestGenerateReviewAllocations:
     """Tests the default implementation of generate_review_allocations."""
 
-    @pytest.mark.parametrize(
-        "num_students, num_reviews", [(10, 10), (3, 15), (0, 0)]
-    )
-    def test_throws_when_too_many_reviews(self, num_students, num_reviews):
-        master_repo_name = "week-2"
-        students = list(string.ascii_lowercase[:num_students])
+    @pytest.mark.parametrize("num_students, num_reviews", [(10, 10), (3, 15)])
+    def test_raises_when_too_many_reviews(self, num_students, num_reviews):
+        teams = list(constants.STUDENTS[:num_students])
         with pytest.raises(ValueError) as exc_info:
-            defaults.generate_review_allocations(
-                master_repo_name,
-                students,
-                num_reviews,
-                util.generate_review_team_name,
-            )
+            defaults.generate_review_allocations(teams, num_reviews)
 
-        assert "num_reviews must be less than len(students)" in str(
+        assert "num_reviews must be less than len(teams)" in str(
             exc_info.value
         )
 
-    def test_throws_when_too_few_reviews(self):
+    def test_raises_when_too_few_reviews(self):
         with pytest.raises(ValueError) as exc_info:
-            defaults.generate_review_allocations(
-                "week-2",
-                list(string.ascii_lowercase),
-                0,
-                util.generate_review_team_name,
-            )
+            defaults.generate_review_allocations(list(constants.STUDENTS), 0)
         assert "num_reviews must be greater than 0" in str(exc_info.value)
 
     @pytest.mark.parametrize(
@@ -47,17 +34,17 @@ class TestGenerateReviewAllocations:
         self, num_students, num_reviews
     ):
         """All students should have to review precisely num_reviews repos."""
-        students = list(string.ascii_letters[:num_students])
+        students = list(constants.STUDENTS[:num_students])
         assert len(students) == num_students, "pre-test assert"
 
         allocations = defaults.generate_review_allocations(
-            "week-2", students, num_reviews, util.generate_review_team_name
+            students, num_reviews
         )
 
         # flatten the peer review lists
         peer_reviewers = list(
             itertools.chain.from_iterable(
-                reviewers for reviewers in allocations.values()
+                alloc.review_team.members for alloc in allocations
             )
         )
         counts = collections.Counter(peer_reviewers)
@@ -70,20 +57,11 @@ class TestGenerateReviewAllocations:
     )
     def test_all_students_get_reviewed(self, num_students, num_reviews):
         """All students should get a review team."""
-        students = string.ascii_letters[:num_students]
-        master_repo_name = "week-5"
-        assert len(students) == num_students, "pre-test assert"
+        teams = list(constants.STUDENTS[:num_students])
+        expected_reviewed_teams = list(teams)
 
-        expected_review_teams = [
-            util.generate_review_team_name(student, master_repo_name)
-            for student in students
-        ]
+        allocations = defaults.generate_review_allocations(teams, num_reviews)
 
-        allocations = defaults.generate_review_allocations(
-            master_repo_name,
-            students,
-            num_reviews,
-            util.generate_review_team_name,
+        assert sorted(expected_reviewed_teams) == sorted(
+            [alloc.reviewed_team for alloc in allocations]
         )
-
-        assert set(expected_review_teams) == set(allocations.keys())


### PR DESCRIPTION
Refactor of the generate_review_allocations hooks. Pre-requisite for implementing reviews for teams with more than one member (see #167).

Fix #303 