### PR TITLE
[misc] Pin python-gitlab to v2.4.0

### DIFF
--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -2,5 +2,5 @@ appdirs
 daiquiri
 pygithub
 colored
-python-gitlab==1.15.0
+python-gitlab==2.4.0
 pluggy==0.13.1

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ required = [
     "daiquiri",
     "pygithub",
     "colored",
-    "python-gitlab==1.15.0",
+    "python-gitlab==2.4.0",
     "pluggy>=0.13.1",
 ]
 


### PR DESCRIPTION
Fix #469 