### PR TITLE
[break] Simplify return type of extension command callback

### DIFF
--- a/docs/repobee_plug/creating_plugins.rst
+++ b/docs/repobee_plug/creating_plugins.rst
@@ -444,12 +444,11 @@ will look something like this instead:
 
     def callback(
         args: argparse.Namespace, api: Optional[plug.API]
-    ) -> Optional[Mapping[str, List[plug.Result]]]:
+    ) -> Optional[plug.Result]:
         # do whatever you want to do!
-        return {
-            PLUGIN_NAME: [plug.Result(
+        return plug.Result(
                 name=PLUGIN_NAME, status=plug.Status.SUCCESS, msg="Hello, world!"
-            )]
+            )
         }
 
     @plug.repobee_hook

--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -56,7 +56,7 @@ def dispatch_command(
     if is_ext_command:
         ext_cmd = ext_commands[ext_command_names.index(args.subparser)]
         res = ext_cmd.callback(args, api)
-        hook_results = res if res else hook_results
+        hook_results = {ext_cmd.name: [res]} if res else hook_results
     elif args.subparser == SETUP_PARSER:
         hook_results = command.setup_student_repos(
             args.master_repo_urls, args.students, api

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -184,8 +184,7 @@ class ExtensionCommand(
         help: str,
         description: str,
         callback: Callable[
-            [argparse.Namespace, Optional[_apimeta.API]],
-            Optional[Mapping[str, Result]],
+            [argparse.Namespace, Optional[_apimeta.API]], Optional[Result],
         ],
         requires_api: bool = False,
         requires_base_parsers: Optional[Iterable[BaseParser]] = None,
@@ -200,9 +199,8 @@ class ExtensionCommand(
                 describing the usage of the command.
             callback: A callback function that is called if this command is
                 used on the CLI. It is passed the parsed namespace and the
-                platform API. It may optionally return a result mapping on
-                the form (name: str -> List[Result]) that's reported by
-                RepoBee.
+                platform API. It may optionally return a plugin result that's
+                reported by RepoBee's CLI.
             requires_api: If True, the base arguments required for the platform
                 API are added as options to the extension command, and the
                 platform API is then passed to the callback function. It is

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -17,6 +17,7 @@ import _repobee.ext.defaults.github
 import _repobee.ext.query
 import _repobee.constants
 import _repobee.plugin
+import _repobee.ext.defaults.configwizard
 from _repobee.cli import mainparser
 from _repobee import exception
 
@@ -709,8 +710,12 @@ class TestExtensionCommands:
         """Return a mock callback function for use with an extension
         command.
         """
+        result = plug.Result(
+            name="mock", msg="Hello!", status=plug.Status.SUCCESS
+        )
         yield mock.MagicMock(
-            spec=_repobee.ext.defaults.configwizard.create_extension_command
+            spec=_repobee.ext.defaults.configwizard.callback,
+            return_value=result,
         )
 
     @pytest.fixture
@@ -805,13 +810,7 @@ class TestExtensionCommands:
             parsed_args, None, EMPTY_PATH, [ext_command]
         )
 
-        # for some reason, this completely sane assertion fails ALWAYS
-        # mock_callback.assert_called_once_with(
-        #   parsed_args, None)
-
-        # this is a workaround
-        assert len(mock_callback.call_args_list) == 1
-        assert mock_callback.call_args_list[0] == mock.call(parsed_args, None)
+        mock_callback.assert_called_once_with(parsed_args, None)
 
     def test_dispatch_ext_command_that_requires_api(
         self,
@@ -841,15 +840,7 @@ class TestExtensionCommands:
             parsed_args, api_instance_mock, EMPTY_PATH, [ext_command]
         )
 
-        # for some reason, this completely sane assertion fails ALWAYS
-        # mock_callback.assert_called_once_with(
-        #   parsed_args, api_instance_mock)
-
-        # this is a workaround
-        assert len(mock_callback.call_args_list) == 1
-        assert mock_callback.call_args_list[0] == mock.call(
-            parsed_args, api_instance_mock
-        )
+        mock_callback.assert_called_once_with(parsed_args, api_instance_mock)
 
     def test_parse_ext_command_that_requires_base_parsers(self):
         """The query command requires the students and repo names parsers."""


### PR DESCRIPTION
Fix #480 

Extension commands should now return a `plug.Result` instead of a `Mappin[str, List[plug.Result]]`