### PR TITLE
[feat] Automatically assign parsed args to plugin command instances

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -47,7 +47,7 @@ def dispatch_command(
     is_ext_command = "_extension_command" in args
     if is_ext_command:
         ext_cmd = args._extension_command
-        res = ext_cmd.callback(args, api)
+        res = ext_cmd.callback(api)
         hook_results = {ext_cmd.name: [res]} if res else hook_results
     else:
         category = args.category

--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -30,8 +30,8 @@ class Wizard(plug.Plugin, plug.cli.Command):
         ),
     )
 
-    def command(self, args: argparse.Namespace, api: plug.API) -> None:
-        return callback(args, api)
+    def command(self, api: plug.API) -> None:
+        return callback(self.args, api)
 
 
 def callback(args: argparse.Namespace, api: plug.API) -> None:

--- a/src/_repobee/ext/javac.py
+++ b/src/_repobee/ext/javac.py
@@ -20,7 +20,6 @@ and specifically the more advanced use of the ``clone_parser_hook`` and
 """
 import subprocess
 import sys
-import argparse
 import pathlib
 from typing import Union, Iterable, Tuple
 
@@ -46,9 +45,6 @@ class JavacCloneHook(plug.Plugin, plug.cli.CommandExtension):
         argparse_kwargs={"nargs": "+"},
     )
 
-    def handle_processed_args(self, args: argparse.Namespace):
-        self.ignore = args.javac_ignore or []
-
     def post_clone(self, path: pathlib.Path, api: plug.API) -> plug.Result:
         """Run ``javac`` on all .java files in the repo.
 
@@ -58,10 +54,11 @@ class JavacCloneHook(plug.Plugin, plug.cli.CommandExtension):
         Returns:
             a Result specifying the outcome.
         """
+        ignore = self.javac_ignore or []
         java_files = [
             str(file)
             for file in util.find_files_by_extension(path, ".java")
-            if file.name not in self.ignore
+            if file.name not in ignore
         ]
 
         if not java_files:

--- a/src/repobee_plug/cli/__init__.py
+++ b/src/repobee_plug/cli/__init__.py
@@ -1,6 +1,12 @@
 from .settings import command_settings, command_extension_settings
 from .categorization import category
-from .args import option, positional, mutually_exclusive_group, ArgumentType
+from .args import (
+    option,
+    positional,
+    mutually_exclusive_group,
+    ArgumentType,
+    is_cli_arg,
+)
 from .commandmarkers import Command, CommandExtension
 
 from ._corecommand import _CoreCommand
@@ -18,4 +24,5 @@ __all__ = [
     "Command",
     "CommandExtension",
     "CoreCommand",
+    "is_cli_arg",
 ]

--- a/src/repobee_plug/cli/args.py
+++ b/src/repobee_plug/cli/args.py
@@ -31,6 +31,17 @@ MutuallyExclusiveGroup = collections.namedtuple(
 )
 
 
+def is_cli_arg(obj: Any) -> bool:
+    """Determine if an object is a CLI argument.
+
+    Args:
+        obj: An object.
+    Returns:
+        True if the object is an instance of a CLI argument class.
+    """
+    return isinstance(obj, (Option, MutuallyExclusiveGroup))
+
+
 def option(
     short_name: Optional[str] = None,
     long_name: Optional[str] = None,
@@ -56,10 +67,10 @@ def option(
             name = plug.cli.option(help="Your name.")
             age = plug.cli.option(converter=int, help="Your age.")
 
-            def command(self, args, api):
+            def command(self, api):
                 print(
-                    f"Hello, my name is {args.name} "
-                    f"and I am {args.age} years old"
+                    f"Hello, my name is {self.name} "
+                    f"and I am {self.age} years old"
                 )
 
     This command can then be called like so:
@@ -122,10 +133,10 @@ def positional(
             name = plug.cli.Positional(help="Your name.")
             age = plug.cli.Positional(converter=int, help="Your age.")
 
-            def command(self, args, api):
+            def command(self, api):
                 print(
-                    f"Hello, my name is {args.name} "
-                    f"and I am {args.age} years old"
+                    f"Hello, my name is {self.name} "
+                    f"and I am {self.age} years old"
                 )
 
     This command can then be called like so:

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -852,7 +852,9 @@ class TestExtensionCommands:
             parsed_args, None, EMPTY_PATH, [ext_command]
         )
 
-        mock_callback.assert_called_once_with(parsed_args, None)
+        calls = mock_callback.mock_calls
+        assert len(calls) == 1
+        assert calls[0] == mock.call(None)
 
     def test_dispatch_ext_command_that_requires_api(
         self,
@@ -883,7 +885,9 @@ class TestExtensionCommands:
             parsed_args, api_instance_mock, EMPTY_PATH, [ext_command]
         )
 
-        mock_callback.assert_called_once_with(parsed_args, api_instance_mock)
+        calls = mock_callback.mock_calls
+        assert len(calls) == 1
+        assert calls[0] == mock.call(api_instance_mock)
 
     def test_parse_ext_command_that_requires_base_parsers(self):
         """The query command requires the students and repo names parsers."""

--- a/tests/unit_tests/repobee/test_main.py
+++ b/tests/unit_tests/repobee/test_main.py
@@ -446,7 +446,7 @@ class TestRun:
     """Tests for the run function."""
 
     class Workdir(plug.Plugin, plug.cli.Command):
-        def command(self, args, api):
+        def command(self, api):
             return plug.Result(
                 name="workdir",
                 msg="workdir",


### PR DESCRIPTION
Fix #525 

Previously, arguments were passed to callback functions via an `args` attribute. As it's inconvenient to try to pass this to all hook functions, arguments are now provided only through the `handle_parsed_args` and `handle_processed_args` hooks. `handle_processed_args` is now automatically implemented for plugin commands/extensions, and assigns arguments defined by the plugin to the destination in the instance.

The `command` function in a `plug.cli.Command` now does not take an `args` argument, instead arguments are accessed through `self`.

The entire namespace is assigned to `self.args`, such that command extensions can access all arguments, even the ones they did not define themselves.

Example:

```python
import repobee_plug as plug
from repobee_plug.cli import (
    option,
    positional,
    category,
    Command,
    command_settings,
)

GreetingCategory = category(
    name="greeting",
    action_names=["hello-there", "bye"],
    help="Make a greeting!",
    description="Time to say hello or bye :)",
)


class Hello(plug.Plugin, Command):
    __settings__ = command_settings(
        action=GreetingCategory.hello_there,
        help="Say hello!",
        description="Say hello!",
    )

    name = option(required=True, help="your name")

    def command(self, api):
        print(f"Hello, {self.name}")


class Bye(plug.Plugin, Command):
    __settings__ = command_settings(
        category=GreetingCategory, help="Say bye!", description="Say bye!"
    )

    name = option(required=True, help="your name")

    def command(self, api):
        print(f"Bye, {self.name}")
```