### PR TITLE
[feat] Add --hook-results-file option to clone command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ daiquiri
 pluggy>=0.8.0
 pygithub
 python-gitlab==1.8.0
-repobee-plug==0.8.0
+repobee-plug==0.9.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ required = [
     "daiquiri",
     "pygithub",
     "colored",
-    "repobee-plug==0.8.0",
+    "repobee-plug==0.9.0",
     "python-gitlab==1.8.0",
 ]
 

--- a/src/_repobee/cli.py
+++ b/src/_repobee/cli.py
@@ -367,10 +367,15 @@ def dispatch_command(
 def _handle_hook_results(hook_results, filepath):
     LOGGER.info(formatters.format_hook_results_output(hook_results))
     if filepath:
+        LOGGER.warning(
+            "Storing hook results to file is a beta feature, the file format "
+            "is not final"
+        )
         output_file = pathlib.Path(filepath)
         util.atomic_write(
             plug.result_mapping_to_json(hook_results), output_file
         )
+        LOGGER.info("Hook results stored to {}".format(filepath))
 
 
 def _add_peer_review_parsers(base_parsers, subparsers):

--- a/src/_repobee/cli.py
+++ b/src/_repobee/cli.py
@@ -30,6 +30,7 @@ from _repobee import util
 from _repobee import exception
 from _repobee import config
 from _repobee import constants
+from _repobee import formatters
 
 daiquiri.setup(
     level=logging.INFO,
@@ -272,6 +273,7 @@ def dispatch_command(
         ext_commands: A list of active extension commands.
     """
     ext_command_names = [cmd.name for cmd in ext_commands or []]
+    hook_results = {}
     if ext_command_names and args.subparser in ext_command_names:
         ext_cmd = ext_commands[ext_command_names.index(args.subparser)]
         with _sys_exit_on_expected_error():
@@ -301,7 +303,9 @@ def dispatch_command(
             command.migrate_repos(args.master_repo_urls, api)
     elif args.subparser == CLONE_PARSER:
         with _sys_exit_on_expected_error():
-            command.clone_repos(args.master_repo_names, args.students, api)
+            hook_results = command.clone_repos(
+                args.master_repo_names, args.students, api
+            )
     elif args.subparser == VERIFY_PARSER:
         with _sys_exit_on_expected_error():
             plug.manager.hook.get_api_class().verify_settings(
@@ -352,6 +356,20 @@ def dispatch_command(
         raise exception.ParseError(
             "Illegal value for subparser: {}. "
             "This is a bug, please open an issue.".format(args.subparser)
+        )
+
+    if hook_results:
+        _handle_hook_results(
+            hook_results=hook_results, filepath=args.hook_results_file
+        )
+
+
+def _handle_hook_results(hook_results, filepath):
+    LOGGER.info(formatters.format_hook_results_output(hook_results))
+    if filepath:
+        output_file = pathlib.Path(filepath)
+        util.atomic_write(
+            plug.result_mapping_to_json(hook_results), output_file
         )
 
 
@@ -751,6 +769,13 @@ def _add_subparsers(parser, show_all_opts, ext_commands):
         description="Clone student repos asynchronously in bulk.",
         parents=[base_parser, base_student_parser, repo_name_parser],
         formatter_class=_OrderedFormatter,
+    )
+    clone.add_argument(
+        "--hook-results-file",
+        help="Path to a file to store results from plugin hooks in. The "
+        "results are stored as JSON, regardless of file extension.",
+        type=str,
+        default=None,
     )
 
     plug.manager.hook.clone_parser_hook(clone_parser=clone)

--- a/src/_repobee/command.py
+++ b/src/_repobee/command.py
@@ -400,7 +400,9 @@ def _clone_repos_no_check(repo_urls, dst_dirpath, api):
     return [repo.name for repo in cloned_repos]
 
 
-def _execute_post_clone_hooks(repo_names: List[str], api: plug.API):
+def _execute_post_clone_hooks(
+    repo_names: List[str], api: plug.API, to_json=True
+):
     LOGGER.info("Executing post clone hooks on repos")
     local_repos = [name for name in os.listdir() if name in repo_names]
 
@@ -412,8 +414,11 @@ def _execute_post_clone_hooks(repo_names: List[str], api: plug.API):
         )
         results[repo_name] = res
     LOGGER.info(formatters.format_hook_results_output(results))
-
     LOGGER.info("Post clone hooks done")
+
+    if to_json:
+        output_file = pathlib.Path(".").resolve() / "repobee_hook_results.json"
+        util.atomic_write(formatters.to_json(results), output_file)
 
 
 def migrate_repos(master_repo_urls: Iterable[str], api: plug.API) -> None:

--- a/src/_repobee/command.py
+++ b/src/_repobee/command.py
@@ -18,7 +18,7 @@ import shutil
 import os
 import sys
 import tempfile
-from typing import Iterable, List, Optional, Tuple, Generator
+from typing import Iterable, List, Optional, Tuple, Generator, Mapping
 from colored import bg, fg, style
 
 import daiquiri
@@ -343,7 +343,7 @@ def close_issue(
 
 def clone_repos(
     master_repo_names: Iterable[str], teams: Iterable[plug.Team], api: plug.API
-) -> None:
+) -> Mapping[str, List[plug.HookResult]]:
     """Clone all student repos related to the provided master repos and student
     teams.
 
@@ -352,6 +352,8 @@ def clone_repos(
         teams: An iterable of student teams.
         api: An implementation of :py:class:`repobee_plug.API` used to
             interface with the platform (e.g. GitHub or GitLab) instance.
+    Returns:
+        A mapping from repo name to a list of hook results.
     """
     repo_urls = api.get_repo_urls(master_repo_names, teams=teams)
     # the reason we first compute the urls and then extract repo names is that
@@ -374,8 +376,8 @@ def clone_repos(
     for plugin in plug.manager.get_plugins():
         if "act_on_cloned_repo" in dir(plugin):
             repo_names = util.generate_repo_names(teams, master_repo_names)
-            _execute_post_clone_hooks(repo_names, api)
-            break
+            return _execute_post_clone_hooks(repo_names, api)
+    return {}
 
 
 def _clone_repos_no_check(repo_urls, dst_dirpath, api):
@@ -401,8 +403,8 @@ def _clone_repos_no_check(repo_urls, dst_dirpath, api):
 
 
 def _execute_post_clone_hooks(
-    repo_names: List[str], api: plug.API, to_json=True
-):
+    repo_names: List[str], api: plug.API
+) -> Mapping[str, List[plug.HookResult]]:
     LOGGER.info("Executing post clone hooks on repos")
     local_repos = [name for name in os.listdir() if name in repo_names]
 
@@ -413,12 +415,8 @@ def _execute_post_clone_hooks(
             path=os.path.abspath(repo_name), api=api
         )
         results[repo_name] = res
-    LOGGER.info(formatters.format_hook_results_output(results))
-    LOGGER.info("Post clone hooks done")
 
-    if to_json:
-        output_file = pathlib.Path(".").resolve() / "repobee_hook_results.json"
-        util.atomic_write(formatters.to_json(results), output_file)
+    return results
 
 
 def migrate_repos(master_repo_urls: Iterable[str], api: plug.API) -> None:

--- a/src/_repobee/formatters.py
+++ b/src/_repobee/formatters.py
@@ -8,14 +8,11 @@ This module contains functions for pretty formatting of command line output.
 .. moduleauthor:: Simon Larsén
 """
 import os
-import json
 from typing import Mapping, List
 
 from colored import fg, bg, style
 from repobee_plug import Status
 import daiquiri
-
-import repobee_plug as plug
 
 from _repobee import tuples
 
@@ -130,27 +127,3 @@ def format_hook_results_output(result_mapping):
         out += os.linesep * 2
 
     return out
-
-
-def to_json(result_mapping):
-    hook_results_as_dicts = {
-        repo_name: {
-            h.hook: {"status": h.status.value, "msg": h.msg}
-            for h in hook_results
-        }
-        for repo_name, hook_results in result_mapping.items()
-    }
-    return json.dumps(hook_results_as_dicts, indent=4, ensure_ascii=False)
-
-
-def from_json(json_string):
-    json_dict = json.loads(json_string)
-    return {
-        repo_name: [
-            plug.HookResult(
-                hook=hook, status=plug.Status(val["status"]), msg=val["msg"]
-            )
-            for hook, val in hook_dicts.items()
-        ]
-        for repo_name, hook_dicts in json_dict.items()
-    }

--- a/src/_repobee/formatters.py
+++ b/src/_repobee/formatters.py
@@ -8,11 +8,14 @@ This module contains functions for pretty formatting of command line output.
 .. moduleauthor:: Simon Larsén
 """
 import os
+import json
 from typing import Mapping, List
 
 from colored import fg, bg, style
 from repobee_plug import Status
 import daiquiri
+
+import repobee_plug as plug
 
 from _repobee import tuples
 
@@ -127,3 +130,27 @@ def format_hook_results_output(result_mapping):
         out += os.linesep * 2
 
     return out
+
+
+def to_json(result_mapping):
+    hook_results_as_dicts = {
+        repo_name: {
+            h.hook: {"status": h.status.value, "msg": h.msg}
+            for h in hook_results
+        }
+        for repo_name, hook_results in result_mapping.items()
+    }
+    return json.dumps(hook_results_as_dicts, indent=4, ensure_ascii=False)
+
+
+def from_json(json_string):
+    json_dict = json.loads(json_string)
+    return {
+        repo_name: [
+            plug.HookResult(
+                hook=hook, status=plug.Status(val["status"]), msg=val["msg"]
+            )
+            for hook, val in hook_dicts.items()
+        ]
+        for repo_name, hook_dicts in json_dict.items()
+    }

--- a/src/_repobee/util.py
+++ b/src/_repobee/util.py
@@ -9,6 +9,8 @@
 import os
 import sys
 import pathlib
+import shutil
+import tempfile
 from typing import Iterable, Generator, Union, Set
 
 from repobee_plug import apimeta
@@ -135,3 +137,21 @@ def find_files_by_extension(
         for file in files:
             if _ends_with_ext(file, extensions):
                 yield pathlib.Path(cwd) / file
+
+
+def atomic_write(content: str, dst: pathlib.Path) -> None:
+    """Write the given contents to the destination "atomically". Achieved by
+    writin in a temporary directory and then moving the file to the
+    destination.
+
+    Args:
+        content: The content to write to the new file.
+        dst: Path to the file.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.NamedTemporaryFile(
+            delete=False, dir=tmpdir, mode="w"
+        ) as file:
+            file.write(content)
+
+        shutil.move(file.name, str(dst))

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -56,6 +56,7 @@ VALID_PARSED_ARGS = dict(
     author=None,
     token=TOKEN,
     num_reviews=1,
+    hook_results_file=None,
 )
 
 
@@ -205,6 +206,8 @@ class TestDispatchCommand:
     ):
         expected_filepath = pathlib.Path(".").resolve() / "results.json"
         expected_json = plug.result_mapping_to_json(hook_result_mapping)
+        args_dict = dict(VALID_PARSED_ARGS)
+        args_dict["hook_results_file"] = str(expected_filepath)
         with mock.patch(
             "_repobee.util.atomic_write", autospec=True
         ) as write, mock.patch(
@@ -212,11 +215,7 @@ class TestDispatchCommand:
             autospec=True,
             return_value=hook_result_mapping,
         ):
-            args = argparse.Namespace(
-                subparser=cli.CLONE_PARSER,
-                **VALID_PARSED_ARGS,
-                hook_results_file=str(expected_filepath)
-            )
+            args = argparse.Namespace(subparser=cli.CLONE_PARSER, **args_dict)
             cli.dispatch_command(args, api_instance_mock)
 
         write.assert_called_once_with(expected_json, expected_filepath)
@@ -228,16 +227,14 @@ class TestDispatchCommand:
         --hook-results-file is specified.
         """
         expected_filepath = pathlib.Path(".").resolve() / "results.json"
+        args_dict = dict(VALID_PARSED_ARGS)
+        args_dict["hook_results_file"] = str(expected_filepath)
         with mock.patch(
             "_repobee.util.atomic_write", autospec=True
         ) as write, mock.patch(
             "_repobee.command.clone_repos", autospec=True, return_value={}
         ):
-            args = argparse.Namespace(
-                subparser=cli.CLONE_PARSER,
-                **VALID_PARSED_ARGS,
-                hook_results_file=expected_filepath
-            )
+            args = argparse.Namespace(subparser=cli.CLONE_PARSER, **args_dict)
             cli.dispatch_command(args, api_instance_mock)
 
         assert not write.called

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 import argparse
-from unittest.mock import MagicMock
+import collections
 from unittest import mock
 
 import pytest
@@ -61,7 +61,7 @@ VALID_PARSED_ARGS = dict(
 
 @pytest.fixture(autouse=True)
 def api_instance_mock(mocker):
-    instance_mock = MagicMock(spec=_repobee.ext.github.GitHubAPI)
+    instance_mock = mock.MagicMock(spec=_repobee.ext.github.GitHubAPI)
     instance_mock.get_repo_urls.side_effect = lambda repo_names, org_name: [
         generate_repo_url(rn, org_name) for rn in repo_names
     ]
@@ -162,8 +162,85 @@ def command_all_raise_mock(command_mock, api_class_mock, request):
     return command_mock
 
 
+@pytest.fixture
+def hook_result_mapping():
+    """A hook result mapping for use as a mocked return value to commands that
+    return hook results (e.g. command.clone_repos).
+    """
+    hook_results = collections.defaultdict(list)
+    for repo_name, hook_name, status, msg, data in [
+        (
+            "slarse-task-1",
+            "junit4",
+            plug.Status.SUCCESS,
+            "All tests passed",
+            {"extra": "data", "arbitrary": {"nesting": "here"}},
+        ),
+        (
+            "slarse-task-1",
+            "javac",
+            plug.Status.ERROR,
+            "Some stuff failed",
+            None,
+        ),
+        (
+            "glassey-task-2",
+            "pylint",
+            plug.Status.WARNING,
+            "-10/10 code quality",
+            None,
+        ),
+    ]:
+        hook_results[repo_name].append(
+            plug.HookResult(hook=hook_name, status=status, msg=msg, data=data)
+        )
+    return dict(hook_results)
+
+
 class TestDispatchCommand:
     """Test the handling of parsed arguments."""
+
+    def test_writes_hook_results_correctly(
+        self, tmpdir, hook_result_mapping, api_instance_mock
+    ):
+        expected_filepath = pathlib.Path(".").resolve() / "results.json"
+        expected_json = plug.result_mapping_to_json(hook_result_mapping)
+        with mock.patch(
+            "_repobee.util.atomic_write", autospec=True
+        ) as write, mock.patch(
+            "_repobee.command.clone_repos",
+            autospec=True,
+            return_value=hook_result_mapping,
+        ):
+            args = argparse.Namespace(
+                subparser=cli.CLONE_PARSER,
+                **VALID_PARSED_ARGS,
+                hook_results_file=str(expected_filepath)
+            )
+            cli.dispatch_command(args, api_instance_mock)
+
+        write.assert_called_once_with(expected_json, expected_filepath)
+
+    def test_does_not_write_hook_results_if_there_are_none(
+        self, tmpdir, api_instance_mock
+    ):
+        """Test that no file is created if there are no hook results, even if
+        --hook-results-file is specified.
+        """
+        expected_filepath = pathlib.Path(".").resolve() / "results.json"
+        with mock.patch(
+            "_repobee.util.atomic_write", autospec=True
+        ) as write, mock.patch(
+            "_repobee.command.clone_repos", autospec=True, return_value={}
+        ):
+            args = argparse.Namespace(
+                subparser=cli.CLONE_PARSER,
+                **VALID_PARSED_ARGS,
+                hook_results_file=expected_filepath
+            )
+            cli.dispatch_command(args, api_instance_mock)
+
+        assert not write.called
 
     def test_raises_on_invalid_subparser_value(self, api_instance_mock):
         parser = "DOES_NOT_EXIST"
@@ -555,7 +632,7 @@ class TestExtensionCommands:
         """Return a mock callback function for use with an extension
         command.
         """
-        yield MagicMock(
+        yield mock.MagicMock(
             spec=_repobee.ext.configwizard.create_extension_command
         )
 


### PR DESCRIPTION
Add the `--hook-results-file` option to the clone command, to store hook results in JSON format in the specified file.

Fix #324 

Also works toward #153 