### PR TITLE
Add Python 3.8 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     python: 3.7
     dist: xenial
     sudo: true
+  - os: linux
+    python: 3.8
   - os: osx
     language: generic
     sudo: true


### PR DESCRIPTION
Fix #380 