### PR TITLE
[feat] Allow config wizard to configure plugins

### DIFF
--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -93,7 +93,7 @@ Current defaults are shown in brackets [].
                 parser.add_section(section)
             parser[section][option] = default
 
-    with open(str(constants.DEFAULT_CONFIG_FILE), "w", encoding="utf8",) as f:
+    with open(str(constants.DEFAULT_CONFIG_FILE), "w", encoding="utf8") as f:
         parser.write(f)
 
     plug.echo(

--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -23,6 +23,7 @@ from repobee_plug._corehooks import PeerReviewHook as _peer_hook
 from repobee_plug._corehooks import APIHook as _api_hook
 from repobee_plug._exthooks import CloneHook as _clone_hook
 from repobee_plug._exthooks import SetupHook as _setup_hook
+from repobee_plug._exthooks import ConfigHook as _config_hook
 
 # Helpers
 from repobee_plug._deprecation import deprecate, deprecated_hooks
@@ -64,6 +65,7 @@ manager.add_hookspecs(_clone_hook)
 manager.add_hookspecs(_setup_hook)
 manager.add_hookspecs(_peer_hook)
 manager.add_hookspecs(_api_hook)
+manager.add_hookspecs(_config_hook)
 
 __all__ = [
     # Plugin stuff

--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -17,6 +17,7 @@ from repobee_plug._containers import ReviewAllocation
 from repobee_plug._containers import BaseParser
 from repobee_plug._containers import Deprecation
 from repobee_plug._containers import HookResult
+from repobee_plug._containers import ConfigurableArguments
 
 # Hook functions
 from repobee_plug._corehooks import PeerReviewHook as _peer_hook
@@ -80,6 +81,7 @@ __all__ = [
     "ReviewAllocation",
     "Review",
     "Deprecation",
+    "ConfigurableArguments",
     # API wrappers
     "Team",
     "TeamPermission",

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -6,10 +6,11 @@
 .. moduleauthor:: Simon Larsén
 """
 import collections
+import dataclasses
 import enum
 import pluggy
 
-from typing import Mapping, Any, Optional
+from typing import Mapping, Any, Optional, List
 
 from repobee_plug import log
 
@@ -145,3 +146,11 @@ Args:
         ``MAJOR.MINOR.PATCH`` by which the deprecated functionality will be
         removed.
 """
+
+
+@dataclasses.dataclass(frozen=True)
+class ConfigurableArguments:
+    """A container for holding a plugin's configurable arguments."""
+
+    config_section_name: str
+    argnames: List[str]

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -130,5 +130,5 @@ class ConfigHook:
     """Hook functions related to configuration."""
 
     @hookspec
-    def configurable_arguments(self) -> ConfigurableArguments:
+    def get_configurable_args(self) -> ConfigurableArguments:
         """Returns the configurable arguments of a plugin."""

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -13,7 +13,8 @@ cloning repos.
 import pathlib
 import argparse
 import configparser
-from typing import Union, Optional
+import dataclasses
+from typing import Union, Optional, List
 
 from repobee_plug._apimeta import PlatformAPI
 from repobee_plug._containers import hookspec
@@ -115,3 +116,19 @@ class SetupHook:
             May also return None, in which case no reporting will be performed
             for the hook.
         """
+
+
+@dataclasses.dataclass(frozen=True)
+class ConfigurableArguments:
+    """A container for holding a plugin's configurable arguments."""
+
+    config_section_name: str
+    argnames: List[str]
+
+
+class ConfigHook:
+    """Hook functions related to configuration."""
+
+    @hookspec
+    def configurable_arguments(self) -> ConfigurableArguments:
+        """Returns the configurable arguments of a plugin."""

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -13,12 +13,11 @@ cloning repos.
 import pathlib
 import argparse
 import configparser
-import dataclasses
-from typing import Union, Optional, List
+from typing import Union, Optional
 
 from repobee_plug._apimeta import PlatformAPI
 from repobee_plug._containers import hookspec
-from repobee_plug._containers import Result
+from repobee_plug._containers import Result, ConfigurableArguments
 from repobee_plug._deprecation import deprecate
 
 
@@ -118,17 +117,17 @@ class SetupHook:
         """
 
 
-@dataclasses.dataclass(frozen=True)
-class ConfigurableArguments:
-    """A container for holding a plugin's configurable arguments."""
-
-    config_section_name: str
-    argnames: List[str]
-
-
 class ConfigHook:
     """Hook functions related to configuration."""
 
     @hookspec
     def get_configurable_args(self) -> ConfigurableArguments:
-        """Returns the configurable arguments of a plugin."""
+        """Get the configurable arguments for a plugin.
+
+        .. danger::
+
+            This is not a public hook, don't implement this manually!
+
+        Returns:
+            The configurable arguments of a plugin.
+        """

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -99,16 +99,19 @@ def _process_cli_plugin(bases, attrdict) -> dict:
     attrdict_copy[handle_processed_args.__name__] = handle_processed_args
     attrdict_copy["attach_options"] = _attach_options
 
-    def get_configurable_args(self) -> _exthooks.ConfigurableArguments:
-        return _exthooks.ConfigurableArguments(
-            config_section_name=self.__settings__.config_section_name
-            or self.plugin_name,
-            argnames=list(
-                _get_configurable_arguments(self.__class__.__dict__)
-            ),
-        )
+    configurable_argnames = list(_get_configurable_arguments(attrdict))
+    if configurable_argnames:
 
-    attrdict_copy[get_configurable_args.__name__] = get_configurable_args
+        def get_configurable_args(self) -> _exthooks.ConfigurableArguments:
+            return _exthooks.ConfigurableArguments(
+                config_section_name=self.__settings__.config_section_name
+                or self.plugin_name,
+                argnames=list(
+                    _get_configurable_arguments(self.__class__.__dict__)
+                ),
+            )
+
+        attrdict_copy[get_configurable_args.__name__] = get_configurable_args
 
     return attrdict_copy
 

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -99,7 +99,7 @@ def _process_cli_plugin(bases, attrdict) -> dict:
     attrdict_copy[handle_processed_args.__name__] = handle_processed_args
     attrdict_copy["attach_options"] = _attach_options
 
-    def configurable_arguments(self) -> _exthooks.ConfigurableArguments:
+    def get_configurable_args(self) -> _exthooks.ConfigurableArguments:
         return _exthooks.ConfigurableArguments(
             config_section_name=self.__settings__.config_section_name
             or self.plugin_name,
@@ -108,7 +108,7 @@ def _process_cli_plugin(bases, attrdict) -> dict:
             ),
         )
 
-    attrdict_copy[configurable_arguments.__name__] = configurable_arguments
+    attrdict_copy[get_configurable_args.__name__] = get_configurable_args
 
     return attrdict_copy
 

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -16,6 +16,7 @@ _HOOK_METHODS = {
     for key, value in [
         *_exthooks.CloneHook.__dict__.items(),
         *_exthooks.SetupHook.__dict__.items(),
+        *_exthooks.ConfigHook.__dict__.items(),
         *_corehooks.PeerReviewHook.__dict__.items(),
         *_corehooks.APIHook.__dict__.items(),
     ]
@@ -40,25 +41,8 @@ class _PluginMeta(type):
         Checking signatures is delegated to ``pluggy`` during registration of
         the hook.
         """
-        if cli.Command in bases and cli.CommandExtension in bases:
-            raise _exceptions.PlugError(
-                "A plugin cannot be both a Command and a CommandExtension"
-            )
-
-        if cli.Command in bases:
-            if "__settings__" not in attrdict:
-                attrdict["__settings__"] = cli.command_settings()
-            handle_processed_args = _generate_handle_processed_args_func()
-            attrdict[handle_processed_args.__name__] = handle_processed_args
-            attrdict["attach_options"] = _attach_options
-        elif cli.CommandExtension in bases:
-            if "__settings__" not in attrdict:
-                raise _exceptions.PlugError(
-                    "CommandExtension must have a '__settings__' attribute"
-                )
-            handle_processed_args = _generate_handle_processed_args_func()
-            attrdict[handle_processed_args.__name__] = handle_processed_args
-            attrdict["attach_options"] = _attach_options
+        if cli.Command in bases or cli.CommandExtension in bases:
+            attrdict = _process_cli_plugin(bases, attrdict)
 
         methods = cls._extract_public_methods(attrdict)
         cls._check_names(methods)
@@ -92,18 +76,74 @@ class _PluginMeta(type):
         }
 
 
+def _process_cli_plugin(bases, attrdict) -> dict:
+    """Process a CLI plugin, generate its hook functions, and return a new
+    attrdict with all attributes set correctly.
+    """
+    attrdict_copy = dict(attrdict)  # copy to avoid mutating original
+    if cli.Command in bases and cli.CommandExtension in bases:
+        raise _exceptions.PlugError(
+            "A plugin cannot be both a Command and a CommandExtension"
+        )
+
+    if cli.Command in bases:
+        if "__settings__" not in attrdict_copy:
+            attrdict_copy["__settings__"] = cli.command_settings()
+    elif cli.CommandExtension in bases:
+        if "__settings__" not in attrdict_copy:
+            raise _exceptions.PlugError(
+                "CommandExtension must have a '__settings__' attribute"
+            )
+
+    handle_processed_args = _generate_handle_processed_args_func()
+    attrdict_copy[handle_processed_args.__name__] = handle_processed_args
+    attrdict_copy["attach_options"] = _attach_options
+
+    def configurable_arguments(self) -> _exthooks.ConfigurableArguments:
+        return _exthooks.ConfigurableArguments(
+            config_section_name=self.__settings__.config_section_name
+            or self.plugin_name,
+            argnames=list(
+                _get_configurable_arguments(self.__class__.__dict__)
+            ),
+        )
+
+    attrdict_copy[configurable_arguments.__name__] = configurable_arguments
+
+    return attrdict_copy
+
+
+def _get_configurable_arguments(attrdict: dict) -> List[str]:
+    """Returns a list of configurable argument names."""
+    cli_args = _extract_flat_cli_options(attrdict)
+    return [
+        arg_name
+        for arg_name, arg in cli_args
+        if hasattr(arg, "configurable") and arg.configurable
+    ]
+
+
 def _extract_cli_options(
     attrdict,
 ) -> List[Tuple[str, Union[Option, MutuallyExclusiveGroup]]]:
-    """Return any members that are CLI options as a list of tuples on the form
-    (member_name, option). Other types of CLI arguments, such as positionals,
-    are converted to :py:class:`~cli.Option`s.
+    """Returns any members that are CLI options as a list of tuples on the form
+    (member_name, option).
     """
     return [
         (key, value)
         for key, value in attrdict.items()
-        if isinstance(value, (Option, MutuallyExclusiveGroup))
+        if cli.is_cli_arg(value)
     ]
+
+
+def _extract_flat_cli_options(
+    attrdict,
+) -> List[Tuple[str, Union[Option, MutuallyExclusiveGroup]]]:
+    """Like _extract_cli_options, but flattens nested options such as mutex
+    groups.
+    """
+    cli_args = _extract_cli_options(attrdict)
+    return itertools.chain.from_iterable(map(_flatten_arg, cli_args))
 
 
 def _attach_options(self, config, show_all_opts, parser):
@@ -137,14 +177,7 @@ def _attach_options(self, config, show_all_opts, parser):
 def _generate_handle_processed_args_func():
     def handle_processed_args(self, args):
         self.args = args
-        cli_args = [
-            (k, v)
-            for k, v in self.__class__.__dict__.items()
-            if cli.is_cli_arg(v)
-        ]
-        flattened_args = itertools.chain.from_iterable(
-            map(_flatten_arg, cli_args)
-        )
+        flattened_args = _extract_flat_cli_options(self.__class__.__dict__)
 
         for name, arg in flattened_args:
             dest = (

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -102,8 +102,8 @@ def _process_cli_plugin(bases, attrdict) -> dict:
     configurable_argnames = list(_get_configurable_arguments(attrdict))
     if configurable_argnames:
 
-        def get_configurable_args(self) -> _exthooks.ConfigurableArguments:
-            return _exthooks.ConfigurableArguments(
+        def get_configurable_args(self) -> _containers.ConfigurableArguments:
+            return _containers.ConfigurableArguments(
                 config_section_name=self.__settings__.config_section_name
                 or self.plugin_name,
                 argnames=list(

--- a/tests/unit_tests/repobee/plugin_tests/test_configwizard.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_configwizard.py
@@ -23,6 +23,15 @@ def defaults_options():
     )
 
 
+@pytest.fixture
+def select_repobee_section(mocker):
+    mocker.patch(
+        "bullet.Bullet.launch",
+        autospec=True,
+        return_value=_repobee.constants.CORE_SECTION_HDR,
+    )
+
+
 def test_exits_when_config_file_exists_and_user_enters_no(config_mock):
     """If the config file exists, a prompt should appear, and if the user
     enters anything but 'yes' the function should exit and the config file
@@ -39,7 +48,7 @@ def test_exits_when_config_file_exists_and_user_enters_no(config_mock):
 
 
 def test_enters_values_if_config_file_exists_and_user_enters_yes(
-    config_mock, defaults_options
+    config_mock, defaults_options, select_repobee_section
 ):
     """If the config file exists, a prompt should appear, and if the user
     enters yes the wizard should proceed as usuall.
@@ -57,7 +66,7 @@ def test_enters_values_if_config_file_exists_and_user_enters_yes(
 
 
 def test_enters_values_without_continue_prompt_if_no_config_exists(
-    config_mock, defaults_options
+    config_mock, defaults_options, select_repobee_section
 ):
     """If no config mock can be found (ensured by the nothing_exists fixture),
     then the config wizard chould proceed without prompting for a continue.
@@ -74,7 +83,9 @@ def test_enters_values_without_continue_prompt_if_no_config_exists(
         assert confparser[_repobee.constants.CORE_SECTION_HDR][key] == value
 
 
-def test_skips_empty_values(empty_config_mock, defaults_options):
+def test_skips_empty_values(
+    empty_config_mock, defaults_options, select_repobee_section
+):
     """Test that empty values are not written to the configuration file."""
     defaults_options = collections.OrderedDict(
         (option, c * 10)
@@ -100,7 +111,9 @@ def test_skips_empty_values(empty_config_mock, defaults_options):
         assert confparser[_repobee.constants.CORE_SECTION_HDR][key] == value
 
 
-def test_retains_values_that_are_not_specified(config_mock, defaults_options):
+def test_retains_values_that_are_not_specified(
+    config_mock, defaults_options, select_repobee_section
+):
     """Test that previous default values are retained if the option is skipped,
     and that plugin sections are not touched.
     """
@@ -153,7 +166,9 @@ def test_retains_values_that_are_not_specified(config_mock, defaults_options):
         assert parser[plugin_section][option] == value
 
 
-def test_creates_directory(config_mock, tmpdir, defaults_options):
+def test_creates_directory(
+    config_mock, tmpdir, defaults_options, select_repobee_section
+):
     with patch(
         "builtins.input", side_effect=["yes"] + list(defaults_options.values())
     ), patch("os.makedirs", autospec=True) as makedirs_mock, patch(

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -193,6 +193,24 @@ class TestDeclarativeExtensionCommand:
         assert configurable_args.config_section_name == plugin_name
         assert sorted(configurable_args.argnames) == sorted(["name", "age"])
 
+    def test_get_configurable_args_when_no_args_configurable(self):
+        """get_configurable_args should not be implemented if no args are
+        configurable.
+        """
+
+        class Greeting(plug.Plugin, plug.cli.Command):
+            name = plug.cli.option(help="your name")
+
+            def command(self, api):
+                pass
+
+        plugin_instance = Greeting("greeting")
+
+        assert not hasattr(
+            plugin_instance,
+            plug._exthooks.ConfigHook.get_configurable_args.__name__,
+        )
+
     def test_raises_when_non_configurable_value_is_configured(self):
         """It shouldn't be allowed to have a configuration value for an
         option that is not marked configurable. This is to avoid accidental

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -170,6 +170,29 @@ class TestDeclarativeExtensionCommand:
 
         assert args.name == configured_name
 
+    def test_configurable_arguments_hook_correctly_implemented(self):
+        """Only configurable arguments should be returned by the
+        configurable_arguments hook.
+        """
+
+        class Greeting(plug.Plugin, plug.cli.Command):
+            name = plug.cli.option(
+                help="your name", required=True, configurable=True
+            )
+            age = plug.cli.option(help="your age", configurable=True)
+            nationality = plug.cli.option(help="your nationality")
+
+            def command(self, api):
+                pass
+
+        plugin_name = "greeting"
+        plugin_instance = Greeting(plugin_name)
+
+        configurable_args = plugin_instance.configurable_arguments()
+
+        assert configurable_args.config_section_name == plugin_name
+        assert sorted(configurable_args.argnames) == sorted(["name", "age"])
+
     def test_raises_when_non_configurable_value_is_configured(self):
         """It shouldn't be allowed to have a configuration value for an
         option that is not marked configurable. This is to avoid accidental

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -170,9 +170,9 @@ class TestDeclarativeExtensionCommand:
 
         assert args.name == configured_name
 
-    def test_configurable_arguments_hook_correctly_implemented(self):
+    def test_get_configurable_args_hook_correctly_implemented(self):
         """Only configurable arguments should be returned by the
-        configurable_arguments hook.
+        get_configurable_args hook.
         """
 
         class Greeting(plug.Plugin, plug.cli.Command):
@@ -188,7 +188,7 @@ class TestDeclarativeExtensionCommand:
         plugin_name = "greeting"
         plugin_instance = Greeting(plugin_name)
 
-        configurable_args = plugin_instance.configurable_arguments()
+        configurable_args = plugin_instance.get_configurable_args()
 
         assert configurable_args.config_section_name == plugin_name
         assert sorted(configurable_args.argnames) == sorted(["name", "age"])


### PR DESCRIPTION
Fix #492 

A little quirk is that a plugin must be active in order to be configurable. I.e. to be able to configure the `junit4` plugin, you need to run `repobee -p junit4 config wizard`, or have it activated in some other way. Otherwise it won't appear.