### PR TITLE
[feat] Add flag to plugin commands

### DIFF
--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -198,7 +198,7 @@ def _add_option(
         else opt.help or ""
     )
 
-    if opt.argument_type == cli.ArgumentType.OPTION:
+    if opt.argument_type in [cli.ArgumentType.OPTION, cli.ArgumentType.FLAG]:
         if opt.short_name:
             args.append(opt.short_name)
 
@@ -208,8 +208,9 @@ def _add_option(
             args.append(f"--{name.replace('_', '-')}")
 
         kwargs["dest"] = name
-        # configured value takes precedence over default
-        kwargs["default"] = configured_value or opt.default
+        if not opt.argument_type == cli.ArgumentType.FLAG:
+            # configured value takes precedence over default
+            kwargs["default"] = configured_value or opt.default
         # required opts become not required if configured
         kwargs["required"] = not configured_value and opt.required
     elif opt.argument_type == cli.ArgumentType.POSITIONAL:

--- a/src/repobee_plug/cli/__init__.py
+++ b/src/repobee_plug/cli/__init__.py
@@ -3,6 +3,7 @@ from .categorization import category
 from .args import (
     option,
     positional,
+    flag,
     mutually_exclusive_group,
     ArgumentType,
     is_cli_arg,
@@ -17,6 +18,7 @@ __all__ = [
     "ArgumentType",
     "option",
     "positional",
+    "flag",
     "mutually_exclusive_group",
     "category",
     "command_settings",

--- a/src/repobee_plug/cli/args.py
+++ b/src/repobee_plug/cli/args.py
@@ -210,7 +210,6 @@ def flag(
                 print("meaning", self.meaning)
                 print("approve", self.approve)
 
-
     We can then call this command (for example) like so:
 
         .. code-block:: bash

--- a/src/repobee_plug/cli/args.py
+++ b/src/repobee_plug/cli/args.py
@@ -169,9 +169,9 @@ def positional(
 def flag(
     short_name: Optional[str] = None,
     long_name: Optional[str] = None,
+    help: str = "",
     const: Any = True,
     default: Optional[Any] = None,
-    help: str = "",
 ) -> Option:
     """Create a command line flag for a :py:class:`Command` or a
     :py:class`CommandExtension`. This is simply a convenience wrapper around
@@ -187,9 +187,6 @@ def flag(
     can also be overridden by specifying the ``default`` argument.
 
     Example:
-
-    .. code-block:: python
-
 
     .. code-block:: python
         :caption: ext.py
@@ -214,11 +211,26 @@ def flag(
                 print("approve", self.approve)
 
 
-    We can then call this command like so:
+    We can then call this command (for example) like so:
 
         .. code-block:: bash
 
-            $ repobee
+            $ repobee -p ext.py flags --meaning --not-great
+            is_great False
+            not_great False
+            meaning 42
+            approve no
+
+    Args:
+        short_name: The short name of this option. Must start with ``-``.
+        long_name: The long name of this option. Must start with `--`.
+        help: A description of this option that is used in the CLI help
+            section.
+        const: The constant to store.
+        default: The value to default to if the flag is omitted.
+    Returns:
+        A CLI argument wrapper used internally by RepoBee to create command
+        line argument.
     """
     resolved_default = (
         not const if default is None and isinstance(const, bool) else default

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -256,9 +256,7 @@ class TestDeclarativeExtensionCommand:
         class Greeting(plug.Plugin, plug.cli.Command):
             age_mutex = plug.cli.mutually_exclusive_group(
                 age=plug.cli.option(converter=int),
-                old=plug.cli.option(
-                    argparse_kwargs=dict(action="store_const", const=1337)
-                ),
+                old=plug.cli.flag(const=1337),
                 __required__=True,
             )
 
@@ -285,13 +283,14 @@ class TestDeclarativeExtensionCommand:
         with pytest.raises(ValueError) as exc_info:
             plug.cli.mutually_exclusive_group(
                 age=plug.cli.positional(converter=int),
-                old=plug.cli.option(
-                    argparse_kwargs=dict(action="store_const", const=1337)
-                ),
+                old=plug.cli.flag(const=1337),
                 __required__=True,
             )
 
-        assert "Positional not allowed in mutex group" in str(exc_info.value)
+        assert (
+            f"{plug.cli.ArgumentType.POSITIONAL.value} not allowed in mutex"
+            in str(exc_info.value)
+        )
 
     def test_mutex_group_allows_one_argument(self):
         """Test that a mutex group allows one argument to be specified."""
@@ -300,9 +299,7 @@ class TestDeclarativeExtensionCommand:
         class Greeting(plug.Plugin, plug.cli.Command):
             age_mutex = plug.cli.mutually_exclusive_group(
                 age=plug.cli.option(converter=int),
-                old=plug.cli.option(
-                    argparse_kwargs=dict(action="store_const", const=old)
-                ),
+                old=plug.cli.flag(const=1337),
                 __required__=True,
             )
 
@@ -415,11 +412,7 @@ class TestDeclarativeExtensionCommand:
             name = plug.cli.option()
             age = plug.cli.positional(converter=int)
             tolerance = plug.cli.mutually_exclusive_group(
-                high=plug.cli.option(
-                    argparse_kwargs=dict(action="store_true")
-                ),
-                low=plug.cli.option(argparse_kwargs=dict(action="store_true")),
-                __required__=True,
+                high=plug.cli.flag(), low=plug.cli.flag(), __required__=True,
             )
 
             def command(self, api):


### PR DESCRIPTION
Fix #531 

Example:

```python
class Flags(plug.Plugin, plug.cli.Command):
    # a normal flag, which toggles between True and False
    is_great = plug.cli.flag()
    # a "reverse" flag which defaults to True instead of False
    not_great = plug.cli.flag(const=False, default=True)
    # a flag that stores a constant and defaults to None
    meaning = plug.cli.flag(const=42)
    # a flag that stores a constant and defaults to another constant
    approve = plug.cli.flag(const="yes", default="no")

    def command(self, api):
        print("is_great", self.is_great)
        print("not_great", self.not_great)
        print("meaning", self.meaning)
        print("approve", self.approve)
```
Can be called like so:

```bash
$ repobee -p ext.py flags --meaning --not-great
is_great False
not_great False
meaning 42
approve no
```