### PR TITLE
[feat] Implement declarative extension commands

### DIFF
--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -218,7 +218,7 @@ def _add_subparsers(parser, show_all_opts, ext_commands, config_file):
         master_org_parser,
         _REPO_NAME_PARSER,
         categories,
-        config._read_config(config_file),
+        config._read_config(config_file) if config_file.is_file() else {},
         show_all_opts,
     )
 

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -218,6 +218,8 @@ def _add_subparsers(parser, show_all_opts, ext_commands, config_file):
         master_org_parser,
         _REPO_NAME_PARSER,
         categories,
+        config._read_config(config_file),
+        show_all_opts,
     )
 
 
@@ -592,6 +594,8 @@ def _add_extension_parsers(
     master_org_parser,
     repo_name_parser,
     categories,
+    parsed_config,
+    show_all_opts,
 ):
     """Add extension parsers defined by plugins."""
     if not ext_commands:
@@ -611,7 +615,13 @@ def _add_extension_parsers(
             parents.append(_REPO_DISCOVERY_PARSER)
         elif bp.REPO_NAMES in req_parsers:
             parents.append(repo_name_parser)
-        parents.append(cmd.parser)
+
+        cmd_parser = (
+            cmd.parser(parsed_config, show_all_opts)
+            if callable(cmd.parser)
+            else cmd.parser
+        )
+        parents.append(cmd_parser)
 
         category_parsers = categories.get(cmd.category) or subparsers
         ext_parser = category_parsers.add_parser(

--- a/src/_repobee/cli/preparser.py
+++ b/src/_repobee/cli/preparser.py
@@ -48,7 +48,12 @@ def parse_args(sys_args: List[str]) -> argparse.Namespace:
         *PRE_PARSER_CONFIG_OPTS,
         help="Specify path to the config file to use.",
         type=pathlib.Path,
-        default=_repobee.constants.DEFAULT_CONFIG_FILE,
+        default=_repobee.constants.DEFAULT_CONFIG_FILE
+    )
+    parser.add_argument(
+        PRE_PARSER_SHOW_ALL_OPTS,
+        help="Unsuppress all options in help menus",
+        action="store_true",
     )
 
     mutex_grp = parser.add_mutually_exclusive_group()
@@ -61,11 +66,6 @@ def parse_args(sys_args: List[str]) -> argparse.Namespace:
     )
     mutex_grp.add_argument(
         PRE_PARSER_NO_PLUGS, help="Disable plugins.", action="store_true"
-    )
-    mutex_grp.add_argument(
-        PRE_PARSER_SHOW_ALL_OPTS,
-        help="Unsuppress all options in help menus",
-        action="store_true",
     )
 
     args = parser.parse_args(sys_args)

--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -19,7 +19,7 @@ from _repobee import constants
 LOGGER = daiquiri.getLogger(__file__)
 
 
-class Wizard(plug.Plugin, plug.cli.Action):
+class Wizard(plug.Plugin, plug.cli.Command):
     __category__ = plug.CoreCommand.config
     __help__ = "Interactive configuration wizard to set up the config file."
     __description__ = (
@@ -28,7 +28,9 @@ class Wizard(plug.Plugin, plug.cli.Action):
         "overwritten."
     )
 
-    def action_callback(self, args: argparse.Namespace, api: plug.API) -> None:
+    def command_callback(
+        self, args: argparse.Namespace, api: plug.API
+    ) -> None:
         return callback(args, api)
 
 

--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -19,6 +19,19 @@ from _repobee import constants
 LOGGER = daiquiri.getLogger(__file__)
 
 
+class Wizard(plug.Plugin, plug.cli.Action):
+    __category__ = plug.CoreCommand.config
+    __help__ = "Interactive configuration wizard to set up the config file."
+    __description__ = (
+        "A configuration wizard that sets up the configuration file."
+        "Warns if there already is a configuration file, as it will be "
+        "overwritten."
+    )
+
+    def action_callback(self, args: argparse.Namespace, api: plug.API) -> None:
+        return callback(args, api)
+
+
 def callback(args: argparse.Namespace, api: plug.API) -> None:
     """Run through a configuration wizard."""
     parser = configparser.ConfigParser()
@@ -71,21 +84,4 @@ def callback(args: argparse.Namespace, api: plug.API) -> None:
         "Configuration file written to {}".format(
             str(constants.DEFAULT_CONFIG_FILE)
         )
-    )
-
-
-@plug.repobee_hook
-def create_extension_command():
-    parser = plug.ExtensionParser()
-    return plug.ExtensionCommand(
-        parser=parser,
-        name="wizard",
-        help="Interactive configuration wizard to set up the config file.",
-        description=(
-            "A configuration wizard that sets up the configuration file."
-            "Warns if there already is a configuration file, as it will be "
-            "overwritten."
-        ),
-        callback=callback,
-        category=plug.CoreCommand.config,
     )

--- a/src/_repobee/ext/javac.py
+++ b/src/_repobee/ext/javac.py
@@ -37,7 +37,8 @@ class JavacCloneHook(plug.Plugin):
     adding/parsing arguments and acting on the repo.
     """
 
-    def __init__(self):
+    def __init__(self, plugin_name: str):
+        super().__init__(plugin_name)
         self._ignore = []
 
     def clone_task(self) -> plug.Task:

--- a/src/_repobee/plugin.py
+++ b/src/_repobee/plugin.py
@@ -151,7 +151,6 @@ def register_plugins(modules: List[ModuleType]) -> List[object]:
     registered = []
     for module in reversed(modules):  # reverse because plugins are run LIFO
         plugin_name = module.__name__.split(".")[-1]
-        module._repobee_plugin_name = plugin_name
         plug.manager.register(module)
         registered.append(module)
 
@@ -162,7 +161,6 @@ def register_plugins(modules: List[ModuleType]) -> List[object]:
                 and value != plug.Plugin
             ):
                 obj = value(plugin_name)
-                obj._repobee_plugin_name = plugin_name
                 plug.manager.register(obj)
                 registered.append(obj)
 

--- a/src/_repobee/plugin.py
+++ b/src/_repobee/plugin.py
@@ -136,7 +136,7 @@ def _try_load_module(qualname: str) -> Optional[ModuleType]:
         return None
 
 
-def register_plugins(modules: List[ModuleType],) -> List[object]:
+def register_plugins(modules: List[ModuleType]) -> List[object]:
     """Register the namespaces of the provided modules, and any plug.Plugin
     instances in them. Registers modules in reverse order as they are
     run in LIFO order.
@@ -150,6 +150,8 @@ def register_plugins(modules: List[ModuleType],) -> List[object]:
 
     registered = []
     for module in reversed(modules):  # reverse because plugins are run LIFO
+        plugin_name = module.__name__.split(".")[-1]
+        module._repobee_plugin_name = plugin_name
         plug.manager.register(module)
         registered.append(module)
 
@@ -159,7 +161,8 @@ def register_plugins(modules: List[ModuleType],) -> List[object]:
                 and issubclass(value, plug.Plugin)
                 and value != plug.Plugin
             ):
-                obj = value()
+                obj = value(plugin_name)
+                obj._repobee_plugin_name = plugin_name
                 plug.manager.register(obj)
                 registered.append(obj)
 

--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -4,8 +4,8 @@ from repobee_plug.__version import __version__  # noqa: F401
 
 # Plugin stuff
 from repobee_plug._pluginmeta import Plugin
-from repobee_plug._pluginmeta import opt
 from repobee_plug._containers import hookimpl as repobee_hook
+from repobee_plug._pluginmeta import cli
 
 # Containers
 from repobee_plug._containers import Review
@@ -80,7 +80,6 @@ __all__ = [
     "Review",
     "Task",
     "Deprecation",
-    "opt",
     # API wrappers
     "Team",
     "TeamPermission",
@@ -103,4 +102,6 @@ __all__ = [
     "generate_review_team_name",
     "deprecate",
     "deprecated_hooks",
+    # Modules
+    "cli",
 ]

--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -4,6 +4,7 @@ from repobee_plug.__version import __version__  # noqa: F401
 
 # Plugin stuff
 from repobee_plug._pluginmeta import Plugin
+from repobee_plug._pluginmeta import opt
 from repobee_plug._containers import hookimpl as repobee_hook
 
 # Containers
@@ -79,6 +80,7 @@ __all__ = [
     "Review",
     "Task",
     "Deprecation",
+    "opt",
     # API wrappers
     "Team",
     "TeamPermission",

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -349,7 +349,7 @@ class ExtensionCommand(
     ):
         if not (isinstance(parser, ExtensionParser) or callable(parser)):
             raise _exceptions.ExtensionCommandError(
-                "parser must be callable or a {.__name__}".format(
+                "parser must be a {.__name__} or callable".format(
                     ExtensionParser
                 )
             )

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -347,9 +347,11 @@ class ExtensionCommand(
         requires_base_parsers: Optional[List[BaseParser]] = None,
         category: Optional[CoreCommand] = None,
     ):
-        if not isinstance(parser, ExtensionParser):
+        if not (isinstance(parser, ExtensionParser) or callable(parser)):
             raise _exceptions.ExtensionCommandError(
-                "parser must be a {.__name__}".format(ExtensionParser)
+                "parser must be callable or a {.__name__}".format(
+                    ExtensionParser
+                )
             )
         if not callable(callback):
             raise _exceptions.ExtensionCommandError(

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -44,7 +44,7 @@ class _PluginMeta(type):
         Checking signatures is delegated to ``pluggy`` during registration of
         the hook.
         """
-        if cli.Action in bases:
+        if cli.Command in bases:
             ext_cmd_func = _generate_extension_command_func(attrdict)
             attrdict[ext_cmd_func.__name__] = ext_cmd_func
 
@@ -76,7 +76,7 @@ class _PluginMeta(type):
             for key, value in attrdict.items()
             if callable(value)
             and not key.startswith("_")
-            and key != "action_callback"
+            and key != "command_callback"
         }
 
 
@@ -132,7 +132,7 @@ def _generate_extension_command_func(attrdict: Mapping[str, Any]) -> Callable:
             name=action_name,
             help=help,
             description=description,
-            callback=self.action_callback,
+            callback=self.command_callback,
             category=category,
             requires_api=requires_api,
             requires_base_parsers=base_parsers,

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -1,6 +1,8 @@
 """Plugin functionality for creating extensions to the RepoBee CLI."""
 import collections
 
+__all__ = ["Option", "Action"]
+
 
 Option = collections.namedtuple(
     "Option",
@@ -16,3 +18,27 @@ Option = collections.namedtuple(
     ],
 )
 Option.__new__.__defaults__ = (None,) * len(Option._fields)
+
+
+class Action:
+    """Mixin class for use with the Plugin class. Explicitly marks a class as a
+    CLI Action.
+
+    Example usage:
+
+    .. code-block:: python
+
+        import repobee_plug as plug
+
+        class Greeting(plug.Plugin, plug.cli.Action):
+
+            name = plug.cli.Option(
+                short_name="-n", help="your name", required=True
+            )
+            age = plug.cli.Option(
+                converter=int, help="your age", default=30
+            )
+
+            def cli_callback(self, args, api):
+                print(f"Hello, my name is {args.name} and I am {args.age}")
+    """

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -1,0 +1,18 @@
+"""Plugin functionality for creating extensions to the RepoBee CLI."""
+import collections
+
+
+Option = collections.namedtuple(
+    "Option",
+    [
+        "short_name",
+        "long_name",
+        "configurable",
+        "help",
+        "converter",
+        "required",
+        "default",
+        "argparse_kwargs",
+    ],
+)
+Option.__new__.__defaults__ = (None,) * len(Option._fields)

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -1,7 +1,7 @@
 """Plugin functionality for creating extensions to the RepoBee CLI."""
 import collections
 
-__all__ = ["Option", "Action"]
+__all__ = ["Option", "Command"]
 
 
 Option = collections.namedtuple(
@@ -20,17 +20,40 @@ Option = collections.namedtuple(
 Option.__new__.__defaults__ = (None,) * len(Option._fields)
 
 
-class Action:
-    """Mixin class for use with the Plugin class. Explicitly marks a class as a
-    CLI Action.
+class Command:
+    """Mixin class for use with the Plugin class. Explicitly marks a class as
+    an extension command.
+
+    An extension command must have an callback defined in the class on the
+    following form:
+
+    .. code-block:: python
+
+        def command_callback(
+            self, args: argparse.Namespace, api: plug.API
+        ) -> Optional[plug.Result]:
+            pass
+
+    Note that the type hints are not required, so the callback can be defined
+    like this instead:
+
+    .. code-block:: python
+
+        def command_callback(self, args, api):
+            pass
+
+    Declaring static members of type :py:class:`Option` will add command line
+    options to the command, and these are then parsed and passed to the
+    callback in the ``args`` object.
 
     Example usage:
 
     .. code-block:: python
+        :caption: command.py
 
         import repobee_plug as plug
 
-        class Greeting(plug.Plugin, plug.cli.Action):
+        class Greeting(plug.Plugin, plug.cli.Command):
 
             name = plug.cli.Option(
                 short_name="-n", help="your name", required=True
@@ -39,6 +62,14 @@ class Action:
                 converter=int, help="your age", default=30
             )
 
-            def cli_callback(self, args, api):
+            def command_callback(self, args, api):
                 print(f"Hello, my name is {args.name} and I am {args.age}")
+
+    Note that the file is called ``command.py``. We can run this command with
+    RepoBee like so:
+
+    .. code-block:: bash
+
+        $ repobee -p command.py greeting -n Alice
+        Hello, my name is Alice and I am 30
     """

--- a/tests/unit_tests/repobee/plugin_tests/test_configwizard.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_configwizard.py
@@ -24,7 +24,9 @@ def defaults_options():
 
 
 def test_ext_command_does_not_require_api():
-    ext_command = configwizard.create_extension_command()
+    ext_command = configwizard.Wizard(
+        "config-wizard"
+    ).create_extension_command()
     assert not ext_command.requires_api
 
 

--- a/tests/unit_tests/repobee/test_main.py
+++ b/tests/unit_tests/repobee/test_main.py
@@ -2,7 +2,7 @@ import argparse
 import tempfile
 import pathlib
 import types
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call, ANY
 from collections import namedtuple
 
 import pytest
@@ -44,7 +44,9 @@ CLONE_ARGS = "clone --mn week-2 -s slarse".split()
 
 module = namedtuple("module", ("name",))
 
-DEFAULT_EXT_COMMANDS = [configwizard.create_extension_command()]
+DEFAULT_EXT_COMMANDS = [
+    configwizard.Wizard("config-wizard").create_extension_command()
+]
 DEFAULT_PLUGIN_NAMES = plugin.get_qualified_module_names(_repobee.ext.defaults)
 
 
@@ -101,14 +103,14 @@ def test_happy_path(
     handle_args_mock.assert_called_once_with(
         sys_args[1:],
         show_all_opts=False,
-        ext_commands=DEFAULT_EXT_COMMANDS,
+        ext_commands=[ANY] * len(DEFAULT_EXT_COMMANDS),
         config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
     dispatch_command_mock.assert_called_once_with(
         PARSED_ARGS,
         api_instance_mock,
         _repobee.constants.DEFAULT_CONFIG_FILE,
-        DEFAULT_EXT_COMMANDS,
+        [ANY] * len(DEFAULT_EXT_COMMANDS),
     )
 
 
@@ -126,7 +128,7 @@ def test_exit_status_1_on_exception_in_parsing(
     handle_args_mock.assert_called_once_with(
         sys_args[1:],
         show_all_opts=False,
-        ext_commands=DEFAULT_EXT_COMMANDS,
+        ext_commands=[ANY] * len(DEFAULT_EXT_COMMANDS),
         config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
     assert not dispatch_command_mock.called
@@ -147,7 +149,7 @@ def test_exit_status_1_on_exception_in_handling_parsed_args(
     handle_args_mock.assert_called_once_with(
         sys_args[1:],
         show_all_opts=False,
-        ext_commands=DEFAULT_EXT_COMMANDS,
+        ext_commands=[ANY] * len(DEFAULT_EXT_COMMANDS),
         config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
 
@@ -359,7 +361,7 @@ def test_logs_traceback_on_exception_in_dispatch_if_traceback(
     handle_args_mock.assert_called_once_with(
         [*CLONE_ARGS, "--traceback"],
         show_all_opts=False,
-        ext_commands=DEFAULT_EXT_COMMANDS,
+        ext_commands=[ANY] * len(DEFAULT_EXT_COMMANDS),
         config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
 
@@ -393,7 +395,7 @@ def test_show_all_opts_correctly_separated(
     handle_args_mock.assert_called_once_with(
         [*plug.CoreCommand.repos.setup.astuple(), "-h"],
         show_all_opts=True,
-        ext_commands=DEFAULT_EXT_COMMANDS,
+        ext_commands=[ANY] * len(DEFAULT_EXT_COMMANDS),
         config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
     parse_preparser_options_mock.assert_called_once_with(

--- a/tests/unit_tests/repobee/test_plugin.py
+++ b/tests/unit_tests/repobee/test_plugin.py
@@ -10,7 +10,7 @@ import shutil
 import pathlib
 import tempfile
 import types
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import call, patch, ANY
 
 import pytest
 
@@ -99,37 +99,21 @@ class TestLoadPluginModules:
 class TestRegisterPlugins:
     """Tests for register_plugins."""
 
-    @pytest.fixture
-    def javac_clone_hook_mock(self, mocker):
-        """Return an instance of the clone hook mock"""
-        instance_mock = MagicMock()
-        mocker.patch(
-            "_repobee.ext.javac.JavacCloneHook.__new__",
-            autospec=True,
-            return_value=instance_mock,
-        )
-        return instance_mock
-
     def test_register_module(self, plugin_manager_mock):
         """Test registering a plugin module with module level hooks."""
         plugin.register_plugins([pylint])
-
         plugin_manager_mock.register.assert_called_once_with(pylint)
 
-    def test_register_module_with_plugin_class(
-        self, plugin_manager_mock, javac_clone_hook_mock
-    ):
+    def test_register_module_with_plugin_class(self, plugin_manager_mock):
         """Test that both the module itself and the class (instance) are
         registered."""
-        expected_calls = [call(javac), call(javac_clone_hook_mock)]
+        expected_calls = [call(javac), call(ANY)]
 
         plugin.register_plugins([javac])
 
         plugin_manager_mock.register.assert_has_calls(expected_calls)
 
-    def test_register_modules_and_classes(
-        self, plugin_manager_mock, javac_clone_hook_mock
-    ):
+    def test_register_modules_and_classes(self, plugin_manager_mock):
         """Test that both module level hooks and class hooks are registered
         properly at the same time.
 
@@ -137,11 +121,7 @@ class TestRegisterPlugins:
         """
         modules = [javac, pylint]
         # pylint should be registered before javac because of FIFO order
-        expected_calls = [
-            call(pylint),
-            call(javac),
-            call(javac_clone_hook_mock),
-        ]
+        expected_calls = [call(pylint), call(javac), call(ANY)]
         plugin.register_plugins(modules)
 
         plugin_manager_mock.register.assert_has_calls(expected_calls)

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -105,47 +105,47 @@ class TestPluginInheritance:
                 return self
 
 
-class TestDeclarativeExtensionAction:
-    """Tests for the declarative style of extension actions."""
+class TestDeclarativeExtensionCommand:
+    """Tests for the declarative style of extension commands."""
 
     @pytest.fixture
-    def basic_greeting_action(self):
-        """A basic extension action aimed to test the default values
-        of e.g. the action name and description.
+    def basic_greeting_command(self):
+        """A basic extension command aimed to test the default values
+        of e.g. the command name and description.
         """
 
-        class Greeting(plug.Plugin, plug.cli.Action):
+        class Greeting(plug.Plugin, plug.cli.Command):
             name = plug.cli.Option(help="your name", required=True)
             age = plug.cli.Option(converter=int, help="your age", default=30)
 
-            def action_callback(self, args, api):
+            def command_callback(self, args, api):
                 print(f"My name is {args.name} and I am {args.age} years old")
 
         return Greeting
 
-    def test_defaults(self, basic_greeting_action):
-        """Test declaring an action with no explicit metadata, and checking
+    def test_defaults(self, basic_greeting_command):
+        """Test declaring an command with no explicit metadata, and checking
         that the defaults are as expected.
         """
-        plugin_instance = basic_greeting_action("greeting")
+        plugin_instance = basic_greeting_command("greeting")
         ext_cmd = plugin_instance.create_extension_command()
 
         assert callable(ext_cmd.parser)
-        assert ext_cmd.name == basic_greeting_action.__name__.lower()
+        assert ext_cmd.name == basic_greeting_command.__name__.lower()
         assert ext_cmd.help == ""
         assert ext_cmd.description == ""
-        assert ext_cmd.callback == plugin_instance.action_callback
+        assert ext_cmd.callback == plugin_instance.command_callback
         assert ext_cmd.requires_api is False
         assert ext_cmd.requires_base_parsers is None
         assert ext_cmd.category is None
 
     def test_with_metadata(self):
-        """Test declaring an action with no explicit metadata, and checking
+        """Test declaring an command with no explicit metadata, and checking
         that the defaults are as expected.
         """
         expected_category = plug.CoreCommand.config
         expected_name = "cool-greetings"
-        expected_help = "This is a greeting action!"
+        expected_help = "This is a greeting command!"
         expected_description = "This is a greeting"
         expected_base_parsers = [
             plug.BaseParser.REPO_NAMES,
@@ -153,7 +153,7 @@ class TestDeclarativeExtensionAction:
         ]
         expected_requires_api = True
 
-        class ExtAction(plug.Plugin, plug.cli.Action):
+        class ExtCommand(plug.Plugin, plug.cli.Command):
             __category__ = expected_category
             __action_name__ = expected_name
             __help__ = expected_help
@@ -161,23 +161,23 @@ class TestDeclarativeExtensionAction:
             __base_parsers__ = expected_base_parsers
             __requires_api__ = expected_requires_api
 
-            def action_callback(self, args, api):
+            def command_callback(self, args, api):
                 pass
 
-        plugin_instance = ExtAction("greeting")
+        plugin_instance = ExtCommand("greeting")
         ext_cmd = plugin_instance.create_extension_command()
 
         assert callable(ext_cmd.parser)
         assert ext_cmd.name == expected_name
         assert ext_cmd.help == expected_help
         assert ext_cmd.description == expected_description
-        assert ext_cmd.callback == plugin_instance.action_callback
+        assert ext_cmd.callback == plugin_instance.command_callback
         assert ext_cmd.requires_api == expected_requires_api
         assert ext_cmd.requires_base_parsers == expected_base_parsers
 
-    def test_generated_parser(self, basic_greeting_action):
+    def test_generated_parser(self, basic_greeting_command):
         """Test the parser that's generated automatically."""
-        ext_cmd = basic_greeting_action("greeting").create_extension_command()
+        ext_cmd = basic_greeting_command("greeting").create_extension_command()
         parser = ext_cmd.parser(config={}, show_all_opts=True)
         args = parser.parse_args("--name Eve".split())
 
@@ -187,12 +187,12 @@ class TestDeclarativeExtensionAction:
     def test_configuration(self):
         """Test configuring a default value for an option."""
 
-        class Greeting(plug.Plugin, plug.cli.Action):
+        class Greeting(plug.Plugin, plug.cli.Command):
             name = plug.cli.Option(
                 help="Your name.", required=True, configurable=True
             )
 
-            def action_callback(self, args, api):
+            def command_callback(self, args, api):
                 pass
 
         plugin_name = "greeting"
@@ -210,10 +210,10 @@ class TestDeclarativeExtensionAction:
         configuration.
         """
 
-        class Greeting(plug.Plugin, plug.cli.Action):
+        class Greeting(plug.Plugin, plug.cli.Command):
             name = plug.cli.Option(help="Your name.", required=True)
 
-            def action_callback(self, args, api):
+            def command_callback(self, args, api):
                 pass
 
         plugin_name = "greeting"
@@ -226,7 +226,7 @@ class TestDeclarativeExtensionAction:
 
         assert (
             f"Plugin '{plugin_name}' does not allow 'name' to be configured"
-            in str(exc_info)
+            in str(exc_info.value)
         )
 
     def test_override_opt_names(self):
@@ -234,7 +234,7 @@ class TestDeclarativeExtensionAction:
         names of an option.
         """
 
-        class Greeting(plug.Plugin, plug.cli.Action):
+        class Greeting(plug.Plugin, plug.cli.Command):
             name = plug.cli.Option(
                 short_name="-n",
                 long_name="--your-name",
@@ -242,7 +242,7 @@ class TestDeclarativeExtensionAction:
                 required=True,
             )
 
-            def action_callback(self, args, api):
+            def command_callback(self, args, api):
                 pass
 
         ext_cmd = Greeting("g").create_extension_command()

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -1,4 +1,7 @@
 import pytest
+
+import repobee_plug as plug
+
 from repobee_plug import _pluginmeta
 from repobee_plug import _exceptions
 
@@ -100,3 +103,154 @@ class TestPluginInheritance:
 
             def _other_method(self):
                 return self
+
+
+class TestDeclarativeExtensionAction:
+    """Tests for the declarative style of extension actions."""
+
+    @pytest.fixture
+    def basic_greeting_action(self):
+        """A basic extension action aimed to test the default values
+        of e.g. the action name and description.
+        """
+
+        class Greeting(plug.Plugin, plug.cli.Action):
+            name = plug.cli.Option(help="your name", required=True)
+            age = plug.cli.Option(converter=int, help="your age", default=30)
+
+            def action_callback(self, args, api):
+                print(f"My name is {args.name} and I am {args.age} years old")
+
+        return Greeting
+
+    def test_defaults(self, basic_greeting_action):
+        """Test declaring an action with no explicit metadata, and checking
+        that the defaults are as expected.
+        """
+        plugin_instance = basic_greeting_action("greeting")
+        ext_cmd = plugin_instance.create_extension_command()
+
+        assert callable(ext_cmd.parser)
+        assert ext_cmd.name == basic_greeting_action.__name__.lower()
+        assert ext_cmd.help == ""
+        assert ext_cmd.description == ""
+        assert ext_cmd.callback == plugin_instance.action_callback
+        assert ext_cmd.requires_api is False
+        assert ext_cmd.requires_base_parsers is None
+        assert ext_cmd.category is None
+
+    def test_with_metadata(self):
+        """Test declaring an action with no explicit metadata, and checking
+        that the defaults are as expected.
+        """
+        expected_category = plug.CoreCommand.config
+        expected_name = "cool-greetings"
+        expected_help = "This is a greeting action!"
+        expected_description = "This is a greeting"
+        expected_base_parsers = [
+            plug.BaseParser.REPO_NAMES,
+            plug.BaseParser.MASTER_ORG,
+        ]
+        expected_requires_api = True
+
+        class ExtAction(plug.Plugin, plug.cli.Action):
+            __category__ = expected_category
+            __action_name__ = expected_name
+            __help__ = expected_help
+            __description__ = expected_description
+            __base_parsers__ = expected_base_parsers
+            __requires_api__ = expected_requires_api
+
+            def action_callback(self, args, api):
+                pass
+
+        plugin_instance = ExtAction("greeting")
+        ext_cmd = plugin_instance.create_extension_command()
+
+        assert callable(ext_cmd.parser)
+        assert ext_cmd.name == expected_name
+        assert ext_cmd.help == expected_help
+        assert ext_cmd.description == expected_description
+        assert ext_cmd.callback == plugin_instance.action_callback
+        assert ext_cmd.requires_api == expected_requires_api
+        assert ext_cmd.requires_base_parsers == expected_base_parsers
+
+    def test_generated_parser(self, basic_greeting_action):
+        """Test the parser that's generated automatically."""
+        ext_cmd = basic_greeting_action("greeting").create_extension_command()
+        parser = ext_cmd.parser(config={}, show_all_opts=True)
+        args = parser.parse_args("--name Eve".split())
+
+        assert args.name == "Eve"
+        assert args.age == 30  # this is the default for --age
+
+    def test_configuration(self):
+        """Test configuring a default value for an option."""
+
+        class Greeting(plug.Plugin, plug.cli.Action):
+            name = plug.cli.Option(
+                help="Your name.", required=True, configurable=True
+            )
+
+            def action_callback(self, args, api):
+                pass
+
+        plugin_name = "greeting"
+        configured_name = "Alice"
+        config = {plugin_name: {"name": configured_name}}
+        ext_cmd = Greeting("greeting").create_extension_command()
+        parser = ext_cmd.parser(config=config, show_all_opts=False)
+        args = parser.parse_args([])
+
+        assert args.name == configured_name
+
+    def test_raises_when_non_configurable_value_is_configured(self):
+        """It shouldn't be allowed to have a configuration value for an
+        option that is not marked configurable. This is to avoid accidental
+        configuration.
+        """
+
+        class Greeting(plug.Plugin, plug.cli.Action):
+            name = plug.cli.Option(help="Your name.", required=True)
+
+            def action_callback(self, args, api):
+                pass
+
+        plugin_name = "greeting"
+        configured_name = "Alice"
+        config = {plugin_name: {"name": configured_name}}
+        ext_cmd = Greeting("greeting").create_extension_command()
+
+        with pytest.raises(plug.PlugError) as exc_info:
+            ext_cmd.parser(config=config, show_all_opts=False)
+
+        assert (
+            f"Plugin '{plugin_name}' does not allow 'name' to be configured"
+            in str(exc_info)
+        )
+
+    def test_override_opt_names(self):
+        """It should be possible to override both the long and short option
+        names of an option.
+        """
+
+        class Greeting(plug.Plugin, plug.cli.Action):
+            name = plug.cli.Option(
+                short_name="-n",
+                long_name="--your-name",
+                help="your name",
+                required=True,
+            )
+
+            def action_callback(self, args, api):
+                pass
+
+        ext_cmd = Greeting("g").create_extension_command()
+        parser = ext_cmd.parser(config={}, show_all_opts=False)
+        name = "Alice"
+
+        short_opt_args = parser.parse_args(f"-n {name}".split())
+        long_opt_args = parser.parse_args(f"--your-name {name}".split())
+
+        assert short_opt_args.name == name
+        assert long_opt_args.name == name


### PR DESCRIPTION
> This is potentially breaking, as it adds a required argument to the `repobee_plug.Plugin` constructor.

Fix #496 
Fix #490 

This PR implements declarative extension commands. Assume that we have a file called `command.py` with the following content.

```python
import repobee_plug as plug


class ExtAction(plug.Plugin, plug.cli.Command):
    __category__ = plug.CoreCommand.config
    __action_name__ = "greeting"
    __help__ = "The best extension action!"
    __description__ = "The most impressive extension"

    name = plug.cli.Option(
        short_name="-n", help="Your name.", required=True, configurable=True
    )
    age = plug.cli.Option(
        converter=int, help="Your age.", default=30, configurable=True
    )

    def command_callback(self, args, api):
        print(f"Hello, my name is {args.name} and I am {args.age} years old")
```

This can then be called from RepoBee like so:

```
$ repobee -p command.py config greeting --name Simon --age 99
Hello, my name is Simon and I am 99 years old
```

As the options are marked `configurable=True`, they can also be configured under the `[<PLUGIN_NAME>]` section in the config file. `<PLUGIN_NAME>` is in this case `command`, as we are using a single-file plugin in `command.py`.

> **Important:** This PR only adds command line options. Positional arguments and mutex groups also need to be added at some point.