### PR TITLE
Issue 404 redesign clone repos

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -71,9 +71,7 @@ def dispatch_command(
     elif args.subparser == MIGRATE_PARSER:
         command.migrate_repos(args.master_repo_urls, api)
     elif args.subparser == CLONE_PARSER:
-        hook_results = command.clone_repos(
-            args.master_repo_names, args.students, api
-        )
+        hook_results = command.clone_repos(args.repos, api)
     elif args.subparser == VERIFY_PARSER:
         plug.manager.hook.get_api_class().verify_settings(
             args.user,

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -155,7 +155,7 @@ def _repo_tuple_generator(
 ) -> Generator[plug.Repo, None, None]:
     for master_repo_name in master_repo_names:
         for team in teams:
-            url, *_ = api.get_repo_urls(master_repo_names, teams=[team])
+            url, *_ = api.get_repo_urls([master_repo_name], teams=[team])
             name = plug.generate_repo_name(team, master_repo_name)
             yield plug.Repo(name=name, url=url, private=True, description="")
 

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -15,7 +15,7 @@ import os
 import pathlib
 import re
 import sys
-from typing import Iterable, Optional, List, Tuple
+from typing import Iterable, Optional, List, Tuple, Generator
 
 import daiquiri
 import repobee_plug as plug
@@ -96,8 +96,6 @@ def _parse_args(
     elif subparser in ext_command_names:
         return args, True
 
-    ext_command_names = [cmd.name for cmd in ext_commands or []]
-
     args_dict = vars(args)
     args_dict["students"] = _extract_groups(args)
     args_dict["issue"] = (
@@ -117,7 +115,7 @@ def _parse_args(
 def _process_args(
     args: argparse.Namespace,
     ext_commands: Optional[List[plug.ExtensionCommand]] = None,
-) -> argparse.Namespace:
+) -> Tuple[argparse.Namespace, plug.API]:
     """Process parsed command line arguments.
 
     Args:
@@ -143,10 +141,23 @@ def _process_args(
     args_dict = vars(args)
     args_dict["master_repo_urls"] = master_urls
     args_dict["master_repo_names"] = master_names
+    args_dict["repos"] = _repo_tuple_generator(
+        master_names, args.students, api
+    )
     # marker for functionality that relies on fully processed args
     args_dict["_repobee_processed"] = True
 
     return argparse.Namespace(**args_dict), api
+
+
+def _repo_tuple_generator(
+    master_repo_names: List[str], teams: List[plug.Team], api: plug.API
+) -> Generator[plug.Repo, None, None]:
+    for master_repo_name in master_repo_names:
+        for team in teams:
+            url, *_ = api.get_repo_urls(master_repo_names, teams=[team])
+            name = plug.generate_repo_name(team, master_repo_name)
+            yield plug.Repo(name=name, url=url, private=True, description="")
 
 
 def _handle_task_parsing(args: argparse.Namespace) -> None:

--- a/src/_repobee/git.py
+++ b/src/_repobee/git.py
@@ -248,8 +248,14 @@ def _batch_execution(
             )
             for arg in args
         ]
-        loop.run_until_complete(asyncio.wait(tasks))
-        completed_tasks += tasks
+        # if
+        # a) arg_list was empty
+        # or
+        # b) len(arg_list) % CONCURRENT_TASKS == 0
+        # the last iteration will have no tasks
+        if tasks:
+            loop.run_until_complete(asyncio.wait(tasks))
+            completed_tasks += tasks
 
     exceptions = [
         task.exception() for task in completed_tasks if task.exception()

--- a/src/_repobee/util.py
+++ b/src/_repobee/util.py
@@ -11,7 +11,7 @@ import sys
 import pathlib
 import shutil
 import tempfile
-from typing import Iterable, Generator, Union, Set, Callable, TypeVar
+from typing import Iterable, Generator, Union, Callable, TypeVar
 
 import repobee_plug as plug
 
@@ -29,20 +29,6 @@ def read_issue(issue_path: str) -> plug.Issue:
         raise ValueError("{} is not a file".format(issue_path))
     with open(issue_path, "r", encoding=sys.getdefaultencoding()) as file:
         return plug.Issue(file.readline().strip(), file.read())
-
-
-def conflicting_files(filenames: Iterable[str], cwd: str = ".") -> Set[str]:
-    """Return a list of files (any kind of file, including directories, pipes
-    etc) in cwd that conflict with any of the given repo names.
-
-    Args:
-        repo_names: A list of filenames.
-        cwd: Directory to operate in.
-    Returns:
-        A set of conflicting filenames.
-    """
-    existing_filenames = set(os.listdir(cwd))
-    return set(filenames).intersection(existing_filenames)
 
 
 def repo_name(repo_url: str) -> str:

--- a/tests/integration_tests/integration_tests.py
+++ b/tests/integration_tests/integration_tests.py
@@ -406,7 +406,9 @@ def hash_directory(path):
     for dirpath, _, filenames in os.walk(str(path)):
         if ".git" in dirpath:
             continue
-        files = (pathlib.Path(dirpath) / filename for filename in filenames)
+        files = list(
+            pathlib.Path(dirpath) / filename for filename in filenames
+        )
         shas += (hashlib.sha1(file.read_bytes()).digest() for file in files)
     return hashlib.sha1(b"".join(shas)).digest()
 
@@ -554,7 +556,9 @@ class TestClone:
         assert_cloned_repos(non_pre_existing_dirnames, tmpdir)
         for dirname in pre_existing_dirnames:
             dirhash = hash_directory(pathlib.Path(str(tmpdir)) / dirname)
-            assert dirhash == expected_dir_hashes[dirname]
+            assert dirhash == expected_dir_hashes[dirname], (
+                "hash mismatch for " + dirname
+            )
 
 
 @pytest.mark.filterwarnings("ignore:.*Unverified HTTPS request.*")


### PR DESCRIPTION
Redesign the clone command without affecting the CLI. This is a preparation for implementing `--discover-repos` and later `--discover-teams`. It should, ideally, not affect usage at all at this point.

Essentially, the change consists of changing `clone_repos(master_repo_names, students, api)` to `clone_repo(repos: List[plug.Repo], api: plug.API)`, and all other changes are just side effects of that.

Fix #404 