### PR TITLE
[misc] Replace bin/repobee with entry point

### DIFF
--- a/bin/repobee
+++ b/bin/repobee
@@ -1,7 +1,0 @@
-#! /usr/bin/env python3
-
-import sys
-from _repobee import main
-
-if __name__ == "__main__":
-    main.main(sys.argv)

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     tests_require=test_requirements,
     install_requires=required,
     extras_require=dict(TEST=test_requirements, DOCS=docs_requirements),
-    scripts=["bin/repobee"],
+    entry_points=dict(console_scripts="repobee = repobee:main"),
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6",


### PR DESCRIPTION
Fix #506 

Using an entry point in `setup.py` makes setuptools generate the shell script instead.