### PR TITLE
[break] Rename master repo names to assignments/assignment names

### DIFF
--- a/docs/clone.rst
+++ b/docs/clone.rst
@@ -10,7 +10,7 @@ repos based on ``task-1`` and ``task-2``.
 
 .. code-block:: bash
 
-    $ repobee clone --mn task-1 task-2 --sf students.txt
+    $ repobee clone -a task-1 task-2 --sf students.txt
     [INFO] cloning into student repos ...
     [INFO] Cloned into https://some-enterprise-host/repobee-demo/slarse-task-1
     [INFO] Cloned into https://some-enterprise-host/repobee-demo/glassey-task-1

--- a/docs/fundamentals.rst
+++ b/docs/fundamentals.rst
@@ -65,14 +65,17 @@ the :ref:`gitlab` section.
   installation is another.
 * *Target organization*: The GitHub Organization_ related to the current course
   round.
-* *Master repository*: Or *master repo*, is a template repository upon which
-  student repositories are based.
+* *Assignment*: What you would expect; an assignment to be handed in.
+* *Template repository*: Or *template repo*, is a template from which student
+  repositories are created for a given assignment. Each assignment has one
+  associated template repo. Template repos share the name of their associated
+  assignment.
 * *Master organization*: The master organization is an optional organization to
-  keep master repos in. The idea is to be able to have the master repos in this
+  keep template repos in. The idea is to be able to have the template repos in this
   organization to avoid having to migrate them to the target organization for
   each course round. It is highly recommended to use a master organization if
-  master repos are being worked on across course rounds.
-* *Student repository*: Or *student repo*, refers to a *copy* of a master repo
+  template repos are being worked on across course rounds.
+* *Student repository*: Or *student repo*, refers to a *copy* of a template repo
   for some specific student or group of students.
 
 .. _conventions:
@@ -85,21 +88,21 @@ The following conventions are fundamental to working with RepoBee.
 * Any user of RepoBee has unrestricted access to the target organization
   (i.e. is an owner). If the user has limited access, some features may work,
   while others may not.
-* Master repos should be available as private repos in one of three places:
+* Template repos should be available as private repos in one of three places:
 
-  - The master organization (recommended if the master repos are being
+  - The master organization (recommended if the template repos are being
     maintained and improved across course rounds).
   - The target organization. If you are doing a trial run or for some reason
     can't have multiple organizations, this may be a good option.
-  - Locally in the current working directory. If your master repos are trivial
+  - Locally in the current working directory. If your template repos are trivial
     (e.g. empty), this may be a good option.
 * Student repositories are copies of the default branches of the master
   repositories (i.e. ``--single-branch`` cloning is used by default). That is,
   until students make modifications.
-* Student repositories are named *<username>-<master_repo_name>* to guarantee
+* Student repositories are named *<username>-<assignment-name>* to guarantee
   unique repo names.
   - Student repositories belonging to groups of students are named
-  *<username-1>-<username-2>-...-<master-repo-name>*.
+  *<username-1>-<username-2>-...-<assignment-name>*.
 * Each student is assigned to a team with the same name as the student's
   username (or a concatenation of usernames for groups). It is the team that is
   granted access to the repositories, not the student's actual user.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -220,7 +220,7 @@ simple as issuing a single command with RepoBee.
 
 .. code-block:: bash
 
-    $ repobee setup --mn task-1 task-2 --sf students.txt
+    $ repobee setup -a task-1 task-2 --sf students.txt
     [INFO] Cloning into master repos ...
     [INFO] Cloning into file:///home/slarse/tmp/task-1
     [INFO] Cloning into file:///home/slarse/tmp/task-2

--- a/docs/group_assignments.rst
+++ b/docs/group_assignments.rst
@@ -26,7 +26,7 @@ the following result:
 
 .. code-block:: bash
 
-    $ repobee setup --mn task-1 task-2 --sf students.txt
+    $ repobee setup -a task-1 task-2 --sf students.txt
     [INFO] cloning into master repos ...
     [INFO] cloning into file:///home/slarse/tmp/task-1
     [INFO] cloning into file:///home/slarse/tmp/task-2

--- a/docs/issues.rst
+++ b/docs/issues.rst
@@ -36,7 +36,7 @@ for our dear students ``slarse``, ``glennol`` and ``glassey``, who are listed in
 
 .. code-block:: bash
 
-    $ repobee open-issues --mn task-2 --sf students.txt -i issue.md
+    $ repobee open-issues -a task-2 --sf students.txt -i issue.md
     [INFO] Opened issue slarse-task-2/#1-'An important announcement'
     [INFO] Opened issue glennol-task-2/#1-'An important announcement'
     [INFO] Opened issue glassey-task-2/#1-'An important announcement'
@@ -58,7 +58,7 @@ announcement`` is simple: we provide the regex ``\AAn important announcement\Z``
 
 .. code-block:: bash
 
-    $ repobee close-issues --mn task-2 --sf students.txt -r '\AAn important announcement\Z'
+    $ repobee close-issues -a task-2 --sf students.txt -r '\AAn important announcement\Z'
     [INFO] Closed issue slarse-task-2/#1-'An important announcement'
     [INFO] Closed issue glennol-task-2/#1-'An important announcement'
     [INFO] Closed issue glassey-task-2/#1-'An important announcement'
@@ -85,7 +85,7 @@ issues like so:
 
 .. code-block:: bash
 
-    $ repobee list-issues --mn task-2 --sf students.txt
+    $ repobee list-issues -a task-2 --sf students.txt
     [INFO] slarse-task-2/#1:  Grading Criteria created 2018-09-12 18:20:56 by glassey
     [INFO] glennol-task-2/#1:  Grading Criteria created 2018-09-12 18:20:56 by glassey
     [INFO] glassey-task-2/#1:   Grading Criteria created 2018-09-12 18:20:56 by glassey
@@ -96,7 +96,7 @@ issues, we must specifically say so with the ``--closed`` argument.
 
 .. code-block:: bash
 
-    $ repobee list-issues --mn task-2 --sf students.txt --closed
+    $ repobee list-issues -a task-2 --sf students.txt --closed
     [INFO] slarse-task-2/#2:  An important announcement created 2018-09-17 17:46:43 by slarse
     [INFO] glennol-task-2/#2:  An important announcement created 2018-09-17 17:46:43 by slarse
     [INFO] glassey-task-2/#2:   An important announcement created 2018-09-17 17:46:43 by slarse

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -19,7 +19,7 @@ directory (i.e. local repos), all we have to do is this:
 
 .. code-block:: bash
 
-    $ repobee migrate --mn task-1 task-2
+    $ repobee migrate -a task-1 task-2
     [INFO] cloning into file:///some/directory/path/task-1
     [INFO] cloning into file:///some/directory/path/task-2
     [INFO] created repobee-demo/task-1
@@ -48,7 +48,7 @@ changing the local repos yields the following output:
 
 .. code-block:: bash
 
-    $ repobee migrate --mn task-1 task-2
+    $ repobee migrate -a task-1 task-2
     [INFO] cloning into file:///some/directory/path/task-1
     [INFO] cloning into file:///some/directory/path/task-2
     [INFO] repobee-demo/task-1 already exists

--- a/docs/peer.rst
+++ b/docs/peer.rst
@@ -32,7 +32,7 @@ that ``students.txt`` lists our three favorite students slarse, glassey and glen
 
 .. code-block:: bash
 
-    $ repobee assign-reviews --mn task-1 --sf students.txt --num-reviews 2
+    $ repobee assign-reviews -a task-1 --sf students.txt --num-reviews 2
     # step 1
     [INFO] Created team slarse-task-1-review
     [INFO] Created team glennol-task-1-review
@@ -112,7 +112,7 @@ specifying the issue like this:
 
 .. code-block:: bash
 
-   $ repobee assign-reviews --mn task-2 --sf students.txt --num-reviews 2 --issue issue.md
+   $ repobee assign-reviews -a task-2 --sf students.txt --num-reviews 2 --issue issue.md
    [INFO] Created team slarse-task-2-review
    [INFO] Created team glennol-task-2-review
    [INFO] Created team glassey-task-2-review
@@ -146,7 +146,7 @@ teams. Here's an example call:
 
 .. code-block:: bash
 
-   $ repobee check-reviews --mn task-2 --sf students.txt --num-reviews 2 --title-regex '\APeer review\Z'
+   $ repobee check-reviews -a task-2 --sf students.txt --num-reviews 2 --title-regex '\APeer review\Z'
    [INFO] Processing glassey-task-2-review
    [INFO] Processing glennol-task-2-review
    [INFO] Processing slarse-task-2-review
@@ -178,7 +178,7 @@ review teams. It's as simple as:
 
 .. code-block:: bash
 
-    $ repobee end-reviews --mn task-1 --sf students.txt
+    $ repobee end-reviews -a task-1 --sf students.txt
     [INFO] Deleted team glennol-task-1-review
     [INFO] Deleted team glassey-task-1-review
     [INFO] Deleted team slarse-task-1-review
@@ -209,14 +209,14 @@ the student ``cabbage`` in the reviews for ``task-2`` back at
 :ref:`assign reviews`. We then do the following:
 
 1. Check if any reviews have already been posted. This can easily be performed
-   with ``repobee list-issues --mn task-2 --sf students.txt -r '^Peer
+   with ``repobee list-issues -a task-2 --sf students.txt -r '^Peer
    review$'`` (assuming the naming conventions were followed!). Take appropriate
    action if you find any reviews already posted (appropriate being anything you
    see fit to alleviate the situation of affected students possibly being
    assigned new repos to review).
-2. Purge the review teams with ``repobee end-reviews --mn task-2
+2. Purge the review teams with ``repobee end-reviews -a task-2
    --sf students.txt``
-3. Close all review issues with ``repobee close-issues --mn task-2 --sf
+3. Close all review issues with ``repobee close-issues -a task-2 --sf
    students.txt -r '^Review of task-2$'``
 4. Create a new ``issue.md`` file apologetically explaining that you messed up:
 
@@ -228,7 +228,7 @@ the student ``cabbage`` in the reviews for ``task-2`` back at
     allocations (repo access has been revoked anyway).
 
 5. Assign peer reviews again, with the new issue, with ``repobee
-   assign-reviews --mn task-2 --sf students.txt --num-reviews 2
+   assign-reviews -a task-2 --sf students.txt --num-reviews 2
    --issue issue.md``
 
 And that's it! Disaster averted.
@@ -251,7 +251,7 @@ scheme, you add ``-p pairwise`` in front of the command.
 
 .. code-block:: bash
 
-    $ repobee -p pairwise assign-reviews --mn task-1 --sf students.txt
+    $ repobee -p pairwise assign-reviews -a task-1 --sf students.txt
 
 Note that the pairwise algorithm ignores the ``--num-reviews`` argument, and
 will issue a warning if this is set (to anything but 1, but you should just not

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -96,7 +96,7 @@ you can activate the builtins_ ``javac`` and ``pylint`` like this:
 
 .. code-block:: bash
 
-    $ repobee -p pylint -p javac clone --mn task-1 --sf students.txt
+    $ repobee -p pylint -p javac clone -a task-1 --sf students.txt
 
 This will clone the repos, and the run the plugins on the repos. You can also
 specify the default plugins you would like to use in the configuration file by

--- a/docs/update.rst
+++ b/docs/update.rst
@@ -18,7 +18,7 @@ Let's say that we've updated ``task-1``, and that users ``slarse``,
 
 .. code-block:: bash
 
-    $ repobee update --mn task-1 -s slarse glennol glassey
+    $ repobee update -a task-1 -s slarse glennol glassey
     [INFO] Cloning into master repos ...
     [INFO] Cloning into https://some-enterprise-host/repobee-demo/task-1
     [INFO] Pushing files to student repos ...
@@ -75,7 +75,7 @@ students, plain text is more helpful. Now it's just a matter of using
 
 .. code-block:: bash
 
-    $ repobee update --mn task-1 -s slarse glennol glassey -i issue.md
+    $ repobee update -a task-1 -s slarse glennol glassey -i issue.md
     [INFO] Cloning into master repos ...
     [INFO] Cloning into https://some-enterprise-host/repobee-demo/task-1
     [INFO] Pushing files to student repos ...

--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -97,9 +97,7 @@ def _dispatch_issues_command(
     issues = plug.cli.CoreCommand.issues
     action = args.action
     if action == issues.open:
-        command.open_issue(
-            args.issue, args.master_repo_names, args.students, api
-        )
+        command.open_issue(args.issue, args.assignments, args.students, api)
         return None
     elif action == issues.close:
         command.close_issue(args.title_regex, args.repos, api)
@@ -143,19 +141,15 @@ def _dispatch_reviews_command(
     action = args.action
     if action == reviews.assign:
         command.assign_peer_reviews(
-            args.master_repo_names,
-            args.students,
-            args.num_reviews,
-            args.issue,
-            api,
+            args.assignments, args.students, args.num_reviews, args.issue, api,
         )
         return None
     elif action == reviews.end:
-        command.purge_review_teams(args.master_repo_names, args.students, api)
+        command.purge_review_teams(args.assignments, args.students, api)
         return None
     elif action == reviews.check:
         command.check_peer_review_progress(
-            args.master_repo_names,
+            args.assignments,
             args.students,
             args.title_regex,
             args.num_reviews,

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -37,8 +37,7 @@ _REPO_NAME_PARSER = argparse.ArgumentParser(add_help=False)
 _REPO_NAME_PARSER.add_argument(
     "-a",
     "--assignments",
-    help="one or more names of master repositories, referring either to local "
-    "directories or repos in the master organization",
+    help="one or more names of assignments",
     type=str,
     required=True,
     nargs="+",
@@ -51,8 +50,7 @@ _DISCOVERY_MUTEX_GRP = _REPO_DISCOVERY_PARSER.add_mutually_exclusive_group(
 _DISCOVERY_MUTEX_GRP.add_argument(
     "-a",
     "--assignments",
-    help="one or more names of master repositories, referring either to local "
-    "directories or repos in the master organization",
+    help="one or more names of assignments",
     type=str,
     nargs="+",
     dest="assignments",

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -35,27 +35,27 @@ _HOOK_RESULTS_PARSER.add_argument(
 )
 _REPO_NAME_PARSER = argparse.ArgumentParser(add_help=False)
 _REPO_NAME_PARSER.add_argument(
-    "--mn",
-    "--master-repo-names",
+    "-a",
+    "--assignments",
     help="one or more names of master repositories, referring either to local "
     "directories or repos in the master organization",
     type=str,
     required=True,
     nargs="+",
-    dest="master_repo_names",
+    dest="assignments",
 )
 _REPO_DISCOVERY_PARSER = argparse.ArgumentParser(add_help=False)
 _DISCOVERY_MUTEX_GRP = _REPO_DISCOVERY_PARSER.add_mutually_exclusive_group(
     required=True
 )
 _DISCOVERY_MUTEX_GRP.add_argument(
-    "--mn",
-    "--master-repo-names",
+    "-a",
+    "--assignments",
     help="one or more names of master repositories, referring either to local "
     "directories or repos in the master organization",
     type=str,
     nargs="+",
-    dest="master_repo_names",
+    dest="assignments",
 )
 _DISCOVERY_MUTEX_GRP.add_argument(
     "--discover-repos",
@@ -502,7 +502,6 @@ def _add_issue_parsers(base_parsers, add_parser):
         help="show the body of the issue, alongside the default info",
     )
     list_parser.add_argument(
-        "-a",
         "--author",
         help="only show issues by this author",
         type=str,

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -153,15 +153,15 @@ def _process_args(
     repos = master_names = master_urls = None
     if "discover_repos" in args and args.discover_repos:
         repos = _discover_repos(args.students, api)
-    elif "master_repo_names" in args:
-        master_names = args.master_repo_names
+    elif "assignments" in args:
+        master_names = args.assignments
         master_urls = _repo_names_to_urls(master_names, master_org_name, api)
         repos = _repo_tuple_generator(master_names, args.students, api)
         assert master_urls and master_names
 
     args_dict = vars(args)
     args_dict["master_repo_urls"] = master_urls
-    args_dict["master_repo_names"] = master_names
+    args_dict["assignments"] = master_names
     args_dict["repos"] = repos
     # marker for functionality that relies on fully processed args
     args_dict["_repobee_processed"] = True
@@ -189,16 +189,16 @@ def _discover_repos(
 
 
 def _repo_tuple_generator(
-    master_repo_names: List[str],
+    assignment_names: List[str],
     teams: List[plug.StudentTeam],
     api: plug.PlatformAPI,
 ) -> Iterable[plug.StudentRepo]:
-    for master_repo_name in master_repo_names:
+    for assignment_name in assignment_names:
         for team in teams:
             url, *_ = api.get_repo_urls(
-                [master_repo_name], team_names=[team.name]
+                [assignment_name], team_names=[team.name]
             )
-            name = plug.generate_repo_name(team, master_repo_name)
+            name = plug.generate_repo_name(team, assignment_name)
             yield plug.StudentRepo(name=name, url=url, team=team)
 
 

--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -184,20 +184,20 @@ def _limit_line_length(s: str, max_line_length: int = 100) -> str:
 
 def open_issue(
     issue: plug.Issue,
-    master_repo_names: Iterable[str],
+    assignment_names: Iterable[str],
     teams: Iterable[plug.StudentTeam],
     api: plug.PlatformAPI,
 ) -> None:
     """Open an issue in student repos.
 
     Args:
-        master_repo_names: Names of master repositories.
+        assignment_names: Names of assignments.
         teams: Team objects specifying student groups.
         issue: An issue to open.
         api: An implementation of :py:class:`repobee_plug.PlatformAPI` used to
             interface with the platform (e.g. GitHub or GitLab) instance.
     """
-    repo_names = plug.generate_repo_names(teams, master_repo_names)
+    repo_names = plug.generate_repo_names(teams, assignment_names)
     repos = progresswrappers.get_repos(repo_names, api)
     for repo in repos:
         issue = api.create_issue(issue.title, issue.body, repo)
@@ -213,7 +213,7 @@ def close_issue(
 
     Args:
         title_regex: A regex to match against issue titles.
-        master_repo_names: Names of master repositories.
+        assignment_names: Names of assignments.
         teams: Team objects specifying student groups.
         api: An implementation of :py:class:`repobee_plug.PlatformAPI` used to
             interface with the platform (e.g. GitHub or GitLab) instance.

--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -342,7 +342,7 @@ class GitHubAPI(plug.PlatformAPI):
 
     def get_repo_urls(
         self,
-        master_repo_names: Iterable[str],
+        assignment_names: Iterable[str],
         org_name: Optional[str] = None,
         team_names: Optional[List[str]] = None,
         insert_auth: bool = False,
@@ -355,9 +355,9 @@ class GitHubAPI(plug.PlatformAPI):
                 else self._github.get_organization(org_name)
             )
         repo_names = (
-            master_repo_names
+            assignment_names
             if not team_names
-            else plug.generate_repo_names(team_names, master_repo_names)
+            else plug.generate_repo_names(team_names, assignment_names)
         )
         return [
             self.insert_auth(url) if insert_auth else url

--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -338,7 +338,7 @@ class GitLabAPI(plug.PlatformAPI):
 
     def get_repo_urls(
         self,
-        master_repo_names: Iterable[str],
+        assignment_names: Iterable[str],
         org_name: Optional[str] = None,
         team_names: Optional[List[str]] = None,
         insert_auth: bool = False,
@@ -347,13 +347,13 @@ class GitLabAPI(plug.PlatformAPI):
         group_name = org_name if org_name else self._group_name
         group_url = f"{self._base_url}/{group_name}"
         repo_urls = (
-            [f"{group_url}/{repo_name}.git" for repo_name in master_repo_names]
+            [f"{group_url}/{repo_name}.git" for repo_name in assignment_names]
             if not team_names
             else [
                 f"{group_url}/{team}/"
-                f"{plug.generate_repo_name(str(team), master_repo_name)}.git"
+                f"{plug.generate_repo_name(str(team), assignment_name)}.git"
                 for team in team_names
-                for master_repo_name in master_repo_names
+                for assignment_name in assignment_names
             ]
         )
         return (

--- a/src/_repobee/ext/query.py
+++ b/src/_repobee/ext/query.py
@@ -45,18 +45,16 @@ class Query(plug.Plugin, plug.cli.Command):
         )
         hook_results_mapping = plug.json_to_result_mapping(contents)
         selected_hook_results = _filter_hook_results(
-            hook_results_mapping,
-            self.args.students,
-            self.args.master_repo_names,
+            hook_results_mapping, self.args.students, self.args.assignments,
         )
         plug.echo(formatters.format_hook_results_output(selected_hook_results))
 
 
-def _filter_hook_results(hook_results_mapping, teams, master_repo_names):
+def _filter_hook_results(hook_results_mapping, teams, assignment_names):
     """Return an OrderedDict of hook result mappings for which the repo name is
     contained in the cross product of teams and master repo names.
     """
-    repo_names = set(plug.generate_repo_names(teams, master_repo_names))
+    repo_names = set(plug.generate_repo_names(teams, assignment_names))
     selected_hook_results = collections.OrderedDict()
     for repo_name, hook_results in sorted(hook_results_mapping.items()):
         if repo_name in repo_names:

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -93,9 +93,9 @@ class BaseParser(enum.Enum):
         STUDENTS: Represents the students parser, which includes the
             ``--students`` and `--students-file`` arguments.
         REPO_NAMES: Represents the repo names parser, which includes the
-            ``--master-repo-names`` argument.
+            ``--assignments`` argument.
         REPO_DISCOVERY: Represents the repo discovery parser, which adds
-            both the ``--master-repo-names`` and the ``--discover-repos``
+            both the ``--assignments`` and the ``--discover-repos``
             arguments.
         MASTER_ORG: Represents the master organization parser, which includes
             the ``--master-org`` argument.

--- a/src/repobee_plug/name.py
+++ b/src/repobee_plug/name.py
@@ -7,47 +7,47 @@ from typing import Iterable
 
 
 def generate_repo_names(
-    team_names: Iterable[str], master_repo_names: Iterable[str]
+    team_names: Iterable[str], assignment_names: Iterable[str]
 ) -> Iterable[str]:
     """Construct all combinations of generate_repo_name(team_name,
-    master_repo_name) for the provided team names and master repo names.
+    assignment_name) for the provided team names and master repo names.
 
     Args:
         team_names: One or more names of teams.
-        master_repo_names: One or more names of master repositories.
+        assignment_names: One or more names of assignments.
 
     Returns:
         a list of repo names for all combinations of team and master repo.
     """
-    master_repo_names = list(
-        master_repo_names
+    assignment_names = list(
+        assignment_names
     )  # needs to be traversed multiple times
     return [
         generate_repo_name(team_name, master_name)
-        for master_name in master_repo_names
+        for master_name in assignment_names
         for team_name in team_names
     ]
 
 
-def generate_repo_name(team_name: str, master_repo_name: str) -> str:
+def generate_repo_name(team_name: str, assignment_name: str) -> str:
     """Construct a repo name for a team.
 
     Args:
         team_name: Name of the associated team.
-        master_repo_name: Name of the template repository.
+        assignment_name: Name of an assignment.
     """
-    return "{}-{}".format(team_name, master_repo_name)
+    return "{}-{}".format(team_name, assignment_name)
 
 
-def generate_review_team_name(student: str, master_repo_name: str) -> str:
+def generate_review_team_name(student: str, assignment_name: str) -> str:
     """Generate a review team name.
 
     Args:
         student: A student username.
-        master_repo_name: Name of a master repository.
+        assignment_name: Name of an assignment.
 
     Returns:
         a review team name for the student repo associated with this master
         repo and student.
     """
-    return generate_repo_name(student, master_repo_name) + "-review"
+    return generate_repo_name(student, assignment_name) + "-review"

--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -351,7 +351,7 @@ class _APISpec:
 
     def get_repo_urls(
         self,
-        master_repo_names: Iterable[str],
+        assignment_names: Iterable[str],
         org_name: Optional[str] = None,
         team_names: Optional[List[str]] = None,
         insert_auth: bool = False,
@@ -369,7 +369,7 @@ class _APISpec:
         computed instead of master repo urls.
 
         Args:
-            master_repo_names: A list of master repository names.
+            assignment_names: A list of master repository names.
             org_name: Organization in which repos are expected. Defaults to the
                 target organization of the API instance.
             team_names: A list of team names specifying student groups.

--- a/src/repobee_testhelpers/fixtures.py
+++ b/src/repobee_testhelpers/fixtures.py
@@ -49,7 +49,7 @@ def platform_url(platform_dir):
 @pytest.fixture
 def with_student_repos(platform_url):
     funcs.run_repobee(
-        f"repos setup --mn {TEMPLATE_REPOS_ARG} "
+        f"repos setup -a {TEMPLATE_REPOS_ARG} "
         f"--students-file {STUDENTS_FILE} "
         f"--base-url {platform_url} "
         f"--user {TEACHER} "

--- a/src/repobee_testhelpers/localapi.py
+++ b/src/repobee_testhelpers/localapi.py
@@ -252,7 +252,7 @@ class LocalAPI(plug.PlatformAPI):
 
     def get_repo_urls(
         self,
-        master_repo_names: Iterable[str],
+        assignment_names: Iterable[str],
         org_name: Optional[str] = None,
         team_names: Optional[List[str]] = None,
         insert_auth: bool = False,
@@ -260,9 +260,9 @@ class LocalAPI(plug.PlatformAPI):
         assert not insert_auth, "not yet implemented"
         base = self._repodir / (org_name or self._org_name)
         repo_names = (
-            master_repo_names
+            assignment_names
             if not team_names
-            else plug.generate_repo_names(team_names, master_repo_names)
+            else plug.generate_repo_names(team_names, assignment_names)
         )
         return [(base / name).as_uri() for name in repo_names]
 

--- a/tests/integration_tests/_helpers/asserts.py
+++ b/tests/integration_tests/_helpers/asserts.py
@@ -15,17 +15,17 @@ from .const import (
 from .helpers import gitlab_and_groups, hash_directory
 
 
-def assert_master_repos_exist(master_repo_names, org_name):
-    """Assert that the master repos are in the specified group."""
+def assert_template_repos_exist(assignment_names, org_name):
+    """Assert that the template repos are in the specified group."""
     gl, *_ = gitlab_and_groups()
     group = gl.groups.list(search=org_name)[0]
     actual_repo_names = [g.name for g in group.projects.list(all=True)]
-    assert sorted(actual_repo_names) == sorted(master_repo_names)
+    assert sorted(actual_repo_names) == sorted(assignment_names)
 
 
-def assert_repos_exist(student_teams, master_repo_names, org_name=ORG_NAME):
+def assert_repos_exist(student_teams, assignment_names, org_name=ORG_NAME):
     """Assert that the associated student repos exist."""
-    repo_names = plug.generate_repo_names(student_teams, master_repo_names)
+    repo_names = plug.generate_repo_names(student_teams, assignment_names)
     gl = gitlab.Gitlab(LOCAL_BASE_URL, private_token=TOKEN, ssl_verify=False)
     target_group = gl.groups.list(search=ORG_NAME)[0]
     student_groups = gl.groups.list(id=target_group.id)
@@ -37,10 +37,10 @@ def assert_repos_exist(student_teams, master_repo_names, org_name=ORG_NAME):
 
 
 def assert_repos_contain(
-    student_teams, master_repo_names, filename, text, org=ORG_NAME
+    student_teams, assignment_names, filename, text, org=ORG_NAME
 ):
     """Assert that each of the student repos contain the given file."""
-    repo_names = plug.generate_repo_names(student_teams, master_repo_names)
+    repo_names = plug.generate_repo_names(student_teams, assignment_names)
     gl = gitlab.Gitlab(LOCAL_BASE_URL, private_token=TOKEN, ssl_verify=False)
     target_group = gl.groups.list(search=ORG_NAME)[0]
     student_groups = gl.groups.list(id=target_group.id)
@@ -110,12 +110,12 @@ def assert_on_groups(
             single_group_assertion(expected=team, actual=group)
 
 
-def _assert_on_projects(student_teams, master_repo_names, assertion):
+def _assert_on_projects(student_teams, assignment_names, assertion):
     """Execute the specified assertion operation on a project. Assertion should
     be a callable taking precisely on project as an argument.
     """
     gl = gitlab.Gitlab(LOCAL_BASE_URL, private_token=TOKEN, ssl_verify=False)
-    repo_names = plug.generate_repo_names(student_teams, master_repo_names)
+    repo_names = plug.generate_repo_names(student_teams, assignment_names)
     target_group = gl.groups.list(search=ORG_NAME)[0]
     student_groups = gl.groups.list(id=target_group.id)
     projects = [
@@ -131,7 +131,7 @@ def _assert_on_projects(student_teams, master_repo_names, assertion):
 
 def assert_issues_exist(
     student_teams,
-    master_repo_names,
+    assignment_names,
     expected_issue,
     expected_state="opened",
     expected_num_asignees=0,
@@ -156,10 +156,10 @@ def assert_issues_exist(
                 return
         assert False, "no issue matching the specified title"
 
-    _assert_on_projects(student_teams, master_repo_names, assertion)
+    _assert_on_projects(student_teams, assignment_names, assertion)
 
 
-def assert_num_issues(student_teams, master_repo_names, num_issues):
+def assert_num_issues(student_teams, assignment_names, num_issues):
     """Assert that there are precisely num_issues issues in each student
     repo.
     """
@@ -167,7 +167,7 @@ def assert_num_issues(student_teams, master_repo_names, num_issues):
     def assertion(project):
         assert len(project.issues.list(all=True)) == num_issues
 
-    _assert_on_projects(student_teams, master_repo_names, assertion)
+    _assert_on_projects(student_teams, assignment_names, assertion)
 
 
 def assert_cloned_repos(student_teams, template_repo_names, tmpdir):

--- a/tests/integration_tests/_helpers/const.py
+++ b/tests/integration_tests/_helpers/const.py
@@ -15,7 +15,7 @@ LOCAL_BASE_URL = "https://" + LOCAL_DOMAIN
 ORG_NAME = "dd1337-fall2020"
 MASTER_ORG_NAME = "dd1337-master"
 TEACHER = "ric"
-MASTER_REPO_NAMES = [
+assignment_names = [
     p.name
     for p in (DIR.parent / "dd1337-master-repos").iterdir()
     if p.is_dir()
@@ -25,12 +25,12 @@ STUDENT_TEAMS = [
     for s in (DIR.parent / "students.txt").read_text().strip().split("\n")
 ]
 STUDENT_TEAM_NAMES = [str(t) for t in STUDENT_TEAMS]
-STUDENT_REPO_NAMES = plug.generate_repo_names(STUDENT_TEAMS, MASTER_REPO_NAMES)
+STUDENT_REPO_NAMES = plug.generate_repo_names(STUDENT_TEAMS, assignment_names)
 REPOBEE_GITLAB = "repobee -p gitlab"
 BASE_ARGS_NO_TB = ["--bu", BASE_URL, "-o", ORG_NAME, "-t", TOKEN]
 BASE_ARGS = [*BASE_ARGS_NO_TB, "--tb"]
 STUDENTS_ARG = ["-s", " ".join(STUDENT_TEAM_NAMES)]
-MASTER_REPOS_ARG = ["--mn", " ".join(MASTER_REPO_NAMES)]
+MASTER_REPOS_ARG = ["-a", " ".join(assignment_names)]
 MASTER_ORG_ARG = ["--mo", MASTER_ORG_NAME]
 TASK_CONTENTS_SHAS = {
     "task-1": b"\xb0\xb0,t\xd1\xe9a bu\xdfX\xcf,\x98\xd2\x04\x1a\xe8\x88",

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -23,7 +23,7 @@ from _helpers.const import (
     MASTER_REPOS_ARG,
     STUDENTS_ARG,
     STUDENT_TEAMS,
-    MASTER_REPO_NAMES,
+    assignment_names,
     LOCAL_BASE_URL,
     TOKEN,
     ORG_NAME,
@@ -134,7 +134,7 @@ def with_student_repos(restore):
 
     # pre-test asserts
     assert result.returncode == 0
-    assert_repos_exist(STUDENT_TEAMS, MASTER_REPO_NAMES)
+    assert_repos_exist(STUDENT_TEAMS, assignment_names)
     assert_on_groups(STUDENT_TEAMS)
 
 
@@ -164,23 +164,21 @@ def open_issues(with_student_repos):
             )
         )
 
-    assert_num_issues(STUDENT_TEAM_NAMES, MASTER_REPO_NAMES, len(issues))
-    assert_issues_exist(STUDENT_TEAM_NAMES, MASTER_REPO_NAMES, task_issue)
-    assert_issues_exist(
-        STUDENT_TEAM_NAMES, MASTER_REPO_NAMES, correction_issue
-    )
+    assert_num_issues(STUDENT_TEAM_NAMES, assignment_names, len(issues))
+    assert_issues_exist(STUDENT_TEAM_NAMES, assignment_names, task_issue)
+    assert_issues_exist(STUDENT_TEAM_NAMES, assignment_names, correction_issue)
 
     return issues
 
 
 @pytest.fixture
 def with_reviews(with_student_repos):
-    master_repo_name = MASTER_REPO_NAMES[1]
+    assignment_name = assignment_names[1]
     expected_review_teams = [
         plug.StudentTeam(
             members=[],
             name=plug.generate_review_team_name(
-                student_team_name, master_repo_name
+                student_team_name, assignment_name
             ),
         )
         for student_team_name in STUDENT_TEAM_NAMES
@@ -190,8 +188,8 @@ def with_reviews(with_student_repos):
             REPOBEE_GITLAB,
             *str(repobee_plug.cli.CoreCommand.reviews.assign).split(),
             *BASE_ARGS,
-            "--mn",
-            master_repo_name,
+            "-a",
+            assignment_name,
             *STUDENTS_ARG,
             "-n",
             "1",
@@ -205,4 +203,4 @@ def with_reviews(with_student_repos):
         expected_review_teams,
         single_group_assertion=expected_num_members_group_assertion(1),
     )
-    return (master_repo_name, expected_review_teams)
+    return (assignment_name, expected_review_teams)

--- a/tests/integration_tests/integration_tests.py
+++ b/tests/integration_tests/integration_tests.py
@@ -13,7 +13,7 @@ import _repobee.cli.mainparser
 import repobee_plug.cli
 
 from _helpers.asserts import (
-    assert_master_repos_exist,
+    assert_template_repos_exist,
     assert_repos_exist,
     assert_repos_contain,
     assert_on_groups,
@@ -322,7 +322,7 @@ class TestMigrate:
         result = run_in_docker_with_coverage(command, extra_args=extra_args)
 
         assert result.returncode == 0
-        assert_master_repos_exist(local_master_repos, ORG_NAME)
+        assert_template_repos_exist(local_master_repos, ORG_NAME)
 
 
 @pytest.mark.filterwarnings("ignore:.*Unverified HTTPS request.*")

--- a/tests/new_integration_tests/test_issues.py
+++ b/tests/new_integration_tests/test_issues.py
@@ -32,7 +32,7 @@ class TestOpen:
         )
 
         funcs.run_repobee(
-            f"issues open --master-repo-names {const.TEMPLATE_REPOS_ARG} "
+            f"issues open --assignments {const.TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url} "
             f"--issue {issue.path} "
         )
@@ -75,7 +75,7 @@ class TestClose:
             for issue in [open_issue, issue_to_close]:
                 funcs.run_repobee(
                     f"issues open "
-                    f"--master-repo-names {const.TEMPLATE_REPOS_ARG} "
+                    f"--assignments {const.TEMPLATE_REPOS_ARG} "
                     f"--base-url {platform_url} "
                     f"--issue {issue.path}"
                 )
@@ -84,7 +84,7 @@ class TestClose:
             funcs.run_repobee(
                 [
                     *f"issues close --base-url {platform_url} "
-                    f"--master-repo-names {const.TEMPLATE_REPOS_ARG} ".split(),
+                    f"--assignments {const.TEMPLATE_REPOS_ARG} ".split(),
                     "--title-regex",
                     issue_to_close_title,
                 ]

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -78,7 +78,7 @@ class TestSetup:
     def test_setup_single_template_repo(self, platform_dir, platform_url):
         template_repo_name = TEMPLATE_REPO_NAMES[0]
         funcs.run_repobee(
-            f"repos setup --mn {template_repo_name} "
+            f"repos setup -a {template_repo_name} "
             f"--base-url {platform_url}"
         )
 
@@ -88,7 +88,7 @@ class TestSetup:
 
     def test_setup_multiple_template_repos(self, platform_dir, platform_url):
         funcs.run_repobee(
-            f"repos setup --mn {TEMPLATE_REPOS_ARG} "
+            f"repos setup -a {TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url}"
         )
 
@@ -104,7 +104,7 @@ class TestSetup:
         """
         for _ in range(2):
             funcs.run_repobee(
-                f"repos setup --mn {TEMPLATE_REPOS_ARG} "
+                f"repos setup -a {TEMPLATE_REPOS_ARG} "
                 f"--base-url {platform_url} "
             )
 
@@ -126,7 +126,7 @@ class TestSetup:
                 assert repo.path.exists
 
         funcs.run_repobee(
-            f"repos setup --mn {TEMPLATE_REPOS_ARG} "
+            f"repos setup -a {TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url}",
             plugins=[PreSetupPlugin],
         )
@@ -141,7 +141,7 @@ class TestClone:
         with tempfile.TemporaryDirectory() as tmp:
             workdir = pathlib.Path(tmp)
             funcs.run_repobee(
-                f"repos clone --mn {TEMPLATE_REPOS_ARG} "
+                f"repos clone -a {TEMPLATE_REPOS_ARG} "
                 f"--base-url {platform_url}",
                 workdir=workdir,
             )
@@ -181,7 +181,7 @@ class TestClone:
                 assert repo.path.is_dir()
 
         funcs.run_repobee(
-            f"repos clone --mn {TEMPLATE_REPOS_ARG} "
+            f"repos clone -a {TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url}",
             plugins=[PostClonePlugin],
         )

--- a/tests/new_integration_tests/test_reviews.py
+++ b/tests/new_integration_tests/test_reviews.py
@@ -21,7 +21,7 @@ class TestAssign:
 
         funcs.run_repobee(
             f"reviews assign -n 1 --base-url {platform_url} "
-            f"--master-repo-names {const.TEMPLATE_REPOS_ARG}",
+            f"--assignments {const.TEMPLATE_REPOS_ARG}",
         )
 
         review_teams = [
@@ -45,12 +45,12 @@ class TestEnd:
         }
         funcs.run_repobee(
             f"reviews assign -n 1 --base-url {platform_url} "
-            f"--master-repo-names {const.TEMPLATE_REPOS_ARG}",
+            f"--assignments {const.TEMPLATE_REPOS_ARG}",
         )
 
         funcs.run_repobee(
             f"reviews end --base-url {platform_url} "
-            f"--master-repo-names {const.TEMPLATE_REPOS_ARG}"
+            f"--assignments {const.TEMPLATE_REPOS_ARG}"
         )
 
         platform_teams = funcs.get_teams(platform_url, const.TARGET_ORG_NAME)
@@ -71,13 +71,13 @@ class TestCheck:
         template_repo_name = const.TEMPLATE_REPO_NAMES[0]
         funcs.run_repobee(
             f"reviews assign -n 1 --base-url {platform_url} "
-            f"--master-repo-names {template_repo_name}",
+            f"--assignments {template_repo_name}",
         )
 
         funcs.run_repobee(
             [
                 *f"reviews check -n 1 --base-url {platform_url} "
-                f"--master-repo-names {const.TEMPLATE_REPOS_ARG} ".split(),
+                f"--assignments {const.TEMPLATE_REPOS_ARG} ".split(),
                 "--title-regex",
                 "Peer review",
             ]

--- a/tests/unit_tests/repobee/conftest.py
+++ b/tests/unit_tests/repobee/conftest.py
@@ -37,15 +37,15 @@ class DummyAPI(plug.PlatformAPI):
 
     def get_repo_urls(
         self,
-        master_repo_names: Iterable[str],
+        assignment_names: Iterable[str],
         org_name: Optional[str] = None,
         team_names: Optional[List[str]] = None,
         insert_auth: bool = False,
     ) -> List[str]:
         repo_names = (
-            master_repo_names
+            assignment_names
             if not team_names
-            else plug.generate_repo_names(team_names, master_repo_names)
+            else plug.generate_repo_names(team_names, assignment_names)
         )
         return [
             f"{constants.HOST_URL}/{org_name or self.org_name}/{repo_name}"

--- a/tests/unit_tests/repobee/plugin_tests/test_github.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_github.py
@@ -355,18 +355,18 @@ class TestGetRepoUrls:
         students.
         """
         students = list(constants.STUDENTS)
-        master_repo_names = [repo.name for repo in repos]
+        assignment_names = [repo.name for repo in repos]
         expected_repo_names = plug.generate_repo_names(
-            students, master_repo_names
+            students, assignment_names
         )
         # assume works correctly when called with just repo names
         expected_urls = api.get_repo_urls(expected_repo_names)
 
         actual_urls = api.get_repo_urls(
-            master_repo_names, team_names=[t.name for t in students]
+            assignment_names, team_names=[t.name for t in students]
         )
 
-        assert len(actual_urls) == len(students) * len(master_repo_names)
+        assert len(actual_urls) == len(students) * len(assignment_names)
         assert sorted(expected_urls) == sorted(actual_urls)
 
 

--- a/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
@@ -308,13 +308,13 @@ class TestInit:
 
 
 @pytest.fixture
-def master_repo_names():
+def assignment_names():
     return ["task-1", "task-2", "task-3"]
 
 
 class TestGetRepoUrls:
-    def test_get_master_repo_urls(self, master_repo_names):
-        """When supplied with only master_repo_names, get_repo_urls should
+    def test_get_master_repo_urls(self, assignment_names):
+        """When supplied with only assignment_names, get_repo_urls should
         return urls for those master repos, expecting them to be in the target
         group.
         """
@@ -322,20 +322,20 @@ class TestGetRepoUrls:
         api = _repobee.ext.gitlab.GitLabAPI(BASE_URL, TOKEN, TARGET_GROUP)
         expected_urls = [
             api._insert_auth("{}/{}/{}.git".format(BASE_URL, TARGET_GROUP, mn))
-            for mn in master_repo_names
+            for mn in assignment_names
         ]
         assert (
             expected_urls
         ), "there must be at least some urls for this test to make sense"
 
         # act
-        actual_urls = api.get_repo_urls(master_repo_names, insert_auth=True)
+        actual_urls = api.get_repo_urls(assignment_names, insert_auth=True)
 
         # assert
         assert sorted(actual_urls) == sorted(expected_urls)
 
-    def test_get_master_repo_urls_in_master_group(self, master_repo_names):
-        """When supplied with master_repo_names and org_name, the urls
+    def test_get_master_repo_urls_in_master_group(self, assignment_names):
+        """When supplied with assignment_names and org_name, the urls
         generated should go to the group named org_name instead of the default
         target group.
         """
@@ -344,7 +344,7 @@ class TestGetRepoUrls:
         api = _repobee.ext.gitlab.GitLabAPI(BASE_URL, TOKEN, TARGET_GROUP)
         expected_urls = [
             api._insert_auth("{}/{}/{}.git".format(BASE_URL, master_group, mn))
-            for mn in master_repo_names
+            for mn in assignment_names
         ]
         assert (
             expected_urls
@@ -352,13 +352,13 @@ class TestGetRepoUrls:
 
         # act
         actual_urls = api.get_repo_urls(
-            master_repo_names, org_name=master_group, insert_auth=True
+            assignment_names, org_name=master_group, insert_auth=True
         )
 
         # assert
         assert sorted(actual_urls) == sorted(expected_urls)
 
-    def test_get_student_repo_urls(self, master_repo_names):
+    def test_get_student_repo_urls(self, assignment_names):
         """When supplied with the students argument, the generated urls should
         go to the student repos related to the supplied master repos.
         """
@@ -374,7 +374,7 @@ class TestGetRepoUrls:
                 )
             )
             for student_group in constants.STUDENTS
-            for mn in master_repo_names
+            for mn in assignment_names
         ]
         assert (
             expected_urls
@@ -382,7 +382,7 @@ class TestGetRepoUrls:
 
         # act
         actual_urls = api.get_repo_urls(
-            master_repo_names,
+            assignment_names,
             team_names=[t.name for t in constants.STUDENTS],
             insert_auth=True,
         )

--- a/tests/unit_tests/repobee/test_main.py
+++ b/tests/unit_tests/repobee/test_main.py
@@ -30,7 +30,7 @@ VALID_PARSED_ARGS = dict(
     base_url=BASE_URL,
     user=USER,
     master_repo_urls="url-1 url-2 url-3".split(),
-    master_repo_names="1 2 3".split(),
+    assignements="1 2 3".split(),
     students=constants.STUDENTS,
     issue=constants.ISSUE,
     title_regex="some regex",
@@ -41,7 +41,7 @@ PARSED_ARGS = argparse.Namespace(
     **repobee_plug.cli.CoreCommand.repos.setup.asdict(), **VALID_PARSED_ARGS
 )
 
-CLONE_ARGS = "clone --mn week-2 -s slarse".split()
+CLONE_ARGS = "clone -a week-2 -s slarse".split()
 
 module = namedtuple("module", ("name",))
 

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -51,7 +51,7 @@ class TestPluginInheritance:
 
             def generate_review_allocations(
                 self,
-                master_repo_name,
+                assignment_name,
                 students,
                 num_reviews,
                 review_team_name_function,
@@ -84,7 +84,7 @@ class TestPluginInheritance:
 
             def generate_review_allocations(
                 self,
-                master_repo_name,
+                assignment_name,
                 students,
                 num_reviews,
                 review_team_name_function,


### PR DESCRIPTION
#437 

Renames master repo names to assignments or assignment names, depending on the context.

### Breaking changes
* The `--mn|--master-repo-names` CLI argument is replaced with `-a|--assignments`
* The `master_repo_names` argument to `PlatformAPI.get_repo_urls` is renamed to `assignment_names`