### PR TITLE
[feat] Allow plugin commands to add categories

### DIFF
--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -651,6 +651,22 @@ def _add_extension_parsers(
                 formatter_class=_OrderedFormatter,
             )
 
+        category = (
+            cmd.name.category
+            if isinstance(cmd.name, plug.cli.Action)
+            else cmd.category
+        )
+        if category and category not in parsers_mapping:
+            # new category
+            category_cmd = subparsers.add_parser(
+                category.name,
+                help=category.help,
+                description=category.description,
+            )
+            category_parsers = category_cmd.add_subparsers(dest=ACTION)
+            category_parsers.required = True
+            parsers_mapping[category] = category_parsers
+
         if cmd.name in parsers_mapping:
             ext_parser = parsers_mapping[cmd.name]
             cmd.parser(
@@ -660,19 +676,6 @@ def _add_extension_parsers(
             )
         elif isinstance(cmd.name, plug.cli.Action):
             action = cmd.name
-            category = action.category
-
-            if category not in parsers_mapping:
-                # new category
-                category_cmd = subparsers.add_parser(
-                    category.name,
-                    help=category.help,
-                    description=category.description,
-                )
-                category_parsers = category_cmd.add_subparsers(dest=ACTION)
-                category_parsers.required = True
-                parsers_mapping[category] = category_parsers
-
             ext_parser = _add_ext_parser(parents=parents, name=action.name)
             cmd.parser(
                 config=parsed_config,

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -659,11 +659,21 @@ def _add_extension_parsers(
                 parser=ext_parser,
             )
         elif isinstance(cmd.name, plug.cli.Action):
-            category_cmd = subparsers.add_parser(cmd.category.name)
-            category_parsers = category_cmd.add_subparsers(dest=ACTION)
-            category_parsers.required = True
-            parsers_mapping[cmd.category] = category_parsers
-            ext_parser = _add_ext_parser(parents=parents, name=cmd.name.name)
+            action = cmd.name
+            category = action.category
+
+            if category not in parsers_mapping:
+                # new category
+                category_cmd = subparsers.add_parser(
+                    category.name,
+                    help=category.help,
+                    description=category.description,
+                )
+                category_parsers = category_cmd.add_subparsers(dest=ACTION)
+                category_parsers.required = True
+                parsers_mapping[category] = category_parsers
+
+            ext_parser = _add_ext_parser(parents=parents, name=action.name)
             cmd.parser(
                 config=parsed_config,
                 show_all_opts=show_all_opts,

--- a/src/_repobee/main.py
+++ b/src/_repobee/main.py
@@ -102,7 +102,7 @@ def run(
         parsed_args, api, ext_commands = _parse_args(
             cmd, config_file, show_all_opts
         )
-        _repobee.cli.dispatch.dispatch_command(
+        return _repobee.cli.dispatch.dispatch_command(
             parsed_args, api, config_file, ext_commands
         )
     finally:

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -160,7 +160,7 @@ def _generate_command_func(attrdict: Mapping[str, Any]) -> Callable:
 
         return _containers.ExtensionCommand(
             parser=functools.partial(_attach_options, plugin=self),
-            name=settings.action_name
+            name=settings.action
             or self.__class__.__name__.lower().replace("_", "-"),
             help=settings.help,
             description=settings.description,

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -402,6 +402,8 @@ class Category(ImmutableMixin, abc.ABC):
         actions: A tuple of names of actions applicable to this category.
     """
 
+    help: str = ""
+    description: str = ""
     name: str
     actions: Tuple["Action"]
     action_names: Set[str]

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -461,7 +461,7 @@ class Category(ImmutableMixin, abc.ABC):
         actions = []
         for action_name in action_names:
             action = Action(action_name.replace("_", "-"), self)
-            object.__setattr__(self, action_name, action)
+            object.__setattr__(self, action_name.replace("-", "_"), action)
             actions.append(action)
 
         object.__setattr__(self, "actions", tuple(actions))

--- a/src/repobee_plug/cli.py
+++ b/src/repobee_plug/cli.py
@@ -3,7 +3,17 @@ import abc
 import collections
 import enum
 import itertools
-from typing import List, Tuple, Optional, Set, Mapping, Iterable, Any, Callable
+from typing import (
+    List,
+    Tuple,
+    Optional,
+    Set,
+    Mapping,
+    Iterable,
+    Any,
+    Callable,
+    Union,
+)
 
 from repobee_plug import _containers
 
@@ -49,7 +59,7 @@ _Option.__new__.__defaults__ = (None,) * len(_Option._fields)
 _CommandSettings = collections.namedtuple(
     "_CommandSettings",
     [
-        "action_name",
+        "action",
         "category",
         "help",
         "description",
@@ -66,7 +76,7 @@ _CommandExtensionSettings = collections.namedtuple(
 
 
 def command_settings(
-    action_name: Optional[str] = None,
+    action: Optional[Union[str, "Action"]] = None,
     category: Optional["CoreCommand"] = None,
     help: str = "",
     description: str = "",
@@ -100,10 +110,13 @@ def command_settings(
         Hello, world!
 
     Args:
-        action_name: The name of the action that the command will be
-            available under. Defaults to the name of the plugin class.
+        action: The name of this command, or a :py:class:`Action` object that
+            defines both category and action for the command. Defaults to the
+            name of the plugin class.
         category: The category to place this command in. If not specified,
-            then the command will be top-level (i.e. uncategorized).
+            then the command will be top-level (i.e. uncategorized). If
+            ``action`` is an :py:class:`Action` (as opposed to a ``str``),
+            then this argument is not allowed.
         help: A help section for the command. This appears when listing the
             help section of the command's category.
         description: A help section for the command. This appears when
@@ -115,8 +128,16 @@ def command_settings(
             command should look for configurable options in. Defaults
             to the name of the plugin the command is defined in.
     """
+    if isinstance(action, Action):
+        if category:
+            raise TypeError(
+                "argument 'category' not allowed when argument 'action' is an "
+                "Action object"
+            )
+        category = action.category
+
     return _CommandSettings(
-        action_name=action_name,
+        action=action,
         category=category,
         help=help,
         description=description,

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -383,6 +383,50 @@ class TestDeclarativeExtensionCommand:
         assert result.data["name"] == name
         assert result.data["age"] == age
 
+    def test_add_two_actions_to_new_category(self):
+        """Test that it's possible to add multiple actions to a custom
+        category.
+        """
+
+        class Greetings(plug.cli.Category):
+            hello: plug.cli.Action
+            bye: plug.cli.Action
+
+        category = Greetings()
+
+        class Hello(plug.Plugin, plug.cli.Command):
+            __settings__ = plug.cli.command_settings(action=category.hello)
+            name = plug.cli.positional()
+
+            def command(self, args, api):
+                return plug.Result(
+                    name=self.plugin_name,
+                    msg=f"Hello {args.name}",
+                    status=plug.Status.SUCCESS,
+                )
+
+        class Bye(plug.Plugin, plug.cli.Command):
+            __settings__ = plug.cli.command_settings(action=category.bye)
+            name = plug.cli.positional()
+
+            def command(self, args, api):
+                return plug.Result(
+                    name=self.plugin_name,
+                    msg=f"Bye {args.name}",
+                    status=plug.Status.SUCCESS,
+                )
+
+        name = "Alice"
+        hello_results = repobee.run(
+            f"greetings hello {name}".split(), plugins=[Hello, Bye]
+        )
+        bye_results = repobee.run(
+            f"greetings bye {name}".split(), plugins=[Hello, Bye]
+        )
+
+        assert hello_results[category.hello][0].msg == f"Hello {name}"
+        assert bye_results[category.bye][0].msg == f"Bye {name}"
+
     def test_raises_when_both_action_and_category_given(self):
         """It is not allowed to give an Action object to the action argument,
         and at the same time give a Category, as the Action object defines

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -159,7 +159,7 @@ class TestDeclarativeExtensionCommand:
         class ExtCommand(plug.Plugin, plug.cli.Command):
             __settings__ = plug.cli.command_settings(
                 category=expected_category,
-                action_name=expected_name,
+                action=expected_name,
                 help=expected_help,
                 description=expected_description,
                 base_parsers=expected_base_parsers,
@@ -352,6 +352,60 @@ class TestDeclarativeExtensionCommand:
         parsed_args = parser.parse_args(["--old"])
 
         assert parsed_args.old == old
+
+    def test_create_new_category(self):
+        """Test that command can be added to a new category."""
+
+        class Greetings(plug.cli.Category):
+            hello: plug.cli.Action
+
+        class Hello(plug.Plugin, plug.cli.Command):
+            __settings__ = plug.cli.command_settings(action=Greetings().hello)
+            name = plug.cli.positional()
+            age = plug.cli.positional(converter=int)
+
+            def command(self, args, api):
+                return plug.Result(
+                    name=self.plugin_name,
+                    msg="Nice!",
+                    status=plug.Status.SUCCESS,
+                    data={"name": args.name, "age": args.age},
+                )
+
+        name = "Bob"
+        age = 24
+        results_mapping = repobee.run(
+            f"greetings hello {name} {age}".split(), plugins=[Hello]
+        )
+        _, results = list(results_mapping.items())[0]
+        result, *_ = results
+
+        assert result.data["name"] == name
+        assert result.data["age"] == age
+
+    def test_raises_when_both_action_and_category_given(self):
+        """It is not allowed to give an Action object to the action argument,
+        and at the same time give a Category, as the Action object defines
+        both.
+        """
+
+        class Cat(plug.cli.Category):
+            greetings: plug.cli.Action
+
+        with pytest.raises(TypeError) as exc_info:
+
+            class Greetings(plug.Plugin, plug.cli.Command):
+                __settings__ = plug.cli.command_settings(
+                    action=Cat().greetings, category=Cat()
+                )
+
+                def command(self, args, api):
+                    pass
+
+        assert (
+            "argument 'category' not allowed when argument "
+            "'action' is an Action object"
+        ) in str(exc_info.value)
 
 
 class TestDeclarativeCommandExtension:

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -432,15 +432,13 @@ class TestDeclarativeExtensionCommand:
         and at the same time give a Category, as the Action object defines
         both.
         """
-
-        class Cat(plug.cli.Category):
-            greetings: plug.cli.Action
+        category = plug.cli.category("cat", action_names=["greetings"])
 
         with pytest.raises(TypeError) as exc_info:
 
             class Greetings(plug.Plugin, plug.cli.Command):
                 __settings__ = plug.cli.command_settings(
-                    action=Cat().greetings, category=Cat()
+                    action=category.greetings, category=category
                 )
 
                 def command(self, args, api):


### PR DESCRIPTION
Fix #500 

Plugins can now define categories of their own. It looks something like this:

```python
# ext.py
import repobee_plug as plug

greeting = plug.cli.category(
    name="greeting",
    action_names=["hello"],
    help="Make a greeting!",
    description="Time to say hello :)",
)


class Hello(plug.Plugin, plug.cli.Command):
    __settings__ = plug.cli.command_settings(
        category=greeting,
        help="Say hello!",
        description="Say hello!",
    )

    name = option(required=True, help="your name")

    def command(self, args, api):
        print(f"Hello, {args.name}")
```

This can be called like so:

```bash
$ repobee -p ext.py greeting hello --name Simon
Hello, Simon
```
Note that the action name provided in the `plug.cli.category` must correspond with the action name of the command. Here, they match, as the class is called `Hello` (which in lowercase becomes `hello`) and the action is `hello`.

A "safer" way to do this is to specify the action instead, and leave the category out.

```python
# ext.py
import repobee_plug as plug

greeting = plug.cli.category(
    name="greeting",
    action_names=["hello"],
    help="Make a greeting!",
    description="Time to say hello :)",
)


class Hello(plug.Plugin, plug.cli.Command):
    __settings__ = plug.cli.command_settings(
        action=greeting.hello,
        help="Say hello!",
        description="Say hello!",
    )

    name = option(required=True, help="your name")

    def command(self, args, api):
        print(f"Hello, {args.name}")
```
This is accessed in the same way. Perhaps this should be the only way to do it.
