### PR TITLE
[fact] Use local representations of API objects when appropriate

### DIFF
--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -21,7 +21,7 @@ from _repobee.command import progresswrappers
 
 
 def list_issues(
-    repos: Iterable[plug.Repo],
+    repos: Iterable[plug.StudentRepo],
     api: plug.PlatformAPI,
     state: plug.IssueState = plug.IssueState.OPEN,
     title_regex: str = "",
@@ -207,7 +207,7 @@ def open_issue(
 
 
 def close_issue(
-    title_regex: str, repos: Iterable[plug.Repo], api: plug.PlatformAPI
+    title_regex: str, repos: Iterable[plug.StudentRepo], api: plug.PlatformAPI
 ) -> None:
     """Close issues whose titles match the title_regex in student repos.
 

--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -185,7 +185,7 @@ def _limit_line_length(s: str, max_line_length: int = 100) -> str:
 def open_issue(
     issue: plug.Issue,
     master_repo_names: Iterable[str],
-    teams: Iterable[plug.Team],
+    teams: Iterable[plug.StudentTeam],
     api: plug.PlatformAPI,
 ) -> None:
     """Open an issue in student repos.

--- a/src/_repobee/command/peer.py
+++ b/src/_repobee/command/peer.py
@@ -29,7 +29,7 @@ DEFAULT_REVIEW_ISSUE = plug.Issue(
 
 def assign_peer_reviews(
     master_repo_names: Iterable[str],
-    teams: Iterable[plug.Team],
+    teams: Iterable[plug.StudentTeam],
     num_reviews: int,
     issue: Optional[plug.Issue],
     api: plug.PlatformAPI,
@@ -78,7 +78,7 @@ def assign_peer_reviews(
             zip(
                 *[
                     (
-                        plug.Team(
+                        plug.StudentTeam(
                             members=alloc.review_team.members,
                             name=plug.generate_review_team_name(
                                 str(alloc.reviewed_team), master_name

--- a/src/_repobee/command/progresswrappers.py
+++ b/src/_repobee/command/progresswrappers.py
@@ -32,7 +32,7 @@ def get_repos(
 
 
 def get_teams(
-    teams: Iterable[Union[plug.Team, str]],
+    teams: Iterable[Union[plug.StudentTeam, str]],
     api: plug.PlatformAPI,
     desc: str = "Fetching teams",
     **kwargs: Any,

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -18,7 +18,7 @@ import shutil
 import os
 import sys
 import tempfile
-from typing import Iterable, List, Optional, Mapping, Generator
+from typing import Iterable, List, Optional, Mapping
 
 import repobee_plug as plug
 
@@ -192,7 +192,7 @@ def _clone_all(urls: Iterable[str], cwd: str):
 
 def update_student_repos(
     master_repo_urls: Iterable[str],
-    teams: Iterable[plug.Team],
+    teams: Iterable[plug.StudentTeam],
     api: plug.PlatformAPI,
     issue: Optional[plug.Issue] = None,
 ) -> Mapping[str, List[plug.Result]]:
@@ -264,7 +264,7 @@ def _open_issue_by_urls(
 
 
 def clone_repos(
-    repos: Iterable[plug.Repo], api: plug.PlatformAPI
+    repos: Iterable[plug.StudentRepo], api: plug.PlatformAPI
 ) -> Mapping[str, List[plug.Result]]:
     """Clone all student repos related to the provided master repos and student
     teams.
@@ -294,7 +294,7 @@ def clone_repos(
 
 def _non_local_repos(
     repos, cwd=pathlib.Path(".")
-) -> Generator[plug.Repo, None, None]:
+) -> Iterable[plug.StudentRepo]:
     """Yield repos with names that do not clash with any of the files present
     in cwd.
     """

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -36,7 +36,7 @@ from _repobee.command import progresswrappers
 
 def setup_student_repos(
     master_repo_urls: Iterable[str],
-    teams: Iterable[plug.Team],
+    teams: Iterable[plug.StudentTeam],
     api: plug.PlatformAPI,
 ) -> Mapping[str, List[plug.Result]]:
     """Setup student repositories based on master repo templates. Performs three

--- a/src/_repobee/command/teams.py
+++ b/src/_repobee/command/teams.py
@@ -3,7 +3,7 @@ import repobee_plug as plug
 
 
 def create_teams(
-    teams: Iterable[plug.Team],
+    teams: Iterable[plug.StudentTeam],
     permission: plug.TeamPermission,
     api: plug.PlatformAPI,
 ) -> Iterable[plug.Team]:

--- a/src/_repobee/ext/defaults/genreviews.py
+++ b/src/_repobee/ext/defaults/genreviews.py
@@ -14,7 +14,7 @@ import repobee_plug as plug
 
 @plug.repobee_hook
 def generate_review_allocations(
-    teams: List[plug.Team], num_reviews: int
+    teams: List[plug.StudentTeam], num_reviews: int
 ) -> List[plug.ReviewAllocation]:
     if num_reviews >= len(teams):
         raise ValueError("num_reviews must be less than len(teams)")
@@ -43,7 +43,7 @@ def generate_review_allocations(
         members = list(
             itertools.chain.from_iterable([team.members for team in teams])
         )
-        return plug.Team(members=members)
+        return plug.StudentTeam(members=members)
 
     transposed_allocations = zip(*allocations)
     review_allocations = [

--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -344,7 +344,7 @@ class GitHubAPI(plug.PlatformAPI):
         self,
         master_repo_names: Iterable[str],
         org_name: Optional[str] = None,
-        teams: Optional[List[plug.Team]] = None,
+        team_names: Optional[List[str]] = None,
         insert_auth: bool = False,
     ) -> List[str]:
         """See :py:meth:`repobee_plug.PlatformAPI.get_repo_urls`."""
@@ -356,8 +356,8 @@ class GitHubAPI(plug.PlatformAPI):
             )
         repo_names = (
             master_repo_names
-            if not teams
-            else plug.generate_repo_names(teams, master_repo_names)
+            if not team_names
+            else plug.generate_repo_names(team_names, master_repo_names)
         )
         return [
             self.insert_auth(url) if insert_auth else url

--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -340,7 +340,7 @@ class GitLabAPI(plug.PlatformAPI):
         self,
         master_repo_names: Iterable[str],
         org_name: Optional[str] = None,
-        teams: Optional[List[plug.Team]] = None,
+        team_names: Optional[List[str]] = None,
         insert_auth: bool = False,
     ) -> List[str]:
         """See :py:meth:`repobee_plug.PlatformAPI.get_repo_urls`."""
@@ -348,11 +348,11 @@ class GitLabAPI(plug.PlatformAPI):
         group_url = f"{self._base_url}/{group_name}"
         repo_urls = (
             [f"{group_url}/{repo_name}.git" for repo_name in master_repo_names]
-            if not teams
+            if not team_names
             else [
                 f"{group_url}/{team}/"
                 f"{plug.generate_repo_name(str(team), master_repo_name)}.git"
-                for team in teams
+                for team in team_names
                 for master_repo_name in master_repo_names
             ]
         )

--- a/src/_repobee/ext/pairwise.py
+++ b/src/_repobee/ext/pairwise.py
@@ -26,7 +26,7 @@ PLUGIN_DESCRIPTION = (
 
 @plug.repobee_hook
 def generate_review_allocations(
-    teams: List[plug.Team], num_reviews: int = 1
+    teams: List[plug.StudentTeam], num_reviews: int = 1
 ) -> List[plug.ReviewAllocation]:
     """Generate peer review allocations such that if team_a reviews team_b,
     then team_b reviews team_a, and no others!

--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -61,6 +61,9 @@ from repobee_plug._exceptions import (
     UnexpectedException,
 )
 
+# Local representations
+from repobee_plug.localreps import StudentTeam, StudentRepo
+
 manager = pluggy.PluginManager(__package__)
 manager.add_hookspecs(_clone_hook)
 manager.add_hookspecs(_setup_hook)
@@ -82,6 +85,8 @@ __all__ = [
     "Review",
     "Deprecation",
     "ConfigurableArguments",
+    "StudentTeam",
+    "StudentRepo",
     # API wrappers
     "Team",
     "TeamPermission",

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -8,9 +8,10 @@
 import collections
 import dataclasses
 import enum
-import pluggy
 
 from typing import Mapping, Any, Optional, List
+
+import pluggy
 
 from repobee_plug import log
 

--- a/src/repobee_plug/_corehooks.py
+++ b/src/repobee_plug/_corehooks.py
@@ -13,7 +13,7 @@ to allow for this dynamic override.
 
 from typing import List, Tuple
 
-from repobee_plug import _apimeta
+from repobee_plug import localreps
 from repobee_plug import _containers
 from repobee_plug._containers import hookspec
 
@@ -23,7 +23,7 @@ class PeerReviewHook:
 
     @hookspec(firstresult=True)
     def generate_review_allocations(
-        self, teams: List[_apimeta.Team], num_reviews: int
+        self, teams: List[localreps.StudentTeam], num_reviews: int
     ) -> List[_containers.ReviewAllocation]:
         """Generate :py:class:`~repobee_plug.containers.ReviewAllocation`
         tuples from the provided teams, given that this concerns reviews for a
@@ -36,7 +36,7 @@ class PeerReviewHook:
 
         .. code-block:: python
 
-            team_c = apimeta.Team(members=team_a.members + team_b.members)
+            team_c = plug.StudentTeam(members=team_a.members + team_b.members)
 
         This can be scaled to however many teams you would like to merge. As a
         practical example, if teams ``team_a`` and ``team_b`` are to review
@@ -46,7 +46,9 @@ class PeerReviewHook:
 
         .. code-block:: python
 
-            review_team = apimeta.Team(members=team_a.members + team_b.members)
+            review_team = plug.StudentTeam(
+                members=team_a.members + team_b.members
+            )
             allocation = containers.ReviewAllocation(
                 review_team=review_team,
                 reviewed_team=team_c,
@@ -59,12 +61,11 @@ class PeerReviewHook:
             num_reviews is ignored, however.
 
         Args:
-            team: A list of :py:class:`~repobee_plug.apimeta.Team` tuples.
+            team: A list of student teams.
             num_reviews: Amount of reviews each student should perform (and
                 consequently amount of reviewers per repo)
         Returns:
-            A list of :py:class:`~repobee_plug.containers.ReviewAllocation`
-                tuples.
+            A list of review allocations tuples.
         """
 
 

--- a/src/repobee_plug/fileutils.py
+++ b/src/repobee_plug/fileutils.py
@@ -4,11 +4,12 @@ import sys
 import os
 from typing import List
 
-from repobee_plug import _apimeta
 from repobee_plug import _exceptions
 
+from repobee_plug.localreps import StudentTeam
 
-def parse_students_file(path: pathlib.Path) -> List[_apimeta.Team]:
+
+def parse_students_file(path: pathlib.Path) -> List[StudentTeam]:
     """Parse the students file.
 
     Args:
@@ -23,7 +24,7 @@ def parse_students_file(path: pathlib.Path) -> List[_apimeta.Team]:
     if not path.stat().st_size:
         raise _exceptions.FileError("'{!s}' is empty".format(path))
     return [
-        _apimeta.Team(members=[s for s in group.strip().split()])
+        StudentTeam(members=[s for s in group.strip().split()])
         for group in path.read_text(encoding=sys.getdefaultencoding()).split(
             os.linesep
         )

--- a/src/repobee_plug/localreps.py
+++ b/src/repobee_plug/localreps.py
@@ -1,0 +1,63 @@
+"""Local representations of API objects."""
+import dataclasses
+import pathlib
+
+from typing import Optional, List
+
+MAX_NAME_LENGTH = 100
+
+__all__ = ["StudentTeam", "StudentRepo"]
+
+
+def _check_name_length(name):
+    """Check that a Team/Repository name does not exceed the maximum GitHub
+    allows (100 characters)
+    """
+    if len(name) > MAX_NAME_LENGTH:
+        raise ValueError(
+            "generated Team/Repository name is too long, was {} chars, "
+            "max is {} chars".format(len(name), MAX_NAME_LENGTH)
+        )
+
+
+@dataclasses.dataclass(frozen=True, order=True)
+class StudentTeam:
+    """Local representation of a student team.
+
+    Attributes:
+        members: A list of members of this team.
+        name: The name of this team.
+    """
+
+    members: List[str] = dataclasses.field(compare=False)
+    name: str = dataclasses.field(default="", compare=True)
+
+    def __str__(self):
+        return self.name
+
+    def __post_init__(self):
+        object.__setattr__(self, "memebers", list(self.members))
+        object.__setattr__(
+            self, "name", self.name or "-".join(sorted(self.members))
+        )
+        _check_name_length(self.name)
+
+
+@dataclasses.dataclass(frozen=True)
+class StudentRepo:
+    """Local representation of a student repo.
+
+    Attributes:
+        name: Name of this repository.
+        team: The team this repository belongs to.
+        url: URL to the platform repository.
+        path: Path to the local repository if it exists on disc.
+    """
+
+    name: str
+    team: StudentTeam
+    url: str
+    path: Optional[pathlib.Path] = None
+
+    def __post_init__(self):
+        _check_name_length(self.name)

--- a/src/repobee_plug/testhelpers/localapi.py
+++ b/src/repobee_plug/testhelpers/localapi.py
@@ -254,15 +254,15 @@ class LocalAPI(plug.PlatformAPI):
         self,
         master_repo_names: Iterable[str],
         org_name: Optional[str] = None,
-        teams: Optional[List[plug.Team]] = None,
+        team_names: Optional[List[str]] = None,
         insert_auth: bool = False,
     ) -> List[str]:
         assert not insert_auth, "not yet implemented"
         base = self._repodir / (org_name or self._org_name)
         repo_names = (
             master_repo_names
-            if not teams
-            else plug.generate_repo_names(teams, master_repo_names)
+            if not team_names
+            else plug.generate_repo_names(team_names, master_repo_names)
         )
         return [(base / name).as_uri() for name in repo_names]
 

--- a/tests/integration_tests/_helpers/const.py
+++ b/tests/integration_tests/_helpers/const.py
@@ -21,7 +21,7 @@ MASTER_REPO_NAMES = [
     if p.is_dir()
 ]
 STUDENT_TEAMS = [
-    plug.Team(members=[s.strip()])
+    plug.StudentTeam(members=[s.strip()])
     for s in (DIR.parent / "students.txt").read_text().strip().split("\n")
 ]
 STUDENT_TEAM_NAMES = [str(t) for t in STUDENT_TEAMS]

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -177,7 +177,7 @@ def open_issues(with_student_repos):
 def with_reviews(with_student_repos):
     master_repo_name = MASTER_REPO_NAMES[1]
     expected_review_teams = [
-        plug.Team(
+        plug.StudentTeam(
             members=[],
             name=plug.generate_review_team_name(
                 student_team_name, master_repo_name

--- a/tests/integration_tests/integration_tests.py
+++ b/tests/integration_tests/integration_tests.py
@@ -457,7 +457,7 @@ class TestAssignReviews:
     def test_assign_one_review(self, with_student_repos, extra_args):
         master_repo_name = MASTER_REPO_NAMES[1]
         expected_review_teams = [
-            plug.Team(
+            plug.StudentTeam(
                 members=[],
                 name=plug.generate_review_team_name(
                     student_team_name, master_repo_name

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -17,7 +17,7 @@ from repobee_plug.testhelpers.const import (
 
 
 def assert_student_repos_match_templates(
-    student_teams: List[plug.Team],
+    student_teams: List[plug.StudentTeam],
     template_repo_names: List[str],
     repos: List[localapi.Repo],
 ):
@@ -31,7 +31,7 @@ def assert_student_repos_match_templates(
 
 
 def assert_cloned_student_repos_match_templates(
-    student_teams: List[plug.Team],
+    student_teams: List[plug.StudentTeam],
     template_repo_names: List[str],
     workdir: pathlib.Path,
 ):
@@ -47,7 +47,7 @@ def assert_cloned_student_repos_match_templates(
 
 
 def _assert_repos_match_templates(
-    student_teams: List[plug.Team],
+    student_teams: List[plug.StudentTeam],
     template_repo_names: List[str],
     repos_dict: Mapping[str, pathlib.Path],
 ):

--- a/tests/unit_tests/repobee/conftest.py
+++ b/tests/unit_tests/repobee/conftest.py
@@ -39,13 +39,13 @@ class DummyAPI(plug.PlatformAPI):
         self,
         master_repo_names: Iterable[str],
         org_name: Optional[str] = None,
-        teams: Optional[List[plug.Team]] = None,
+        team_names: Optional[List[str]] = None,
         insert_auth: bool = False,
     ) -> List[str]:
         repo_names = (
             master_repo_names
-            if not teams
-            else plug.generate_repo_names(teams, master_repo_names)
+            if not team_names
+            else plug.generate_repo_names(team_names, master_repo_names)
         )
         return [
             f"{constants.HOST_URL}/{org_name or self.org_name}/{repo_name}"

--- a/tests/unit_tests/repobee/constants.py
+++ b/tests/unit_tests/repobee/constants.py
@@ -14,7 +14,7 @@ BASE_URL = "{}/api/v3".format(HOST_URL)
 
 # 5! = 120 different students
 STUDENTS = tuple(
-    plug.Team(members=["".join(perm)])
+    plug.StudentTeam(members=["".join(perm)])
     for perm in permutations(string.ascii_lowercase[:5])
 )
 ISSUE_PATH = "some/issue/path"

--- a/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
@@ -382,7 +382,9 @@ class TestGetRepoUrls:
 
         # act
         actual_urls = api.get_repo_urls(
-            master_repo_names, teams=constants.STUDENTS, insert_auth=True
+            master_repo_names,
+            team_names=[t.name for t in constants.STUDENTS],
+            insert_auth=True,
         )
 
         # assert

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -62,15 +62,16 @@ VALID_PARSED_ARGS = dict(
     token=TOKEN,
     num_reviews=1,
     hook_results_file=None,
-    repos=(
+    repos=[
         plug.StudentRepo(
             name=plug.generate_repo_name(team, master_name),
+            team=team,
             url=generate_repo_url(
                 plug.generate_repo_name(team, master_name), ORG_NAME
             ),
         )
         for team, master_name in itertools.product(STUDENTS, REPO_NAMES)
-    ),
+    ],
 )
 
 

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -63,13 +63,11 @@ VALID_PARSED_ARGS = dict(
     num_reviews=1,
     hook_results_file=None,
     repos=(
-        plug.Repo(
+        plug.StudentRepo(
             name=plug.generate_repo_name(team, master_name),
             url=generate_repo_url(
                 plug.generate_repo_name(team, master_name), ORG_NAME
             ),
-            description="",
-            private=True,
         )
         for team, master_name in itertools.product(STUDENTS, REPO_NAMES)
     ),
@@ -796,7 +794,7 @@ class TestStudentParsing:
             ["cat", "dog", "mouse"],
         )
         expected_groups = sorted(
-            plug.Team(members=group) for group in groupings
+            plug.StudentTeam(members=group) for group in groupings
         )
         empty_students_file.write(
             os.linesep.join([" ".join(group) for group in groupings])
@@ -826,7 +824,7 @@ class TestStudentParsing:
         groupings = (
             ["buddy", "shuddy"],
             # TODO remove dependency on _apimeta, it's private!
-            ["a" * plug._apimeta.MAX_NAME_LENGTH, "b"],
+            ["a" * plug.localreps.MAX_NAME_LENGTH, "b"],
             ["cat", "dog", "mouse"],
         )
         empty_students_file.write(


### PR DESCRIPTION
Fix #567 

Uses `StudentTeam` and `StudentRepo` when an implementation is not available.