### PR TITLE
[feat] Allow plugin commands to add options to core parsers

### DIFF
--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -634,9 +634,14 @@ def _add_extension_parsers(
         elif bp.REPO_NAMES in req_parsers:
             parents.append(repo_name_parser)
 
-        if callable(cmd.parser):
-            action = cmd.category.get(cmd.name) if cmd.category else None
-            ext_parser = parsers_mapping.get(action) or (
+        def _add_ext_parser(
+            parents: List[argparse.ArgumentParser],
+        ) -> argparse.ArgumentParser:
+            """Add a new parser either to the extension command's category (if
+            specified), or to the top level subparsers (if category is not
+            specified).
+            """
+            return (
                 parsers_mapping.get(cmd.category) or subparsers
             ).add_parser(
                 cmd.name,
@@ -645,6 +650,19 @@ def _add_extension_parsers(
                 parents=parents,
                 formatter_class=_OrderedFormatter,
             )
+
+        if cmd.name in plug.CoreCommand:
+            ext_parser = parsers_mapping[cmd.name]
+            cmd.parser(
+                config=parsed_config,
+                show_all_opts=show_all_opts,
+                parser=ext_parser,
+            )
+        elif callable(cmd.parser):
+            action = cmd.category.get(cmd.name) if cmd.category else None
+            ext_parser = parsers_mapping.get(action) or _add_ext_parser(
+                parents
+            )
             cmd.parser(
                 config=parsed_config,
                 show_all_opts=show_all_opts,
@@ -652,14 +670,7 @@ def _add_extension_parsers(
             )
         else:
             parents.append(cmd.parser)
-            category_parsers = parsers_mapping.get(cmd.category) or subparsers
-            ext_parser = category_parsers.add_parser(
-                cmd.name,
-                help=cmd.help,
-                description=cmd.description,
-                parents=parents,
-                formatter_class=_OrderedFormatter,
-            )
+            ext_parser = _add_ext_parser(parents)
 
         try:
             _add_traceback_arg(ext_parser)

--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -19,6 +19,8 @@ from repobee_plug._containers import BaseParser
 from repobee_plug._containers import Deprecation
 from repobee_plug._containers import HookResult
 from repobee_plug._tasks import Task
+from repobee_plug._containers import Action
+from repobee_plug._containers import Category
 
 # Hook functions
 from repobee_plug._corehooks import PeerReviewHook as _peer_hook
@@ -80,6 +82,8 @@ __all__ = [
     "Review",
     "Task",
     "Deprecation",
+    "Action",
+    "Category",
     # API wrappers
     "Team",
     "TeamPermission",

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -187,6 +187,9 @@ class Category(_ImmutableMixin, abc.ABC):
         object.__setattr__(self, "actions", tuple(actions))
         object.__setattr__(self, "_action_table", {a.name: a for a in actions})
 
+    def get(self, key: str) -> "Action":
+        return self._action_table.get(key)
+
     def __getitem__(self, key: str) -> "Action":
         return self._action_table[key]
 
@@ -231,6 +234,16 @@ class Action(_ImmutableMixin):
 
     def __str__(self):
         return f"{self.category.name} {self.name}"
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__)
+            and self.name == other.name
+            and self.category == other.category
+        )
+
+    def __hash__(self):
+        return hash(str(self))
 
     def asdict(self) -> Mapping[str, str]:
         """This is a convenience method for testing that returns a dictionary

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -1,5 +1,6 @@
 import argparse
 import daiquiri
+import functools
 
 from typing import List, Tuple, Callable, Mapping, Any
 
@@ -44,8 +45,17 @@ class _PluginMeta(type):
         Checking signatures is delegated to ``pluggy`` during registration of
         the hook.
         """
-        if cli.Command in bases:
-            ext_cmd_func = _generate_extension_command_func(attrdict)
+        if cli.Command in bases and cli.CommandExtension in bases:
+            raise _exceptions.PlugError(
+                "A plugin cannot be both a Command and a CommandExtension"
+            )
+
+        if cli.Command in bases or cli.CommandExtension in bases:
+            ext_cmd_func = (
+                _generate_command_func(attrdict)
+                if cli.Command in bases
+                else _generate_command_extension_func()
+            )
             attrdict[ext_cmd_func.__name__] = ext_cmd_func
 
         methods = cls._extract_public_methods(attrdict)
@@ -91,11 +101,46 @@ def _extract_cli_options(attrdict) -> List[Tuple[str, cli.Option]]:
     ]
 
 
-def _generate_extension_command_func(attrdict: Mapping[str, Any]) -> Callable:
+def _generate_command_extension_func() -> Callable:
+    """Generate an implementation of the ``create_extension_command`` that
+    returns an extension to an existing command.
+    """
+
+    def create_extension_command(self):
+        return _containers.ExtensionCommand(
+            parser=functools.partial(_attach_options, plugin=self),
+            name=self.__action__,
+            callback=lambda: None,
+            description=None,
+            help=None,
+        )
+
+    return create_extension_command
+
+
+def _attach_options(config, show_all_opts, parser, plugin: "Plugin"):
+    config_name = (
+        getattr(plugin, "__config_section__", None) or plugin.plugin_name
+    )
+    config_section = dict(config[config_name]) if config_name in config else {}
+
+    opts = _extract_cli_options(plugin.__class__.__dict__)
+    for (name, opt) in opts:
+        configured_value = config_section.get(name)
+        if configured_value and not opt.configurable:
+            raise _exceptions.PlugError(
+                f"Plugin '{plugin.plugin_name}' does not allow "
+                f"'{name}' to be configured"
+            )
+        _add_option(name, opt, configured_value, show_all_opts, parser)
+
+    return parser
+
+
+def _generate_command_func(attrdict: Mapping[str, Any]) -> Callable:
     """Generate an implementation of the ``create_extension_command`` hook
     function based on the declarative-style extension command class.
     """
-    opts = _extract_cli_options(attrdict)
 
     def create_extension_command(self):
         category = attrdict.get("__category__")
@@ -107,27 +152,8 @@ def _generate_extension_command_func(attrdict: Mapping[str, Any]) -> Callable:
         requires_api = attrdict.get("__requires_api__") or False
         base_parsers = attrdict.get("__base_parsers__") or None
 
-        def attach_options(config, show_all_opts, parser):
-            config_name = (
-                attrdict.get("__config_section__") or self.plugin_name
-            )
-            config_section = (
-                dict(config[config_name]) if config_name in config else {}
-            )
-
-            for (name, opt) in opts:
-                configured_value = config_section.get(name)
-                if configured_value and not opt.configurable:
-                    raise _exceptions.PlugError(
-                        f"Plugin '{self.plugin_name}' does not allow "
-                        f"'{name}' to be configured"
-                    )
-                _add_option(name, opt, configured_value, show_all_opts, parser)
-
-            return parser
-
         return _containers.ExtensionCommand(
-            parser=attach_options,
+            parser=functools.partial(_attach_options, plugin=self),
             name=action_name,
             help=help,
             description=description,

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -98,8 +98,16 @@ def _generate_extension_command_func(attrdict: Mapping[str, Any]) -> Callable:
     opts = _extract_cli_options(attrdict)
 
     def create_extension_command(self):
-        def create_parser(config, show_all_opts):
-            parser = _containers.ExtensionParser()
+        category = attrdict.get("__category__")
+        action_name = attrdict.get(
+            "__action_name__"
+        ) or self.__class__.__name__.lower().replace("_", "-")
+        help = attrdict.get("__help__") or ""
+        description = attrdict.get("__description__") or ""
+        requires_api = attrdict.get("__requires_api__") or False
+        base_parsers = attrdict.get("__base_parsers__") or None
+
+        def attach_options(config, show_all_opts, parser):
             config_name = (
                 attrdict.get("__config_section__") or self.plugin_name
             )
@@ -118,17 +126,8 @@ def _generate_extension_command_func(attrdict: Mapping[str, Any]) -> Callable:
 
             return parser
 
-        category = attrdict.get("__category__")
-        action_name = attrdict.get(
-            "__action_name__"
-        ) or self.__class__.__name__.lower().replace("_", "-")
-        help = attrdict.get("__help__") or ""
-        description = attrdict.get("__description__") or ""
-        requires_api = attrdict.get("__requires_api__") or False
-        base_parsers = attrdict.get("__base_parsers__") or None
-
         return _containers.ExtensionCommand(
-            parser=create_parser,
+            parser=attach_options,
             name=action_name,
             help=help,
             description=description,

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -1,7 +1,7 @@
 """Plugin functionality for creating extensions to the RepoBee CLI."""
 import collections
 
-__all__ = ["Option", "Command"]
+__all__ = ["Option", "Command", "CommandExtension"]
 
 
 Option = collections.namedtuple(
@@ -18,6 +18,12 @@ Option = collections.namedtuple(
     ],
 )
 Option.__new__.__defaults__ = (None,) * len(Option._fields)
+
+
+class CommandExtension:
+    """Mixin class for use with the Plugin class. Marks the extending class as
+    a command extension, that adds options to an existing command.
+    """
 
 
 class Command:


### PR DESCRIPTION
Fix #493 

The implementation is a bit of a hack using the `ExtensionCommand` tuple in ways it's not intended to be used, and needs to be refactored, but it shows the primary functionality.