### PR TITLE
[feat] Add mutex groups to plugin commands

### DIFF
--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -123,7 +123,7 @@ class BaseParser(enum.Enum):
     MASTER_ORG = "master-org"
 
 
-class _ImmutableMixin:
+class ImmutableMixin:
     """Make a class (more or less) immutable."""
 
     def __setattr__(self, name, value):
@@ -133,7 +133,7 @@ class _ImmutableMixin:
         self.__setattr__(name, value)
 
 
-class Category(_ImmutableMixin, abc.ABC):
+class Category(ImmutableMixin, abc.ABC):
     """Class describing a command category for RepoBee's CLI. The purpose of
     this class is to make it easy to programmatically access the different
     commands in RepoBee.
@@ -214,7 +214,7 @@ class Category(_ImmutableMixin, abc.ABC):
         return hash(repr(self))
 
 
-class Action(_ImmutableMixin):
+class Action(ImmutableMixin):
     """Class describing a RepoBee CLI action.
 
     Attributes:
@@ -272,7 +272,7 @@ class Action(_ImmutableMixin):
         return (self.category.name, self.name)
 
 
-class _CoreCommand(_ImmutableMixin):
+class _CoreCommand(ImmutableMixin):
     """Parser category signifying where an extension parser belongs."""
 
     def iter_actions(self) -> Iterable[Action]:

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -1,7 +1,16 @@
 """Plugin functionality for creating extensions to the RepoBee CLI."""
 import collections
+from typing import List, Tuple
 
-__all__ = ["Option", "Command", "CommandExtension"]
+from repobee_plug import _containers
+
+__all__ = [
+    "Option",
+    "Positional",
+    "MutuallyExclusiveGroup",
+    "Command",
+    "CommandExtension",
+]
 
 
 Option = collections.namedtuple(
@@ -23,6 +32,45 @@ Positional = collections.namedtuple(
     "Positional", ["help", "converter", "argparse_kwargs"]
 )
 Positional.__new__.__defaults__ = (None,) * len(Positional._fields)
+
+
+class MutuallyExclusiveGroup(_containers.ImmutableMixin):
+    """A group of mutually exclusive CLI options.
+
+    Attributes:
+        ALLOWED_TYPES: The types that are allowed to be passed in the
+            constructor kwargs.
+        options: The options that have been stored in this group.
+        required: Whether or not this mutex group is required.
+    """
+
+    ALLOWED_TYPES = (Option,)
+    options: List[Tuple[str, Option]]
+    required: bool
+
+    def __init__(self, *, required: bool = False, **kwargs):
+        """
+        Args:
+            required: Whether or not this mutex group is required.
+            kwargs: Keyword arguments on the form ``name=plug.cli.Option()``.
+        """
+
+        def _check_type(key, value):
+            if not isinstance(value, self.ALLOWED_TYPES):
+                raise TypeError(
+                    f"{value.__class__.__name__} "
+                    f"not allowed in mutex group: {key}={value}"
+                )
+            return True
+
+        options = [
+            (key, value)
+            for key, value in kwargs.items()
+            if _check_type(key, value)
+        ]
+
+        object.__setattr__(self, "options", options)
+        object.__setattr__(self, "required", required)
 
 
 class CommandExtension:

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -48,10 +48,10 @@ class MutuallyExclusiveGroup(_containers.ImmutableMixin):
     options: List[Tuple[str, Option]]
     required: bool
 
-    def __init__(self, *, required: bool = False, **kwargs):
+    def __init__(self, *, __required__: bool = False, **kwargs):
         """
         Args:
-            required: Whether or not this mutex group is required.
+            __required__: Whether or not this mutex group is required.
             kwargs: Keyword arguments on the form ``name=plug.cli.Option()``.
         """
 
@@ -70,7 +70,7 @@ class MutuallyExclusiveGroup(_containers.ImmutableMixin):
         ]
 
         object.__setattr__(self, "options", options)
-        object.__setattr__(self, "required", required)
+        object.__setattr__(self, "required", __required__)
 
 
 class CommandExtension:

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -327,7 +327,7 @@ class TestDeclarativeExtensionCommand:
                 __required__=True,
             )
 
-        assert "Positional not allowed in mutex group" in str(exc_info)
+        assert "Positional not allowed in mutex group" in str(exc_info.value)
 
     def test_mutex_group_allows_one_argument(self):
         """Test that a mutex group allows one argument to be specified."""

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -297,6 +297,7 @@ class TestDeclarativeExtensionCommand:
                 old=plug.cli.Option(
                     argparse_kwargs=dict(action="store_const", const=1337),
                 ),
+                __required__=True,
             )
 
             def command_callback(self, args, api):
@@ -323,6 +324,7 @@ class TestDeclarativeExtensionCommand:
                 old=plug.cli.Option(
                     argparse_kwargs=dict(action="store_const", const=1337),
                 ),
+                __required__=True,
             )
 
         assert "Positional not allowed in mutex group" in str(exc_info)
@@ -337,6 +339,7 @@ class TestDeclarativeExtensionCommand:
                 old=plug.cli.Option(
                     argparse_kwargs=dict(action="store_const", const=old),
                 ),
+                __required__=True,
             )
 
             def command_callback(self, args, api):


### PR DESCRIPTION
Fix #499 

Adds mutually exclusive groups to plugin commands. Can be used like so:

```python
import repobee_plug as plug


class Hello(plug.Plugin, plug.cli.Command):
    age_mutex = plug.cli.MutuallyExclusiveGroup(
        age=plug.cli.Option(help="Your age.", converter=int),
        half_age=plug.cli.Option(
            help="Half your age.", converter=lambda half: int(half) * 2
        ),
        __required__=True,
    )

    def command_callback(self, args, api):
        print(f"Hello, my name is RALPH and I am {args.age if args.age else args.half_age} years old")
```