### PR TITLE
[feat] Wrap plugin command settings in object

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -38,10 +38,10 @@ def dispatch_command(
     """
     hook_results = {}
     dispatch_table = {
-        plug.CoreCommand.repos: _dispatch_repos_command,
-        plug.CoreCommand.issues: _dispatch_issues_command,
-        plug.CoreCommand.config: _dispatch_config_command,
-        plug.CoreCommand.reviews: _dispatch_reviews_command,
+        plug.cli.CoreCommand.repos: _dispatch_repos_command,
+        plug.cli.CoreCommand.issues: _dispatch_issues_command,
+        plug.cli.CoreCommand.config: _dispatch_config_command,
+        plug.cli.CoreCommand.reviews: _dispatch_reviews_command,
     }
 
     is_ext_command = "_extension_command" in args
@@ -50,15 +50,15 @@ def dispatch_command(
         res = ext_cmd.callback(args, api)
         hook_results = {ext_cmd.name: [res]} if res else hook_results
     else:
-        category = plug.CoreCommand(args.category)
+        category = plug.cli.CoreCommand(args.category)
         hook_results = (
             dispatch_table[category](args, config_file, api) or hook_results
         )
 
     if is_ext_command or args.action in [
-        plug.CoreCommand.repos.setup.name,
-        plug.CoreCommand.repos.update.name,
-        plug.CoreCommand.repos.clone.name,
+        plug.cli.CoreCommand.repos.setup.name,
+        plug.cli.CoreCommand.repos.update.name,
+        plug.cli.CoreCommand.repos.clone.name,
     ]:
         LOGGER.info(formatters.format_hook_results_output(hook_results))
     if hook_results and "hook_results_file" in args and args.hook_results_file:
@@ -72,7 +72,7 @@ def dispatch_command(
 def _dispatch_repos_command(
     args: argparse.Namespace, config_file: pathlib.Path, api: plug.API
 ) -> Optional[Mapping[str, List[plug.Result]]]:
-    repos = plug.CoreCommand.repos
+    repos = plug.cli.CoreCommand.repos
     action = repos[args.action]
     if action == repos.setup:
         return command.setup_student_repos(
@@ -97,7 +97,7 @@ def _dispatch_repos_command(
 def _dispatch_issues_command(
     args: argparse.Namespace, config_file: pathlib.Path, api: plug.API
 ) -> Optional[Mapping[str, List[plug.Result]]]:
-    issues = plug.CoreCommand.issues
+    issues = plug.cli.CoreCommand.issues
     action = issues[args.action]
     if action == issues.open:
         command.open_issue(
@@ -122,7 +122,7 @@ def _dispatch_issues_command(
 def _dispatch_config_command(
     args: argparse.Namespace, config_file: pathlib.Path, api: plug.API
 ) -> Optional[Mapping[str, List[plug.Result]]]:
-    config = plug.CoreCommand.config
+    config = plug.cli.CoreCommand.config
     action = config[args.action]
     if action == config.verify:
         plug.manager.hook.get_api_class().verify_settings(
@@ -142,7 +142,7 @@ def _dispatch_config_command(
 def _dispatch_reviews_command(
     args: argparse.Namespace, config_file: pathlib.Path, api: plug.API
 ) -> Optional[Mapping[str, List[plug.Result]]]:
-    reviews = plug.CoreCommand.reviews
+    reviews = plug.cli.CoreCommand.reviews
     action = reviews[args.action]
     if action == reviews.assign:
         command.assign_peer_reviews(

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -168,7 +168,7 @@ def _add_subparsers(parser, show_all_opts, ext_commands, config_file):
     subparsers = parser.add_subparsers(dest=SUB)
     subparsers.required = True
     parsers: Mapping[
-        Union[plug.Category, plug.Action], argparse.ArgumentParser
+        Union[plug.cli.Category, plug.cli.Action], argparse.ArgumentParser
     ] = {}
 
     def _create_category_parsers(category, help, description):
@@ -181,22 +181,22 @@ def _add_subparsers(parser, show_all_opts, ext_commands, config_file):
         return category_parsers
 
     repo_parsers = _create_category_parsers(
-        plug.CoreCommand.repos,
+        plug.cli.CoreCommand.repos,
         description="Manage repositories.",
         help="Manage repositories.",
     )
     issues_parsers = _create_category_parsers(
-        plug.CoreCommand.issues,
+        plug.cli.CoreCommand.issues,
         description="Manage issues.",
         help="Manage issues.",
     )
     review_parsers = _create_category_parsers(
-        plug.CoreCommand.reviews,
+        plug.cli.CoreCommand.reviews,
         help="Manage peer reviews.",
         description="Manage peer reviews.",
     )
     config_parsers = _create_category_parsers(
-        plug.CoreCommand.config,
+        plug.cli.CoreCommand.config,
         help="Configure RepoBee.",
         description="Configure RepoBee.",
     )
@@ -245,7 +245,7 @@ def _add_repo_parsers(
     base_parser, base_student_parser, master_org_parser, add_parser
 ):
     add_parser(
-        plug.CoreCommand.repos.setup,
+        plug.cli.CoreCommand.repos.setup,
         help="Setup student repos.",
         description=(
             "Setup student repositories based on master repositories. "
@@ -267,7 +267,7 @@ def _add_repo_parsers(
     )
 
     update = add_parser(
-        plug.CoreCommand.repos.update,
+        plug.cli.CoreCommand.repos.update,
         help="Update existing student repos.",
         description=(
             "Push changes from master repos to student repos. If the "
@@ -294,7 +294,7 @@ def _add_repo_parsers(
     )
 
     clone = add_parser(
-        plug.CoreCommand.repos.clone,
+        plug.cli.CoreCommand.repos.clone,
         help="Clone student repos.",
         description="Clone student repos asynchronously in bulk.",
         parents=[
@@ -312,7 +312,7 @@ def _add_repo_parsers(
     plug.manager.hook.clone_parser_hook(clone_parser=clone)
 
     add_parser(
-        plug.CoreCommand.repos.create_teams,
+        plug.cli.CoreCommand.repos.create_teams,
         help="Create student teams without creating repos.",
         description=(
             "Only create student teams. This is intended for when you want to "
@@ -326,7 +326,7 @@ def _add_repo_parsers(
     )
 
     add_parser(
-        plug.CoreCommand.repos.migrate,
+        plug.cli.CoreCommand.repos.migrate,
         help="Migrate repositories into the target organization.",
         description=(
             "Migrate repositories into the target organization. "
@@ -340,7 +340,7 @@ def _add_repo_parsers(
 
 def _add_config_parsers(base_parser, master_org_parser, add_parser):
     show_config = add_parser(
-        plug.CoreCommand.config.show,
+        plug.cli.CoreCommand.config.show,
         help="Show the configuration file",
         description=(
             "Show the contents of the configuration file. If no configuration "
@@ -352,7 +352,7 @@ def _add_config_parsers(base_parser, master_org_parser, add_parser):
     _add_traceback_arg(show_config)
 
     add_parser(
-        plug.CoreCommand.config.verify,
+        plug.cli.CoreCommand.config.verify,
         help="Verify core settings.",
         description="Verify core settings by trying various API requests.",
         parents=[base_parser, master_org_parser],
@@ -362,7 +362,7 @@ def _add_config_parsers(base_parser, master_org_parser, add_parser):
 
 def _add_peer_review_parsers(base_parsers, add_parser):
     assign_parser = add_parser(
-        plug.CoreCommand.reviews.assign,
+        plug.cli.CoreCommand.reviews.assign,
         description=(
             "For each student repo, create a review team with read access "
             "named <student-repo-name>-review and randomly assign "
@@ -398,7 +398,7 @@ def _add_peer_review_parsers(base_parsers, add_parser):
         type=str,
     )
     check_review_progress = add_parser(
-        plug.CoreCommand.reviews.check,
+        plug.cli.CoreCommand.reviews.check,
         description=(
             "Check which students have opened review review issues in their "
             "assigned repos. As it is possible for students to leave the peer "
@@ -433,7 +433,7 @@ def _add_peer_review_parsers(base_parsers, add_parser):
         required=True,
     )
     add_parser(
-        plug.CoreCommand.reviews.end,
+        plug.cli.CoreCommand.reviews.end,
         description=(
             "Delete review allocations assigned with `assign-reviews`. "
             "This is a destructive action, as the allocations for reviews "
@@ -458,7 +458,7 @@ def _add_peer_review_parsers(base_parsers, add_parser):
 def _add_issue_parsers(base_parsers, add_parser):
     base_parser, base_student_parser, master_org_parser = base_parsers
     open_parser = add_parser(
-        plug.CoreCommand.issues.open,
+        plug.cli.CoreCommand.issues.open,
         description=(
             "Open issues in student repositories. For each master repository "
             "specified, the student list is traversed. For every student repo "
@@ -479,7 +479,7 @@ def _add_issue_parsers(base_parsers, add_parser):
     )
 
     close_parser = add_parser(
-        plug.CoreCommand.issues.close,
+        plug.cli.CoreCommand.issues.close,
         description=(
             "Close issues in student repos based on a regex. For each master "
             "repository specified, the student list is traversed. For every "
@@ -502,7 +502,7 @@ def _add_issue_parsers(base_parsers, add_parser):
     )
 
     list_parser = add_parser(
-        plug.CoreCommand.issues.list,
+        plug.cli.CoreCommand.issues.list,
         description="List issues in student repos.",
         help="List issues in student repos.",
         parents=[
@@ -651,7 +651,7 @@ def _add_extension_parsers(
                 formatter_class=_OrderedFormatter,
             )
 
-        if cmd.name in plug.CoreCommand:
+        if cmd.name in plug.cli.CoreCommand:
             ext_parser = parsers_mapping[cmd.name]
             cmd.parser(
                 config=parsed_config,

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -135,10 +135,10 @@ def _resolve_requires_processing(args: argparse.Namespace) -> _ArgsProcessing:
     This is primarily decided on whether or not the platform API is required,
     as that implies further processing.
     """
-    action = plug.CoreCommand(args.category)[args.action]
+    action = plug.cli.CoreCommand(args.category)[args.action]
     if action in [
-        plug.CoreCommand.config.verify,
-        plug.CoreCommand.config.show,
+        plug.cli.CoreCommand.config.verify,
+        plug.cli.CoreCommand.config.show,
     ]:
         return _ArgsProcessing.NONE
     return _ArgsProcessing.CORE
@@ -193,12 +193,12 @@ def _handle_task_parsing(args: argparse.Namespace) -> None:
     """
     assert args._repobee_processed
 
-    action = plug.CoreCommand(args.category)[args.action]
-    if action == plug.CoreCommand.repos.clone:
+    action = plug.cli.CoreCommand(args.category)[args.action]
+    if action == plug.cli.CoreCommand.repos.clone:
         plug.manager.hook.parse_args(args=args)
         for task in plug.manager.hook.clone_task():
             util.call_if_defined(task.handle_args, args)
-    elif args.action == plug.CoreCommand.repos.setup:
+    elif args.action == plug.cli.CoreCommand.repos.setup:
         for task in plug.manager.hook.setup_task():
             util.call_if_defined(task.handle_args, args)
 

--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -20,12 +20,14 @@ LOGGER = daiquiri.getLogger(__file__)
 
 
 class Wizard(plug.Plugin, plug.cli.Command):
-    __category__ = plug.cli.CoreCommand.config
-    __help__ = "Interactive configuration wizard to set up the config file."
-    __description__ = (
-        "A configuration wizard that sets up the configuration file."
-        "Warns if there already is a configuration file, as it will be "
-        "overwritten."
+    __settings__ = plug.cli.CommandSettings(
+        category=plug.cli.CoreCommand.config,
+        help="Interactive configuration wizard to set up the config file.",
+        description=(
+            "A configuration wizard that sets up the configuration file."
+            "Warns if there already is a configuration file, as it will be "
+            "overwritten."
+        ),
     )
 
     def command_callback(

--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -20,7 +20,7 @@ LOGGER = daiquiri.getLogger(__file__)
 
 
 class Wizard(plug.Plugin, plug.cli.Command):
-    __category__ = plug.CoreCommand.config
+    __category__ = plug.cli.CoreCommand.config
     __help__ = "Interactive configuration wizard to set up the config file."
     __description__ = (
         "A configuration wizard that sets up the configuration file."

--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -13,14 +13,11 @@ from repobee_plug._containers import Result
 from repobee_plug._containers import Status
 from repobee_plug._containers import ExtensionParser
 from repobee_plug._containers import ExtensionCommand
-from repobee_plug._containers import CoreCommand
 from repobee_plug._containers import ReviewAllocation
 from repobee_plug._containers import BaseParser
 from repobee_plug._containers import Deprecation
 from repobee_plug._containers import HookResult
 from repobee_plug._tasks import Task
-from repobee_plug._containers import Action
-from repobee_plug._containers import Category
 
 # Hook functions
 from repobee_plug._corehooks import PeerReviewHook as _peer_hook
@@ -77,13 +74,10 @@ __all__ = [
     "Status",
     "ExtensionParser",
     "ExtensionCommand",
-    "CoreCommand",
     "ReviewAllocation",
     "Review",
     "Task",
     "Deprecation",
-    "Action",
-    "Category",
     # API wrappers
     "Team",
     "TeamPermission",

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -9,10 +9,8 @@ import collections
 import enum
 import argparse
 import pluggy
-import itertools
-import abc
 
-from typing import Mapping, Any, Optional, Callable, Iterable, List, Tuple, Set
+from typing import Mapping, Any, Optional, Callable, Iterable, List
 
 import daiquiri
 
@@ -133,202 +131,6 @@ class ImmutableMixin:
         self.__setattr__(name, value)
 
 
-class Category(ImmutableMixin, abc.ABC):
-    """Class describing a command category for RepoBee's CLI. The purpose of
-    this class is to make it easy to programmatically access the different
-    commands in RepoBee.
-
-    A full command in RepoBee typically takes the following form:
-
-    .. code-block:: bash
-
-        $ repobee <category> <action> [options ...]
-
-    For example, the command ``repobee issues list`` has category ``issues``
-    and action ``list``. Actions are unique only within their category.
-
-    Attributes:
-        name: Name of this category.
-        actions: A tuple of names of actions applicable to this category.
-    """
-
-    name: str
-    actions: Tuple["Action"]
-    action_names: Set[str]
-    _action_table: Mapping[str, "Action"]
-
-    def __init__(self):
-        # determine the name of this category based on the runtime type of the
-        # inheriting class
-        name = self.__class__.__name__.lower().strip("_")
-        # determine the action names based on type annotations in the
-        # inheriting class
-        action_names = {
-            name
-            for name, tpe in self.__annotations__.items()
-            if issubclass(tpe, Action)
-        }
-
-        object.__setattr__(self, "name", name)
-        object.__setattr__(self, "action_names", set(action_names))
-        # This is just to reserve the name 'actions'
-        object.__setattr__(self, "actions", None)
-
-        for key in self.__dict__.keys():
-            if key in action_names:
-                raise ValueError(f"Illegal action name: {key}")
-
-        actions = []
-        for action_name in action_names:
-            action = Action(action_name.replace("_", "-"), self)
-            object.__setattr__(self, action_name, action)
-            actions.append(action)
-
-        object.__setattr__(self, "actions", tuple(actions))
-        object.__setattr__(self, "_action_table", {a.name: a for a in actions})
-
-    def get(self, key: str) -> "Action":
-        return self._action_table.get(key)
-
-    def __getitem__(self, key: str) -> "Action":
-        return self._action_table[key]
-
-    def __iter__(self) -> Iterable["Action"]:
-        return iter(self.actions)
-
-    def __len__(self):
-        return len(self.actions)
-
-    def __repr__(self):
-        return f"Category(name={self.name}, actions={self.action_names})"
-
-    def __str__(self):
-        return self.name
-
-    def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-        return self.name == other.name
-
-    def __hash__(self):
-        return hash(repr(self))
-
-
-class Action(ImmutableMixin):
-    """Class describing a RepoBee CLI action.
-
-    Attributes:
-        name: Name of this action.
-        category: The category this action belongs to.
-    """
-
-    name: str
-    category: Category
-
-    def __init__(self, name: str, category: Category):
-        object.__setattr__(self, "name", name)
-        object.__setattr__(self, "category", category)
-
-    def __repr__(self):
-        return f"<Action(name={self.name},category={self.category})>"
-
-    def __str__(self):
-        return f"{self.category.name} {self.name}"
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, self.__class__)
-            and self.name == other.name
-            and self.category == other.category
-        )
-
-    def __hash__(self):
-        return hash(str(self))
-
-    def asdict(self) -> Mapping[str, str]:
-        """This is a convenience method for testing that returns a dictionary
-        on the following form:
-
-        .. code-block:: python
-
-            {"category": self.category.name "action": self.name}
-
-        Returns:
-            A dictionary with the name of this action and its category.
-        """
-        return {"category": self.category.name, "action": self.name}
-
-    def astuple(self) -> Tuple[str, str]:
-        """This is a convenience method for testing that returns a tuple
-        on the following form:
-
-        .. code-block:: python
-
-            (self.category.name, self.name)
-
-        Returns:
-            A dictionary with the name of this action and its category.
-        """
-        return (self.category.name, self.name)
-
-
-class _CoreCommand(ImmutableMixin):
-    """Parser category signifying where an extension parser belongs."""
-
-    def iter_actions(self) -> Iterable[Action]:
-        """Iterate over all command actions."""
-        return iter(self)
-
-    def __call__(self, key):
-        category_map = {c.name: c for c in self._categories}
-        if key not in category_map:
-            raise ValueError(f"No such category: '{key}'")
-        return category_map[key]
-
-    def __iter__(self) -> Iterable[Action]:
-        return itertools.chain.from_iterable(map(iter, self._categories))
-
-    def __len__(self):
-        return sum(map(len, self._categories))
-
-    @property
-    def _categories(self):
-        return [
-            attr
-            for attr in self.__class__.__dict__.values()
-            if isinstance(attr, Category)
-        ]
-
-    class _Repos(Category):
-        setup: Action
-        update: Action
-        clone: Action
-        migrate: Action
-        create_teams: Action
-
-    class _Issues(Category):
-        open: Action
-        close: Action
-        list: Action
-
-    class _Config(Category):
-        show: Action
-        verify: Action
-
-    class _Reviews(Category):
-        assign: Action
-        check: Action
-        end: Action
-
-    repos = _Repos()
-    issues = _Issues()
-    config = _Config()
-    reviews = _Reviews()
-
-
-CoreCommand = _CoreCommand()
-
-
 class ExtensionCommand(
     collections.namedtuple(
         "ExtensionCommand",
@@ -358,7 +160,7 @@ class ExtensionCommand(
         ],
         requires_api: bool = False,
         requires_base_parsers: Optional[List[BaseParser]] = None,
-        category: Optional[CoreCommand] = None,
+        category: Optional = None,
     ):
         if not (isinstance(parser, ExtensionParser) or callable(parser)):
             raise _exceptions.ExtensionCommandError(
@@ -401,7 +203,7 @@ class ExtensionCommand(
         ],
         requires_api: bool = False,
         requires_base_parsers: Optional[Iterable[BaseParser]] = None,
-        category: Optional[CoreCommand] = None,
+        category: Optional = None,
     ):
         """
         Args:

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -50,12 +50,15 @@ class _PluginMeta(type):
                 "A plugin cannot be both a Command and a CommandExtension"
             )
 
-        if cli.Command in bases or cli.CommandExtension in bases:
-            ext_cmd_func = (
-                _generate_command_func(attrdict)
-                if cli.Command in bases
-                else _generate_command_extension_func()
-            )
+        if cli.Command in bases:
+            ext_cmd_func = _generate_command_func(attrdict)
+            attrdict[ext_cmd_func.__name__] = ext_cmd_func
+        elif cli.CommandExtension in bases:
+            if "__settings__" not in attrdict:
+                raise _exceptions.PlugError(
+                    "CommandExtension must have a '__settings__' attribute"
+                )
+            ext_cmd_func = _generate_command_extension_func()
             attrdict[ext_cmd_func.__name__] = ext_cmd_func
 
         methods = cls._extract_public_methods(attrdict)

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -15,6 +15,7 @@ __all__ = [
     "Action",
     "Category",
     "CoreCommand",
+    "CommandSettings",
 ]
 
 from repobee_plug._containers import ImmutableMixin
@@ -40,24 +41,75 @@ Positional = collections.namedtuple(
 Positional.__new__.__defaults__ = (None,) * len(Positional._fields)
 
 
-class Settings(_containers.ImmutableMixin):
-    """Settings for a :py:class:`Command`.
+class CommandSettings(_containers.ImmutableMixin):
+    """Settings for a :py:class:`Command`, that can be provided in the
+    ``__settings__`` attribute.
 
-    Args:
-        action_name: The name of the action that the command will be
-            available under.
+    Example usage:
+
+    .. code-block:: python
+        :caption: ext.py
+
+        import repobee_plug as plug
+
+        class Ext(plug.Plugin, plug.cli.Command):
+            __settings__ = plug.cli.CommandSettings(
+                action_name="hello",
+                category=plug.cli.CoreCommand.config,
+            )
+
+            def command_callback(self, args, api):
+                print("Hello, world!")
+
+    This can then be called with:
+
+    .. code-block:: bash
+
+        $ repobee -p ext.py config hello
+        Hello, world!
     """
 
     def __init__(
         self,
         action_name: Optional[str] = None,
-        category: Optional[str] = None,
-        help: Optional[str] = None,
-        description: Optional[str] = None,
-        requires_api: Optional[bool] = None,
+        category: Optional["CoreCommand"] = None,
+        help: str = "",
+        description: str = "",
+        requires_api: bool = False,
         base_parsers: Optional[List[_containers.BaseParser]] = None,
+        config_section_name: Optional[str] = None,
     ):
-        pass
+        """
+        Args:
+            action_name: The name of the action that the command will be
+                available under.
+        """
+        object.__setattr__(self, "action_name", action_name)
+        object.__setattr__(self, "category", category)
+        object.__setattr__(self, "help", help)
+        object.__setattr__(self, "description", description)
+        object.__setattr__(self, "requires_api", requires_api)
+        object.__setattr__(self, "base_parsers", base_parsers)
+        object.__setattr__(self, "config_section_name", config_section_name)
+
+
+class CommandExtensionSettings(_containers.ImmutableMixin):
+    """Settings for a :py:class:`CommandExtension`."""
+
+    actions: List["Action"]
+    config_section_name: Optional[str]
+
+    def __init__(
+        self,
+        actions: List["Action"],
+        config_section_name: Optional[str] = None,
+    ):
+        if not actions:
+            raise ValueError(
+                f"argument 'actions' must be a non-empty list: {actions}"
+            )
+        object.__setattr__(self, "actions", actions)
+        object.__setattr__(self, "config_section_name", config_section_name)
 
 
 class MutuallyExclusiveGroup(_containers.ImmutableMixin):

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -69,6 +69,14 @@ class CommandSettings(_containers.ImmutableMixin):
         Hello, world!
     """
 
+    action_name: Optional[str]
+    category: Optional["CoreCommand"]
+    help: str
+    description: str
+    requires_api: bool
+    base_parsers: Optional[List[_containers.BaseParser]]
+    config_section_name: Optional[str]
+
     def __init__(
         self,
         action_name: Optional[str] = None,
@@ -82,7 +90,19 @@ class CommandSettings(_containers.ImmutableMixin):
         """
         Args:
             action_name: The name of the action that the command will be
-                available under.
+                available under. Defaults to the name of the plugin class.
+            category: The category to place this command in. If not specified,
+                then the command will be top-level (i.e. uncategorized).
+            help: A help section for the command. This appears when listing the
+                help section of the command's category.
+            description: A help section for the command. This appears when
+                listing the help section for the command itself.
+            requires_api: If True, a platform API will be insantiated and
+                passed to the command function.
+            base_parsers: A list of base parsers to add to the command.
+            config_section_name: The name of the configuration section the
+                command should look for configurable options in. Defaults
+                to the name of the plugin the command is defined in.
         """
         object.__setattr__(self, "action_name", action_name)
         object.__setattr__(self, "category", category)
@@ -104,6 +124,14 @@ class CommandExtensionSettings(_containers.ImmutableMixin):
         actions: List["Action"],
         config_section_name: Optional[str] = None,
     ):
+        """
+        Args:
+            actions: A list of actions to extend.
+            config_section_name: Name of the configuration section that the
+                command extension will fetch configuration values from.
+                Defaults to the name of the plugin in which the extension is
+                defined.
+        """
         if not actions:
             raise ValueError(
                 f"argument 'actions' must be a non-empty list: {actions}"

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 import repobee_plug as plug
 
 import gitlabmanager
+import repobee_plug.cli
 from _helpers.asserts import (
     assert_repos_exist,
     assert_on_groups,
@@ -121,7 +122,7 @@ def with_student_repos(restore):
     command = " ".join(
         [
             REPOBEE_GITLAB,
-            *str(plug.CoreCommand.repos.setup).split(),
+            *str(repobee_plug.cli.CoreCommand.repos.setup).split(),
             *BASE_ARGS,
             *MASTER_ORG_ARG,
             *MASTER_REPOS_ARG,
@@ -187,7 +188,7 @@ def with_reviews(with_student_repos):
     command = " ".join(
         [
             REPOBEE_GITLAB,
-            *str(plug.CoreCommand.reviews.assign).split(),
+            *str(repobee_plug.cli.CoreCommand.reviews.assign).split(),
             *BASE_ARGS,
             "--mn",
             master_repo_name,

--- a/tests/integration_tests/integration_tests.py
+++ b/tests/integration_tests/integration_tests.py
@@ -9,6 +9,7 @@ import repobee_plug as plug
 import _repobee.ext
 import _repobee.ext.gitlab
 import _repobee.cli.mainparser
+import repobee_plug.cli
 
 from _helpers.asserts import (
     assert_master_repos_exist,
@@ -58,7 +59,7 @@ class TestClone:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.clone).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.clone).split(),
                 *BASE_ARGS,
                 *MASTER_REPOS_ARG,
                 *STUDENTS_ARG,
@@ -76,7 +77,7 @@ class TestClone:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.clone).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.clone).split(),
                 *BASE_ARGS,
                 *MASTER_REPOS_ARG,
                 *STUDENTS_ARG,
@@ -104,7 +105,7 @@ class TestClone:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.clone).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.clone).split(),
                 *BASE_ARGS,
                 *STUDENTS_ARG,
                 "--mn",
@@ -142,7 +143,7 @@ class TestClone:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.clone).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.clone).split(),
                 *BASE_ARGS,
                 *MASTER_REPOS_ARG,
                 *STUDENTS_ARG,
@@ -164,7 +165,7 @@ class TestClone:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.clone).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.clone).split(),
                 *BASE_ARGS,
                 *STUDENTS_ARG,
                 "--discover-repos",
@@ -186,7 +187,7 @@ class TestSetup:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.setup).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.setup).split(),
                 *BASE_ARGS,
                 *MASTER_ORG_ARG,
                 *MASTER_REPOS_ARG,
@@ -204,7 +205,7 @@ class TestSetup:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.setup).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.setup).split(),
                 *BASE_ARGS,
                 *MASTER_ORG_ARG,
                 *MASTER_REPOS_ARG,
@@ -232,7 +233,7 @@ class TestUpdate:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.update).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.update).split(),
                 *MASTER_ORG_ARG,
                 *BASE_ARGS,
                 "--mn",
@@ -264,7 +265,7 @@ class TestUpdate:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.update).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.update).split(),
                 *MASTER_ORG_ARG,
                 *BASE_ARGS,
                 "--mn",
@@ -312,7 +313,7 @@ class TestMigrate:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.repos.migrate).split(),
+                *str(repobee_plug.cli.CoreCommand.repos.migrate).split(),
                 *BASE_ARGS,
                 *MASTER_REPOS_ARG,
             ]
@@ -339,7 +340,7 @@ class TestOpenIssues:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.issues.open).split(),
+                *str(repobee_plug.cli.CoreCommand.issues.open).split(),
                 *BASE_ARGS,
                 *MASTER_REPOS_ARG,
                 *STUDENTS_ARG,
@@ -367,7 +368,7 @@ class TestCloseIssues:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.issues.close).split(),
+                *str(repobee_plug.cli.CoreCommand.issues.close).split(),
                 *BASE_ARGS,
                 *MASTER_REPOS_ARG,
                 *STUDENTS_ARG,
@@ -423,7 +424,7 @@ class TestListIssues:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.issues.list).split(),
+                *str(repobee_plug.cli.CoreCommand.issues.list).split(),
                 *BASE_ARGS,
                 *repo_arg,
                 *STUDENTS_ARG,
@@ -463,7 +464,7 @@ class TestAssignReviews:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.reviews.assign).split(),
+                *str(repobee_plug.cli.CoreCommand.reviews.assign).split(),
                 *BASE_ARGS,
                 "--mn",
                 master_repo_name,
@@ -503,7 +504,7 @@ class TestAssignReviews:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.reviews.assign).split(),
+                *str(repobee_plug.cli.CoreCommand.reviews.assign).split(),
                 *BASE_ARGS_NO_TB,
                 "--mn",
                 master_repo_name,
@@ -534,7 +535,7 @@ class TestEndReviews:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.reviews.end).split(),
+                *str(repobee_plug.cli.CoreCommand.reviews.end).split(),
                 *BASE_ARGS,
                 "--mn",
                 master_repo_name,
@@ -561,7 +562,7 @@ class TestEndReviews:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.reviews.end).split(),
+                *str(repobee_plug.cli.CoreCommand.reviews.end).split(),
                 *BASE_ARGS,
                 "--mn",
                 master_repo_name,
@@ -602,7 +603,7 @@ class TestCheckReviews:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.reviews.check).split(),
+                *str(repobee_plug.cli.CoreCommand.reviews.check).split(),
                 *BASE_ARGS,
                 "--mn",
                 master_repo_name,
@@ -659,7 +660,7 @@ class TestCheckReviews:
         command = " ".join(
             [
                 REPOBEE_GITLAB,
-                *str(plug.CoreCommand.reviews.check).split(),
+                *str(repobee_plug.cli.CoreCommand.reviews.check).split(),
                 *BASE_ARGS,
                 "--mn",
                 master_repo_name,

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -18,6 +18,7 @@ import _repobee.ext.query
 import _repobee.constants
 import _repobee.plugin
 import _repobee.ext.defaults.configwizard
+import repobee_plug.cli
 from _repobee.cli import mainparser
 from _repobee import exception
 
@@ -140,7 +141,7 @@ def git_mock(mocker):
     return mocker.patch("_repobee.git", autospec=True)
 
 
-@pytest.fixture(scope="function", params=iter(plug.CoreCommand))
+@pytest.fixture(scope="function", params=iter(repobee_plug.cli.CoreCommand))
 def parsed_args_all_subparsers(request):
     """Parametrized fixture which returns a namespace for each of the
     subparsers. These arguments are valid for all subparsers, even though
@@ -222,8 +223,14 @@ class TestDispatchCommand:
     @pytest.mark.parametrize(
         "action, command_func",
         [
-            (plug.CoreCommand.repos.clone, "_repobee.command.clone_repos"),
-            (plug.CoreCommand.issues.list, "_repobee.command.list_issues"),
+            (
+                repobee_plug.cli.CoreCommand.repos.clone,
+                "_repobee.command.clone_repos",
+            ),
+            (
+                repobee_plug.cli.CoreCommand.issues.list,
+                "_repobee.command.list_issues",
+            ),
         ],
     )
     def test_writes_hook_results_correctly(
@@ -261,7 +268,7 @@ class TestDispatchCommand:
         expected_filepath = pathlib.Path(".").resolve() / "results.json"
         args_dict = dict(VALID_PARSED_ARGS)
         args_dict["hook_results_file"] = str(expected_filepath)
-        action = plug.CoreCommand.repos.clone
+        action = repobee_plug.cli.CoreCommand.repos.clone
 
         with mock.patch(
             "_repobee.util.atomic_write", autospec=True
@@ -303,7 +310,8 @@ class TestDispatchCommand:
         self, command_mock, api_instance_mock
     ):
         args = argparse.Namespace(
-            **plug.CoreCommand.repos.setup.asdict(), **VALID_PARSED_ARGS
+            **repobee_plug.cli.CoreCommand.repos.setup.asdict(),
+            **VALID_PARSED_ARGS
         )
 
         _repobee.cli.dispatch.dispatch_command(
@@ -318,7 +326,8 @@ class TestDispatchCommand:
         self, command_mock, api_instance_mock
     ):
         args = argparse.Namespace(
-            **plug.CoreCommand.repos.update.asdict(), **VALID_PARSED_ARGS
+            **repobee_plug.cli.CoreCommand.repos.update.asdict(),
+            **VALID_PARSED_ARGS
         )
 
         _repobee.cli.dispatch.dispatch_command(
@@ -334,7 +343,8 @@ class TestDispatchCommand:
 
     def test_create_teams_called_with_correct_args(self, api_instance_mock):
         args = argparse.Namespace(
-            **plug.CoreCommand.repos.create_teams.asdict(), **VALID_PARSED_ARGS
+            **repobee_plug.cli.CoreCommand.repos.create_teams.asdict(),
+            **VALID_PARSED_ARGS
         )
         expected_arg = list(args.students)
 
@@ -350,7 +360,8 @@ class TestDispatchCommand:
         self, command_mock, api_instance_mock
     ):
         args = argparse.Namespace(
-            **plug.CoreCommand.issues.open.asdict(), **VALID_PARSED_ARGS
+            **repobee_plug.cli.CoreCommand.issues.open.asdict(),
+            **VALID_PARSED_ARGS
         )
 
         _repobee.cli.dispatch.dispatch_command(
@@ -368,7 +379,8 @@ class TestDispatchCommand:
         self, command_mock, api_instance_mock
     ):
         args = argparse.Namespace(
-            **plug.CoreCommand.issues.close.asdict(), **VALID_PARSED_ARGS
+            **repobee_plug.cli.CoreCommand.issues.close.asdict(),
+            **VALID_PARSED_ARGS
         )
 
         _repobee.cli.dispatch.dispatch_command(
@@ -383,7 +395,8 @@ class TestDispatchCommand:
         self, command_mock, api_instance_mock
     ):
         args = argparse.Namespace(
-            **plug.CoreCommand.repos.migrate.asdict(), **VALID_PARSED_ARGS
+            **repobee_plug.cli.CoreCommand.repos.migrate.asdict(),
+            **VALID_PARSED_ARGS
         )
 
         _repobee.cli.dispatch.dispatch_command(
@@ -398,7 +411,8 @@ class TestDispatchCommand:
         self, command_mock, api_instance_mock
     ):
         args = argparse.Namespace(
-            **plug.CoreCommand.repos.clone.asdict(), **VALID_PARSED_ARGS
+            **repobee_plug.cli.CoreCommand.repos.clone.asdict(),
+            **VALID_PARSED_ARGS
         )
 
         _repobee.cli.dispatch.dispatch_command(
@@ -413,7 +427,7 @@ class TestDispatchCommand:
         # regular mockaing is broken for static methods, it seems, produces
         # non-callable so using monkeypatch instead
         args = argparse.Namespace(
-            **plug.CoreCommand.config.verify.asdict(),
+            **repobee_plug.cli.CoreCommand.config.verify.asdict(),
             user=USER,
             base_url=BASE_URL,
             token=TOKEN,
@@ -429,7 +443,7 @@ class TestDispatchCommand:
 
     def test_verify_settings_called_with_master_org_name(self, api_class_mock):
         args = argparse.Namespace(
-            **plug.CoreCommand.config.verify.asdict(),
+            **repobee_plug.cli.CoreCommand.config.verify.asdict(),
             user=USER,
             base_url=BASE_URL,
             org_name=ORG_NAME,
@@ -444,7 +458,7 @@ class TestDispatchCommand:
         )
 
 
-@pytest.mark.parametrize("action", plug.CoreCommand.iter_actions())
+@pytest.mark.parametrize("action", repobee_plug.cli.CoreCommand.iter_actions())
 def test_help_calls_add_arguments(monkeypatch, action):
     """Test that the --help command causes _OrderedFormatter.add_arguments to
     be called. The reason this may not be the case is that
@@ -486,7 +500,7 @@ class TestBaseParsing:
         """Test that configured args are shown when show_all_opts is True."""
         with pytest.raises(SystemExit):
             _repobee.cli.parsing.handle_args(
-                [*plug.CoreCommand.repos.setup.astuple(), "-h"],
+                [*repobee_plug.cli.CoreCommand.repos.setup.astuple(), "-h"],
                 show_all_opts=True,
                 ext_commands=[],
             )
@@ -505,7 +519,7 @@ class TestBaseParsing:
         """Test that configured args are hidden when show_all_opts is False."""
         with pytest.raises(SystemExit):
             _repobee.cli.parsing.handle_args(
-                [*plug.CoreCommand.repos.setup.astuple(), "-h"],
+                [*repobee_plug.cli.CoreCommand.repos.setup.astuple(), "-h"],
                 show_all_opts=False,
                 ext_commands=[],
             )
@@ -531,7 +545,7 @@ class TestBaseParsing:
         with pytest.raises(exception.NotFoundError) as exc_info:
             _repobee.cli.parsing.handle_args(
                 [
-                    *plug.CoreCommand.repos.setup.astuple(),
+                    *repobee_plug.cli.CoreCommand.repos.setup.astuple(),
                     *COMPLETE_PUSH_ARGS,
                     "--sf",
                     str(students_file),
@@ -551,7 +565,7 @@ class TestBaseParsing:
         with pytest.raises(exception.BadCredentials) as exc_info:
             _repobee.cli.parsing.handle_args(
                 [
-                    *plug.CoreCommand.repos.setup.astuple(),
+                    *repobee_plug.cli.CoreCommand.repos.setup.astuple(),
                     *COMPLETE_PUSH_ARGS,
                     "--sf",
                     str(students_file),
@@ -571,7 +585,7 @@ class TestBaseParsing:
         with pytest.raises(exception.ServiceNotFoundError) as exc_info:
             _repobee.cli.parsing.handle_args(
                 [
-                    *plug.CoreCommand.repos.setup.astuple(),
+                    *repobee_plug.cli.CoreCommand.repos.setup.astuple(),
                     *COMPLETE_PUSH_ARGS,
                     "--sf",
                     str(students_file),
@@ -583,7 +597,11 @@ class TestBaseParsing:
         )
 
     @pytest.mark.parametrize(
-        "action", [plug.CoreCommand.repos.setup, plug.CoreCommand.repos.update]
+        "action",
+        [
+            repobee_plug.cli.CoreCommand.repos.setup,
+            repobee_plug.cli.CoreCommand.repos.update,
+        ],
     )
     def test_master_org_overrides_target_org_for_master_repos(
         self, command_mock, api_instance_mock, students_file, action
@@ -607,7 +625,11 @@ class TestBaseParsing:
         )
 
     @pytest.mark.parametrize(
-        "action", [plug.CoreCommand.repos.setup, plug.CoreCommand.repos.update]
+        "action",
+        [
+            repobee_plug.cli.CoreCommand.repos.setup,
+            repobee_plug.cli.CoreCommand.repos.update,
+        ],
     )
     def test_master_org_name_defaults_to_org_name(
         self, api_instance_mock, students_file, action
@@ -629,7 +651,11 @@ class TestBaseParsing:
         )
 
     @pytest.mark.parametrize(
-        "action", [plug.CoreCommand.repos.setup, plug.CoreCommand.repos.update]
+        "action",
+        [
+            repobee_plug.cli.CoreCommand.repos.setup,
+            repobee_plug.cli.CoreCommand.repos.update,
+        ],
     )
     def test_token_env_variable_picked_up(
         self, api_instance_mock, students_file, action
@@ -646,7 +672,11 @@ class TestBaseParsing:
         assert parsed_args.token == TOKEN
 
     @pytest.mark.parametrize(
-        "action", [plug.CoreCommand.repos.setup, plug.CoreCommand.repos.update]
+        "action",
+        [
+            repobee_plug.cli.CoreCommand.repos.setup,
+            repobee_plug.cli.CoreCommand.repos.update,
+        ],
     )
     def test_token_cli_arg_picked_up(
         self, mocker, api_instance_mock, students_file, action
@@ -681,7 +711,7 @@ class TestBaseParsing:
         required.
         """
         sys_args = [
-            *plug.CoreCommand.repos.setup.astuple(),
+            *repobee_plug.cli.CoreCommand.repos.setup.astuple(),
             "-u",
             USER,
             "-o",
@@ -703,7 +733,7 @@ class TestBaseParsing:
     ):
         """Test that the create-teams command is correctly parsed."""
         sys_args = [
-            *plug.CoreCommand.repos.create_teams.astuple(),
+            *repobee_plug.cli.CoreCommand.repos.create_teams.astuple(),
             *BASE_ARGS,
             "--sf",
             str(students_file),
@@ -895,14 +925,14 @@ class TestStudentParsing:
     STUDENT_PARSING_PARAMS = (
         "action, extra_args",
         [
-            (plug.CoreCommand.repos.setup, BASE_PUSH_ARGS),
-            (plug.CoreCommand.repos.update, BASE_PUSH_ARGS),
+            (repobee_plug.cli.CoreCommand.repos.setup, BASE_PUSH_ARGS),
+            (repobee_plug.cli.CoreCommand.repos.update, BASE_PUSH_ARGS),
             (
-                plug.CoreCommand.issues.close,
+                repobee_plug.cli.CoreCommand.issues.close,
                 ["--mn", *REPO_NAMES, "-r", "some-regex"],
             ),
             (
-                plug.CoreCommand.issues.open,
+                repobee_plug.cli.CoreCommand.issues.open,
                 ["--mn", *REPO_NAMES, "-i", ISSUE_PATH],
             ),
         ],
@@ -1093,7 +1123,10 @@ def assert_config_args(action, parsed_args):
     assert parsed_args.students == list(STUDENTS)
     assert parsed_args.org_name == ORG_NAME
 
-    if action in [plug.CoreCommand.repos.setup, plug.CoreCommand.repos.update]:
+    if action in [
+        repobee_plug.cli.CoreCommand.repos.setup,
+        repobee_plug.cli.CoreCommand.repos.update,
+    ]:
         assert parsed_args.user == USER
 
 
@@ -1103,10 +1136,10 @@ class TestConfig:
     @pytest.mark.parametrize(
         "action, extra_args",
         [
-            (plug.CoreCommand.repos.setup, ["--mn", *REPO_NAMES]),
-            (plug.CoreCommand.repos.update, ["--mn", *REPO_NAMES]),
+            (repobee_plug.cli.CoreCommand.repos.setup, ["--mn", *REPO_NAMES]),
+            (repobee_plug.cli.CoreCommand.repos.update, ["--mn", *REPO_NAMES]),
             (
-                plug.CoreCommand.issues.open,
+                repobee_plug.cli.CoreCommand.issues.open,
                 ["--mn", *REPO_NAMES, "-i", ISSUE_PATH],
             ),
         ],
@@ -1135,7 +1168,7 @@ class TestConfig:
             return
 
         sys_args = [
-            *plug.CoreCommand.repos.setup.astuple(),
+            *repobee_plug.cli.CoreCommand.repos.setup.astuple(),
             "--mn",
             *REPO_NAMES,
         ]
@@ -1159,7 +1192,7 @@ class TestConfig:
             missing_arg = "whatever"
 
         sys_args = [
-            *plug.CoreCommand.repos.setup.astuple(),
+            *repobee_plug.cli.CoreCommand.repos.setup.astuple(),
             "--mn",
             *REPO_NAMES,
             config_missing_option,
@@ -1171,7 +1204,11 @@ class TestConfig:
 
 
 @pytest.mark.parametrize(
-    "action", [plug.CoreCommand.repos.setup, plug.CoreCommand.repos.update]
+    "action",
+    [
+        repobee_plug.cli.CoreCommand.repos.setup,
+        repobee_plug.cli.CoreCommand.repos.update,
+    ],
 )
 class TestSetupAndUpdateParsers:
     """Tests that are in common for setup and update."""
@@ -1244,7 +1281,7 @@ class TestMigrateParser:
 
     def test_happy_path(self):
         sys_args = [
-            *plug.CoreCommand.repos.migrate.astuple(),
+            *repobee_plug.cli.CoreCommand.repos.migrate.astuple(),
             *BASE_ARGS,
             "--mn",
             *self.NAMES,
@@ -1259,7 +1296,7 @@ class TestVerifyParser:
     """Tests for the VERIFY_PARSER."""
 
     def test_happy_path(self):
-        action = plug.CoreCommand.config.verify
+        action = repobee_plug.cli.CoreCommand.config.verify
         sys_args = [*action.astuple(), *BASE_ARGS]
 
         args, _ = _repobee.cli.parsing.handle_args(sys_args)
@@ -1274,7 +1311,7 @@ class TestCloneParser:
     """Tests for the CLONE_PARSER."""
 
     def test_happy_path(self, students_file, plugin_manager_mock):
-        action = plug.CoreCommand.repos.clone
+        action = repobee_plug.cli.CoreCommand.repos.clone
         sys_args = [
             *action.astuple(),
             *BASE_ARGS,
@@ -1302,15 +1339,15 @@ class TestCloneParser:
         "action, extra_args",
         [
             (
-                plug.CoreCommand.repos.setup,
+                repobee_plug.cli.CoreCommand.repos.setup,
                 ["-s", *STUDENTS_STRING.split(), "--mn", *REPO_NAMES],
             ),
             (
-                plug.CoreCommand.repos.update,
+                repobee_plug.cli.CoreCommand.repos.update,
                 ["-s", *STUDENTS_STRING.split(), "--mn", *REPO_NAMES],
             ),
             (
-                plug.CoreCommand.issues.open,
+                repobee_plug.cli.CoreCommand.issues.open,
                 [
                     "-s",
                     *STUDENTS_STRING.split(),
@@ -1321,7 +1358,7 @@ class TestCloneParser:
                 ],
             ),
             (
-                plug.CoreCommand.issues.close,
+                repobee_plug.cli.CoreCommand.issues.close,
                 [
                     "-s",
                     *STUDENTS_STRING.split(),
@@ -1331,8 +1368,11 @@ class TestCloneParser:
                     "some-regex",
                 ],
             ),
-            (plug.CoreCommand.config.verify, []),
-            (plug.CoreCommand.repos.migrate, ["--mn", *REPO_NAMES]),
+            (repobee_plug.cli.CoreCommand.config.verify, []),
+            (
+                repobee_plug.cli.CoreCommand.repos.migrate,
+                ["--mn", *REPO_NAMES],
+            ),
         ],
     )
     def test_no_other_parser_gets_parse_hook(
@@ -1353,10 +1393,10 @@ class TestShowConfigParser:
 
     def test_happy_path(self):
         args, _ = _repobee.cli.parsing.handle_args(
-            plug.CoreCommand.config.show.astuple()
+            repobee_plug.cli.CoreCommand.config.show.astuple()
         )
 
         assert (
             args.category,
             args.action,
-        ) == plug.CoreCommand.config.show.astuple()
+        ) == repobee_plug.cli.CoreCommand.config.show.astuple()

--- a/tests/unit_tests/repobee/test_main.py
+++ b/tests/unit_tests/repobee/test_main.py
@@ -14,6 +14,7 @@ import _repobee.ext.defaults
 import _repobee.ext.dist
 from functions import raise_
 import _repobee.constants
+import repobee_plug.cli
 from _repobee import main
 from _repobee import plugin
 from _repobee.ext.defaults import configwizard
@@ -37,7 +38,7 @@ VALID_PARSED_ARGS = dict(
 )
 
 PARSED_ARGS = argparse.Namespace(
-    **plug.CoreCommand.repos.setup.asdict(), **VALID_PARSED_ARGS
+    **repobee_plug.cli.CoreCommand.repos.setup.asdict(), **VALID_PARSED_ARGS
 )
 
 CLONE_ARGS = "clone --mn week-2 -s slarse".split()
@@ -384,7 +385,7 @@ def test_show_all_opts_correctly_separated(
     sys_args = [
         "repobee",
         _repobee.cli.preparser.PRE_PARSER_SHOW_ALL_OPTS,
-        *plug.CoreCommand.repos.setup.astuple(),
+        *repobee_plug.cli.CoreCommand.repos.setup.astuple(),
         "-h",
     ]
 
@@ -393,7 +394,7 @@ def test_show_all_opts_correctly_separated(
 
     assert msg in str(exc_info.value)
     handle_args_mock.assert_called_once_with(
-        [*plug.CoreCommand.repos.setup.astuple(), "-h"],
+        [*repobee_plug.cli.CoreCommand.repos.setup.astuple(), "-h"],
         show_all_opts=True,
         ext_commands=[ANY] * len(DEFAULT_EXT_COMMANDS),
         config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
@@ -433,7 +434,7 @@ user = some-unlikely-user
             "repobee",
             "--config-file",
             tmpfile.name,
-            *plug.CoreCommand.config.show.astuple(),
+            *repobee_plug.cli.CoreCommand.config.show.astuple(),
         ]
         main.main(sys_args)
 

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -4,7 +4,6 @@ import pathlib
 import pytest
 
 import repobee_plug as plug
-import repobee_plug.cli
 
 from repobee_plug import _pluginmeta
 from repobee_plug import _exceptions
@@ -145,11 +144,9 @@ class TestDeclarativeExtensionCommand:
         assert ext_cmd.requires_base_parsers is None
         assert ext_cmd.category is None
 
-    def test_with_metadata(self):
-        """Test declaring an command with no explicit metadata, and checking
-        that the defaults are as expected.
-        """
-        expected_category = repobee_plug.cli.CoreCommand.config
+    def test_with_settings(self):
+        """Test declaring an command with settings."""
+        expected_category = plug.cli.CoreCommand.config
         expected_name = "cool-greetings"
         expected_help = "This is a greeting command!"
         expected_description = "This is a greeting"
@@ -160,12 +157,14 @@ class TestDeclarativeExtensionCommand:
         expected_requires_api = True
 
         class ExtCommand(plug.Plugin, plug.cli.Command):
-            __category__ = expected_category
-            __action_name__ = expected_name
-            __help__ = expected_help
-            __description__ = expected_description
-            __base_parsers__ = expected_base_parsers
-            __requires_api__ = expected_requires_api
+            __settings__ = plug.cli.CommandSettings(
+                category=expected_category,
+                action_name=expected_name,
+                help=expected_help,
+                description=expected_description,
+                base_parsers=expected_base_parsers,
+                requires_api=expected_requires_api,
+            )
 
             def command_callback(self, args, api):
                 pass
@@ -370,7 +369,9 @@ class TestDeclarativeCommandExtension:
         """Tests adding a required option to ``config show``."""
 
         class ConfigShowExt(plug.Plugin, plug.cli.CommandExtension):
-            __action__ = repobee_plug.cli.CoreCommand.config.show
+            __settings__ = plug.cli.CommandExtensionSettings(
+                actions=[plug.cli.CoreCommand.config.show]
+            )
 
             silly_new_option = plug.cli.Option(help="your name", required=True)
 

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -404,3 +404,27 @@ class TestDeclarativeCommandExtension:
             "A plugin cannot be both a Command and a CommandExtension"
             in str(exc_info.value)
         )
+
+    def test_requires_settings(self):
+        """Test that an error is raised if the __settings__ attribute is not
+        defined.
+        """
+        with pytest.raises(plug.PlugError) as exc_info:
+
+            class Ext(plug.Plugin, plug.cli.CommandExtension):
+                pass
+
+        assert "CommandExtension must have a '__settings__' attribute" in str(
+            exc_info.value
+        )
+
+    def test_requires_non_empty_actions_list(self):
+
+        with pytest.raises(ValueError) as exc_info:
+
+            class Ext(plug.Plugin, plug.cli.CommandExtension):
+                __settings__ = plug.cli.CommandExtensionSettings(actions=[])
+
+        assert "argument 'actions' must be a non-empty list" in str(
+            exc_info.value
+        )

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -4,6 +4,7 @@ import pathlib
 import pytest
 
 import repobee_plug as plug
+import repobee_plug.cli
 
 from repobee_plug import _pluginmeta
 from repobee_plug import _exceptions
@@ -148,7 +149,7 @@ class TestDeclarativeExtensionCommand:
         """Test declaring an command with no explicit metadata, and checking
         that the defaults are as expected.
         """
-        expected_category = plug.CoreCommand.config
+        expected_category = repobee_plug.cli.CoreCommand.config
         expected_name = "cool-greetings"
         expected_help = "This is a greeting command!"
         expected_description = "This is a greeting"
@@ -369,7 +370,7 @@ class TestDeclarativeCommandExtension:
         """Tests adding a required option to ``config show``."""
 
         class ConfigShowExt(plug.Plugin, plug.cli.CommandExtension):
-            __action__ = plug.CoreCommand.config.show
+            __action__ = repobee_plug.cli.CoreCommand.config.show
 
             silly_new_option = plug.cli.Option(help="your name", required=True)
 


### PR DESCRIPTION
Fix #502 

This adds two wrappers for command settings: `repobee_plug.cli.CommandSettings` (optional with `cli.Command`) and `repobee_plug.cli.CommandExtensionSettings` (required with `cli.CommandExtension`)