### PR TITLE
[feat] Implement `--discover-repos` for `clone` and `list-issues` commands

### DIFF
--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -2,5 +2,5 @@ appdirs
 daiquiri
 pygithub
 colored
-repobee-plug==0.12.0-alpha.4
-python-gitlab==1.9.0
+repobee-plug==0.12.0-alpha.5
+python-gitlab==1.15.0

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ required = [
     "daiquiri",
     "pygithub",
     "colored",
-    "repobee-plug==0.12.0-alpha.4",
-    "python-gitlab==1.9.0",
+    "repobee-plug==0.12.0-alpha.5",
+    "python-gitlab==1.15.0",
 ]
 
 setup(

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -137,6 +137,7 @@ def _process_args(
     elif args.subparser != CREATE_TEAMS_PARSER:
         master_names = args.master_repo_names
         master_urls = _repo_names_to_urls(master_names, master_org_name, api)
+        repos = _repo_tuple_generator(master_names, args.students, api)
         assert master_urls and master_names
 
     args_dict = vars(args)

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -131,19 +131,18 @@ def _process_args(
     if "master_org_name" in args and args.master_org_name is not None:
         master_org_name = args.master_org_name
 
-    if args.subparser != CREATE_TEAMS_PARSER:
+    repos = master_names = master_urls = None
+    if "discover_repos" in args and args.discover_repos:
+        repos = api.discover_repos(args.students)
+    elif args.subparser != CREATE_TEAMS_PARSER:
         master_names = args.master_repo_names
         master_urls = _repo_names_to_urls(master_names, master_org_name, api)
         assert master_urls and master_names
-    else:
-        master_names = master_urls = None
 
     args_dict = vars(args)
     args_dict["master_repo_urls"] = master_urls
     args_dict["master_repo_names"] = master_names
-    args_dict["repos"] = _repo_tuple_generator(
-        master_names, args.students, api
-    )
+    args_dict["repos"] = repos
     # marker for functionality that relies on fully processed args
     args_dict["_repobee_processed"] = True
 

--- a/src/_repobee/ext/github.py
+++ b/src/_repobee/ext/github.py
@@ -604,6 +604,23 @@ class GitHubAPI(plug.API):
                 "Can't find repos: {}".format(", ".join(missing_repos))
             )
 
+    def discover_repos(
+        self, teams: Iterable[plug.Team]
+    ) -> Generator[plug.Repo, None, None]:
+        """See :py:meth:`repobee_plug.APISpec.discover_repos."""
+        raw_teams = self._get_teams_in([team.name for team in teams])
+        with _try_api_request():
+            for team in raw_teams:
+                for repo in team.get_repos():
+                    yield plug.Repo(
+                        name=repo.name,
+                        description=repo.description,
+                        private=repo.private,
+                        team_id=team.id,
+                        url=self._insert_auth(repo.html_url),
+                        implementation=repo,
+                    )
+
     @staticmethod
     def verify_settings(
         user: str,

--- a/src/_repobee/ext/github.py
+++ b/src/_repobee/ext/github.py
@@ -607,7 +607,7 @@ class GitHubAPI(plug.API):
     def discover_repos(
         self, teams: Iterable[plug.Team]
     ) -> Generator[plug.Repo, None, None]:
-        """See :py:meth:`repobee_plug.APISpec.discover_repos."""
+        """See :py:meth:`repobee_plug.APISpec.discover_repos`."""
         raw_teams = self._get_teams_in([team.name for team in teams])
         with _try_api_request():
             for team in raw_teams:

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -1412,8 +1412,8 @@ class TestCommandDeprecation:
         )
 
         # exhaust the generators
-        old_parsed_args.repos = list(old_parsed_args.repos)
-        new_parsed_args.repos = list(new_parsed_args.repos)
+        old_parsed_args.repos = list(old_parsed_args.repos or [])
+        new_parsed_args.repos = list(new_parsed_args.repos or [])
 
         assert old_parsed_args.subparser == current_parser
         assert old_parsed_args == new_parsed_args


### PR DESCRIPTION
Fix #383 

Also:

* Bump version number for `repobee-plug` as a new API method was needed.
* Bump version number for `python-gitlab` as searching while including subgroups was required.