### PR TITLE
[feat] Add run function to repobee module

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -25,7 +25,7 @@ def dispatch_command(
     api: plug.API,
     config_file: pathlib.Path,
     ext_commands: Optional[List[plug.ExtensionCommand]] = None,
-):
+) -> Mapping[str, List[plug.Result]]:
     """Handle parsed CLI arguments and dispatch commands to the appropriate
     functions. Expected exceptions are caught and turned into SystemExit
     exceptions, while unexpected exceptions are allowed to propagate.
@@ -65,6 +65,8 @@ def dispatch_command(
         _handle_hook_results(
             hook_results=hook_results, filepath=args.hook_results_file
         )
+
+    return hook_results
 
 
 def _dispatch_repos_command(

--- a/src/_repobee/plugin.py
+++ b/src/_repobee/plugin.py
@@ -164,6 +164,7 @@ def register_plugins(modules: List[ModuleType]) -> List[object]:
                 plug.manager.register(obj)
                 registered.append(obj)
 
+    _handle_deprecation()
     return registered
 
 
@@ -273,7 +274,6 @@ def initialize_plugins(
         if p not in registered_plugins
     ]
     registered = register_plugins(plug_modules)
-    _handle_deprecation()
     return registered
 
 

--- a/src/repobee.py
+++ b/src/repobee.py
@@ -1,13 +1,20 @@
 import sys
 
-from _repobee.main import main
+from _repobee.main import run
 from _repobee.plugin import unregister_all_plugins, try_register_plugin
 
 __all__ = [
-    main.__name__,
-    try_register_plugin.__name__,
-    unregister_all_plugins.__name__,
+    "run",
+    "try_register_plugin",
+    "unregister_all_plugins",
 ]
 
+
+def main():
+    import _repobee.main
+
+    _repobee.main.main(sys.argv)
+
+
 if __name__ == "__main__":
-    main(sys.argv)
+    main()


### PR DESCRIPTION
Fix #503 

This function is much more convenient to use for testing than the `main` function was.

This replaces the `main` function in the `repobee` module, but I'm not marking this as a breaking change as it is only breaking against the last alpha release.