### PR TITLE
[fact] Refactor CLI plugin classes to be accessed via functions

### DIFF
--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -20,7 +20,7 @@ LOGGER = daiquiri.getLogger(__file__)
 
 
 class Wizard(plug.Plugin, plug.cli.Command):
-    __settings__ = plug.cli.CommandSettings(
+    __settings__ = plug.cli.command_settings(
         category=plug.cli.CoreCommand.config,
         help="Interactive configuration wizard to set up the config file.",
         description=(

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -202,7 +202,7 @@ def _add_option(
         return
 
     args = []
-    kwargs = opt.argparse_kwargs or {}
+    kwargs = opt.argparse_kwargs
 
     if opt.converter:
         kwargs["type"] = opt.converter

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -96,7 +96,9 @@ class _PluginMeta(type):
 def _extract_cli_options(
     attrdict,
 ) -> List[
-    Tuple[str, Union[cli.Option, cli.Positional, cli.MutuallyExclusiveGroup]]
+    Tuple[
+        str, Union[cli._Option, cli._Positional, cli._MutuallyExclusiveGroup]
+    ]
 ]:
     """Return any members that are CLI options as a list of tuples on the form
     (member_name, option). Other types of CLI arguments, such as positionals,
@@ -106,7 +108,7 @@ def _extract_cli_options(
         (key, value)
         for key, value in attrdict.items()
         if isinstance(
-            value, (cli.Option, cli.Positional, cli.MutuallyExclusiveGroup)
+            value, (cli._Option, cli._Positional, cli._MutuallyExclusiveGroup)
         )
     ]
 
@@ -160,7 +162,7 @@ def _generate_command_func(attrdict: Mapping[str, Any]) -> Callable:
     """
 
     def create_extension_command(self):
-        settings = attrdict.get("__settings__") or cli.CommandSettings()
+        settings = attrdict.get("__settings__") or cli._CommandSettings()
         if settings.config_section_name:
             self.__config_section__ = settings.config_section_name
 
@@ -181,13 +183,13 @@ def _generate_command_func(attrdict: Mapping[str, Any]) -> Callable:
 
 def _add_option(
     name: str,
-    opt: Union[cli.Positional, cli.Option, cli.MutuallyExclusiveGroup],
+    opt: Union[cli._Positional, cli._Option, cli._MutuallyExclusiveGroup],
     configured_value: str,
     show_all_opts: bool,
     parser: argparse.ArgumentParser,
 ) -> None:
     """Add an option to the parser based on the cli option."""
-    if isinstance(opt, cli.MutuallyExclusiveGroup):
+    if isinstance(opt, cli._MutuallyExclusiveGroup):
         mutex_parser = parser.add_mutually_exclusive_group(
             required=opt.required
         )
@@ -213,7 +215,7 @@ def _add_option(
         else opt.help or ""
     )
 
-    if isinstance(opt, cli.Option):
+    if isinstance(opt, cli._Option):
         if opt.short_name:
             args.append(opt.short_name)
 
@@ -227,7 +229,7 @@ def _add_option(
         kwargs["default"] = configured_value or opt.default
         # required opts become not required if configured
         kwargs["required"] = not configured_value and opt.required
-    elif isinstance(opt, cli.Positional):
+    elif isinstance(opt, cli._Positional):
         args.append(name)
 
     parser.add_argument(*args, **kwargs)

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -95,11 +95,7 @@ class _PluginMeta(type):
 
 def _extract_cli_options(
     attrdict,
-) -> List[
-    Tuple[
-        str, Union[cli._Option, cli._Positional, cli._MutuallyExclusiveGroup]
-    ]
-]:
+) -> List[Tuple[str, Union[cli._Option, cli._MutuallyExclusiveGroup]]]:
     """Return any members that are CLI options as a list of tuples on the form
     (member_name, option). Other types of CLI arguments, such as positionals,
     are converted to :py:class:`~cli.Option`s.
@@ -107,9 +103,7 @@ def _extract_cli_options(
     return [
         (key, value)
         for key, value in attrdict.items()
-        if isinstance(
-            value, (cli._Option, cli._Positional, cli._MutuallyExclusiveGroup)
-        )
+        if isinstance(value, (cli._Option, cli._MutuallyExclusiveGroup))
     ]
 
 
@@ -162,7 +156,7 @@ def _generate_command_func(attrdict: Mapping[str, Any]) -> Callable:
     """
 
     def create_extension_command(self):
-        settings = attrdict.get("__settings__") or cli._CommandSettings()
+        settings = attrdict.get("__settings__") or cli.command_settings()
         if settings.config_section_name:
             self.__config_section__ = settings.config_section_name
 
@@ -183,7 +177,7 @@ def _generate_command_func(attrdict: Mapping[str, Any]) -> Callable:
 
 def _add_option(
     name: str,
-    opt: Union[cli._Positional, cli._Option, cli._MutuallyExclusiveGroup],
+    opt: Union[cli._Option, cli._MutuallyExclusiveGroup],
     configured_value: str,
     show_all_opts: bool,
     parser: argparse.ArgumentParser,
@@ -203,6 +197,7 @@ def _add_option(
             )
         return
 
+    assert isinstance(opt, cli._Option)
     args = []
     kwargs = opt.argparse_kwargs
 
@@ -215,7 +210,7 @@ def _add_option(
         else opt.help or ""
     )
 
-    if isinstance(opt, cli._Option):
+    if opt.argument_type == cli.ArgumentType.OPTION:
         if opt.short_name:
             args.append(opt.short_name)
 
@@ -229,7 +224,7 @@ def _add_option(
         kwargs["default"] = configured_value or opt.default
         # required opts become not required if configured
         kwargs["required"] = not configured_value and opt.required
-    elif isinstance(opt, cli._Positional):
+    elif opt.argument_type == cli.ArgumentType.POSITIONAL:
         args.append(name)
 
     parser.add_argument(*args, **kwargs)

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -277,7 +277,7 @@ def mutually_exclusive_group(*, __required__: bool = False, **kwargs):
     """
     Args:
         __required__: Whether or not this mutex group is required.
-        kwargs: Keyword arguments on the form ``name=plug.cli.Option()``.
+        kwargs: Keyword arguments on the form ``name=plug.cli.option()``.
     """
     allowed_types = (ArgumentType.OPTION,)
 
@@ -342,10 +342,10 @@ class Command:
 
         class Greeting(plug.Plugin, plug.cli.Command):
 
-            name = plug.cli.Option(
+            name = plug.cli.option(
                 short_name="-n", help="your name", required=True
             )
-            age = plug.cli.Option(
+            age = plug.cli.option(
                 converter=int, help="your age", default=30
             )
 

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -30,7 +30,7 @@ class OptionType(enum.Enum):
     MUTEX_GROUP = enum.auto()
 
 
-Option = collections.namedtuple(
+_Option = collections.namedtuple(
     "Option",
     [
         "short_name",
@@ -43,40 +43,16 @@ Option = collections.namedtuple(
         "argparse_kwargs",
     ],
 )
-Option.__new__.__defaults__ = (None,) * len(Option._fields)
 
-Positional = collections.namedtuple(
+_Positional = collections.namedtuple(
     "Positional", ["help", "converter", "argparse_kwargs"]
 )
-Positional.__new__.__defaults__ = (None,) * len(Positional._fields)
 
 
-class CommandSettings(_containers.ImmutableMixin):
+class _CommandSettings(_containers.ImmutableMixin):
     """Settings for a :py:class:`Command`, that can be provided in the
     ``__settings__`` attribute.
 
-    Example usage:
-
-    .. code-block:: python
-        :caption: ext.py
-
-        import repobee_plug as plug
-
-        class Ext(plug.Plugin, plug.cli.Command):
-            __settings__ = plug.cli.CommandSettings(
-                action_name="hello",
-                category=plug.cli.CoreCommand.config,
-            )
-
-            def command_callback(self, args, api):
-                print("Hello, world!")
-
-    This can then be called with:
-
-    .. code-block:: bash
-
-        $ repobee -p ext.py config hello
-        Hello, world!
     """
 
     action_name: Optional[str]
@@ -123,7 +99,7 @@ class CommandSettings(_containers.ImmutableMixin):
         object.__setattr__(self, "config_section_name", config_section_name)
 
 
-class CommandExtensionSettings(_containers.ImmutableMixin):
+class _CommandExtensionSettings(_containers.ImmutableMixin):
     """Settings for a :py:class:`CommandExtension`."""
 
     actions: List["Action"]
@@ -159,7 +135,31 @@ def command_settings(
     base_parsers: Optional[List[_containers.BaseParser]] = None,
     config_section_name: Optional[str] = None,
 ):
-    """
+    """Create a settings object for a :py:class:`Command`.
+
+    Example usage:
+
+    .. code-block:: python
+        :caption: ext.py
+
+        import repobee_plug as plug
+
+        class Ext(plug.Plugin, plug.cli.Command):
+            __settings__ = plug.cli.command_settings(
+                action_name="hello",
+                category=plug.cli.CoreCommand.config,
+            )
+
+            def command_callback(self, args, api):
+                print("Hello, world!")
+
+    This can then be called with:
+
+    .. code-block:: bash
+
+        $ repobee -p ext.py config hello
+        Hello, world!
+
     Args:
         action_name: The name of the action that the command will be
             available under. Defaults to the name of the plugin class.
@@ -176,7 +176,7 @@ def command_settings(
             command should look for configurable options in. Defaults
             to the name of the plugin the command is defined in.
     """
-    return CommandSettings(
+    return _CommandSettings(
         action_name=action_name,
         category=category,
         help=help,
@@ -190,7 +190,7 @@ def command_settings(
 def command_extension_settings(
     actions: List["Action"], config_section_name: Optional[str] = None
 ):
-    return CommandExtensionSettings(
+    return _CommandExtensionSettings(
         actions=actions, config_section_name=config_section_name
     )
 
@@ -205,7 +205,7 @@ def option(
     converter: Optional[Callable[[str], Any]] = None,
     argparse_kwargs: Optional[Mapping[str, Any]] = None,
 ):
-    return Option(
+    return _Option(
         short_name=short_name,
         long_name=long_name,
         configurable=configurable,
@@ -222,16 +222,16 @@ def positional(
     converter: Optional[Callable[[str], Any]] = None,
     argparse_kwargs: Optional[Mapping[str, Any]] = None,
 ):
-    return Positional(
+    return _Positional(
         help=help, converter=converter, argparse_kwargs=argparse_kwargs or {}
     )
 
 
 def mutually_exclusive_group(*, __required__: bool = False, **kwargs):
-    return MutuallyExclusiveGroup(__required__=__required__, **kwargs)
+    return _MutuallyExclusiveGroup(__required__=__required__, **kwargs)
 
 
-class MutuallyExclusiveGroup(_containers.ImmutableMixin):
+class _MutuallyExclusiveGroup(_containers.ImmutableMixin):
     """A group of mutually exclusive CLI options.
 
     Attributes:
@@ -241,8 +241,8 @@ class MutuallyExclusiveGroup(_containers.ImmutableMixin):
         required: Whether or not this mutex group is required.
     """
 
-    ALLOWED_TYPES = (Option,)
-    options: List[Tuple[str, Option]]
+    ALLOWED_TYPES = (_Option,)
+    options: List[Tuple[str, _Option]]
     required: bool
 
     def __init__(self, *, __required__: bool = False, **kwargs):

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -120,8 +120,8 @@ class TestDeclarativeExtensionCommand:
         """
 
         class Greeting(plug.Plugin, plug.cli.Command):
-            name = plug.cli.Option(help="your name", required=True)
-            age = plug.cli.Option(converter=int, help="your age", default=30)
+            name = plug.cli.option(help="your name", required=True)
+            age = plug.cli.option(converter=int, help="your age", default=30)
 
             def command_callback(self, args, api):
                 print(f"My name is {args.name} and I am {args.age} years old")
@@ -157,7 +157,7 @@ class TestDeclarativeExtensionCommand:
         expected_requires_api = True
 
         class ExtCommand(plug.Plugin, plug.cli.Command):
-            __settings__ = plug.cli.CommandSettings(
+            __settings__ = plug.cli.command_settings(
                 category=expected_category,
                 action_name=expected_name,
                 help=expected_help,
@@ -194,7 +194,7 @@ class TestDeclarativeExtensionCommand:
         """Test configuring a default value for an option."""
 
         class Greeting(plug.Plugin, plug.cli.Command):
-            name = plug.cli.Option(
+            name = plug.cli.option(
                 help="Your name.", required=True, configurable=True
             )
 
@@ -218,7 +218,7 @@ class TestDeclarativeExtensionCommand:
         """
 
         class Greeting(plug.Plugin, plug.cli.Command):
-            name = plug.cli.Option(help="Your name.", required=True)
+            name = plug.cli.option(help="Your name.", required=True)
 
             def command_callback(self, args, api):
                 pass
@@ -246,7 +246,7 @@ class TestDeclarativeExtensionCommand:
         """
 
         class Greeting(plug.Plugin, plug.cli.Command):
-            name = plug.cli.Option(
+            name = plug.cli.option(
                 short_name="-n",
                 long_name="--your-name",
                 help="your name",
@@ -269,8 +269,8 @@ class TestDeclarativeExtensionCommand:
 
     def test_positional_arguments(self):
         class Greeting(plug.Plugin, plug.cli.Command):
-            name = plug.cli.Positional()
-            age = plug.cli.Positional(converter=int)
+            name = plug.cli.positional()
+            age = plug.cli.positional(converter=int)
 
             def command_callback(self, args, api):
                 pass
@@ -292,10 +292,10 @@ class TestDeclarativeExtensionCommand:
         """
 
         class Greeting(plug.Plugin, plug.cli.Command):
-            age_mutex = plug.cli.MutuallyExclusiveGroup(
-                age=plug.cli.Option(converter=int),
-                old=plug.cli.Option(
-                    argparse_kwargs=dict(action="store_const", const=1337),
+            age_mutex = plug.cli.mutually_exclusive_group(
+                age=plug.cli.option(converter=int),
+                old=plug.cli.option(
+                    argparse_kwargs=dict(action="store_const", const=1337)
                 ),
                 __required__=True,
             )
@@ -319,10 +319,10 @@ class TestDeclarativeExtensionCommand:
         """Positional arguments don't make sense in a mutex group."""
 
         with pytest.raises(TypeError) as exc_info:
-            plug.cli.MutuallyExclusiveGroup(
-                age=plug.cli.Positional(converter=int),
-                old=plug.cli.Option(
-                    argparse_kwargs=dict(action="store_const", const=1337),
+            plug.cli.mutually_exclusive_group(
+                age=plug.cli.positional(converter=int),
+                old=plug.cli.option(
+                    argparse_kwargs=dict(action="store_const", const=1337)
                 ),
                 __required__=True,
             )
@@ -334,10 +334,10 @@ class TestDeclarativeExtensionCommand:
         old = 1337
 
         class Greeting(plug.Plugin, plug.cli.Command):
-            age_mutex = plug.cli.MutuallyExclusiveGroup(
-                age=plug.cli.Option(converter=int),
-                old=plug.cli.Option(
-                    argparse_kwargs=dict(action="store_const", const=old),
+            age_mutex = plug.cli.mutually_exclusive_group(
+                age=plug.cli.option(converter=int),
+                old=plug.cli.option(
+                    argparse_kwargs=dict(action="store_const", const=old)
                 ),
                 __required__=True,
             )
@@ -369,11 +369,11 @@ class TestDeclarativeCommandExtension:
         """Tests adding a required option to ``config show``."""
 
         class ConfigShowExt(plug.Plugin, plug.cli.CommandExtension):
-            __settings__ = plug.cli.CommandExtensionSettings(
+            __settings__ = plug.cli.command_extension_settings(
                 actions=[plug.cli.CoreCommand.config.show]
             )
 
-            silly_new_option = plug.cli.Option(help="your name", required=True)
+            silly_new_option = plug.cli.option(help="your name", required=True)
 
         with pytest.raises(SystemExit):
             repobee.run(
@@ -423,7 +423,7 @@ class TestDeclarativeCommandExtension:
         with pytest.raises(ValueError) as exc_info:
 
             class Ext(plug.Plugin, plug.cli.CommandExtension):
-                __settings__ = plug.cli.CommandExtensionSettings(actions=[])
+                __settings__ = plug.cli.command_extension_settings(actions=[])
 
         assert "argument 'actions' must be a non-empty list" in str(
             exc_info.value

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -318,7 +318,7 @@ class TestDeclarativeExtensionCommand:
     def test_positionals_not_allowed_in_mutex_group(self):
         """Positional arguments don't make sense in a mutex group."""
 
-        with pytest.raises(TypeError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             plug.cli.mutually_exclusive_group(
                 age=plug.cli.positional(converter=int),
                 old=plug.cli.option(


### PR DESCRIPTION
Fix #512 

The only difference from a usage perspective that this brings is that all of the CLI classes (except for `Command` and `CommandExtension`) have been made private, and are now constructed via functions. For example, what was previously `plug.cli.Positional` is now `plug.cli.positional`.