### PR TITLE
[break] Rename "master org name" to "template org name"

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -42,7 +42,7 @@ consequence, a single organization).
     base_url = https://some-api-v3-url
     user = YOUR_USERNAME
     org_name = ORGANIZATION_NAME
-    master_org_name = TEMPLATE_ORGANIZATION_NAME
+    template_org_name = TEMPLATE_ORGANIZATION_NAME
     students_file = STUDENTS_FILE_ABSOLUTE_PATH
     token = SUPER_SECRET_TOKEN
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -42,7 +42,7 @@ consequence, a single organization).
     base_url = https://some-api-v3-url
     user = YOUR_USERNAME
     org_name = ORGANIZATION_NAME
-    master_org_name = MASTER_ORGANIZATION_NAME
+    master_org_name = TEMPLATE_ORGANIZATION_NAME
     students_file = STUDENTS_FILE_ABSOLUTE_PATH
     token = SUPER_SECRET_TOKEN
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -80,7 +80,7 @@ has defaults for at least the following:
    base_url = https://some-enterprise-host/api/v3
    user = slarse
    org_name = repobee-demo
-   master_org_name = master-repos
+   template_org_name = master-repos
    token = SUPER_SECRET_TOKEN
 
 Now, run ``repobee config-wizard`` and enter your own values for the options
@@ -95,7 +95,7 @@ value. Here are some pointers regarding the different values:
 * Replace ``slarse`` with your GitHub username.
 * Replace ``repobee-demo`` with whatever you named your target organization.
 * Replace ``SUPER_SECRET_TOKEN`` with your access token.
-* Replace ``master_org_name`` with the name of the organization with your master repos.
+* Replace ``template_org_name`` with the name of the organization with your master repos.
     - It you keep the master repos in the target organization or locally, **skip
       this option**.
 * **If you are using GitLab**:
@@ -117,7 +117,7 @@ that you got everything correctly.
     base_url = https://some-enterprise-host/api/v3
     user = slarse
     org_name = repobee-demo
-    master_org_name = master-repos
+    template_org_name = master-repos
     token = SUPER_SECRET_TOKEN
     -----------------END CONFIG FILE------------------
 
@@ -162,7 +162,7 @@ Set up master repos
 How you do this will depend on where you want to have your master repos. I
 recommend having a separate, persistent organization so that you can work on
 repos across course rounds. If you already have a master organization with your
-master repos set up somewhere, and ``master_org_name`` is specified in the
+master repos set up somewhere, and ``template_org_name`` is specified in the
 config, you're good to go. If you need to migrate repos into the target
 organization (e.g. if you keep master repos in the target organization), see
 the :ref:`migrate` section. For all commands but the ``migrate`` command, the

--- a/docs/gitlab.rst
+++ b/docs/gitlab.rst
@@ -54,7 +54,7 @@ differences between GitHub and GitLab that the user should be aware of.
   and not to any specific endpoint (as is the case when using GitHub). When
   using ``github.com`` for example, the url should be provided as
   ``base_url = https://gitlab.com`` in the config.
-* The ``org-name`` and ``master-org-name`` arguments should be given the *path*
+* The ``org-name`` and ``template-org-name`` arguments should be given the *path*
   of the respective groups. If you create a group with a long name, GitLab may
   shorten the path automatically. For example, I created the group
   ``repobee-master-repos``, and it got the path ``repobee-master``. You can find

--- a/docs/migrate.rst
+++ b/docs/migrate.rst
@@ -1,10 +1,10 @@
 .. _migrate:
 
-Migrate repositories into the target (or master) organization (``migrate`` command)
-***********************************************************************************
+Migrate repositories into the target (or template) organization (``migrate`` command)
+*************************************************************************************
 Migrating repositories into an organization can be useful in a few cases. You
 may have repos that should be accessible to students and need to be moved
-across course rounds, or you might be storing your master repos in the target
+across course rounds, or you might be storing your template repos in the target
 organization and need to migrate them for each new course round. To migrate
 repos into the target organization, they must be local on disc. Assuming we
 have the repos ``task-1`` and ``task-2`` in the current working
@@ -33,7 +33,7 @@ directory (i.e. local repos), all we have to do is this:
 
     If you want to use this command to migrate repos into a master organization,
     you must specify it with the ``--org-name`` option here (instead of the
-    ``--master-org-name``).
+    ``--template-org-name``).
 
 What happens here is pretty straightforward, except for the local repos being
 cloned, which is an implementation detail that does not need to be thought

--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -125,7 +125,7 @@ def _dispatch_config_command(
             args.org_name,
             args.base_url,
             args.token,
-            args.master_org_name,
+            args.template_org_name,
         )
         return None
     elif action == config.show:

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -635,7 +635,7 @@ def _add_extension_parsers(
             parents.append(base_parser)
         if bp.STUDENTS in req_parsers:
             parents.append(base_student_parser)
-        if bp.MASTER_ORG in req_parsers:
+        if bp.TEMPLATE_ORG in req_parsers:
             parents.append(master_org_parser)
 
         if bp.REPO_DISCOVERY in req_parsers:

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -145,9 +145,11 @@ def _add_subparsers(parser, show_all_opts, config_file):
     `base_` prefixed parser, of course).
     """
 
-    base_parser, base_student_parser, master_org_parser = _create_base_parsers(
-        show_all_opts, config_file
-    )
+    (
+        base_parser,
+        base_student_parser,
+        template_org_parser,
+    ) = _create_base_parsers(show_all_opts, config_file)
 
     subparsers = parser.add_subparsers(dest=CATEGORY)
     subparsers.required = True
@@ -203,13 +205,13 @@ def _add_subparsers(parser, show_all_opts, config_file):
     _add_repo_parsers(
         base_parser,
         base_student_parser,
-        master_org_parser,
+        template_org_parser,
         _add_action_parser(repo_parsers),
     )
     _add_teams_parsers(
         base_parser,
         base_student_parser,
-        master_org_parser,
+        template_org_parser,
         _add_action_parser(teams_parsers),
     )
     _add_issue_parsers(
@@ -221,14 +223,14 @@ def _add_subparsers(parser, show_all_opts, config_file):
         _add_action_parser(review_parsers),
     )
     _add_config_parsers(
-        base_parser, master_org_parser, _add_action_parser(config_parsers)
+        base_parser, template_org_parser, _add_action_parser(config_parsers)
     )
 
     _add_extension_parsers(
         subparsers,
         base_parser,
         base_student_parser,
-        master_org_parser,
+        template_org_parser,
         _REPO_NAME_PARSER,
         parsers,
         config._read_config(config_file) if config_file.is_file() else {},
@@ -237,7 +239,7 @@ def _add_subparsers(parser, show_all_opts, config_file):
 
 
 def _add_repo_parsers(
-    base_parser, base_student_parser, master_org_parser, add_parser
+    base_parser, base_student_parser, template_org_parser, add_parser
 ):
     add_parser(
         plug.cli.CoreCommand.repos.setup,
@@ -254,7 +256,7 @@ def _add_repo_parsers(
         parents=[
             base_parser,
             base_student_parser,
-            master_org_parser,
+            template_org_parser,
             _REPO_NAME_PARSER,
             _HOOK_RESULTS_PARSER,
         ],
@@ -273,7 +275,7 @@ def _add_repo_parsers(
         parents=[
             base_parser,
             base_student_parser,
-            master_org_parser,
+            template_org_parser,
             _REPO_NAME_PARSER,
         ],
         formatter_class=_OrderedFormatter,
@@ -313,7 +315,7 @@ def _add_repo_parsers(
 
 
 def _add_teams_parsers(
-    base_parser, base_student_parser, master_org_parser, add_parser
+    base_parser, base_student_parser, template_org_parser, add_parser
 ):
 
     add_parser(
@@ -331,7 +333,7 @@ def _add_teams_parsers(
     )
 
 
-def _add_config_parsers(base_parser, master_org_parser, add_parser):
+def _add_config_parsers(base_parser, template_org_parser, add_parser):
     show_config = add_parser(
         plug.cli.CoreCommand.config.show,
         help="show the configuration file",
@@ -348,7 +350,7 @@ def _add_config_parsers(base_parser, master_org_parser, add_parser):
         plug.cli.CoreCommand.config.verify,
         help="verify core settings",
         description="Verify core settings by trying various API requests.",
-        parents=[base_parser, master_org_parser],
+        parents=[base_parser, template_org_parser],
         formatter_class=_OrderedFormatter,
     )
 
@@ -435,7 +437,7 @@ def _add_peer_review_parsers(base_parsers, add_parser):
 
 
 def _add_issue_parsers(base_parsers, add_parser):
-    base_parser, base_student_parser, master_org_parser = base_parsers
+    base_parser, base_student_parser, template_org_parser = base_parsers
     open_parser = add_parser(
         plug.cli.CoreCommand.issues.open,
         description=(
@@ -579,7 +581,7 @@ def _add_extension_parsers(
     subparsers,
     base_parser,
     base_student_parser,
-    master_org_parser,
+    template_org_parser,
     repo_name_parser,
     parsers_mapping,
     parsed_config,
@@ -636,7 +638,7 @@ def _add_extension_parsers(
         if bp.STUDENTS in req_parsers:
             parents.append(base_student_parser)
         if bp.TEMPLATE_ORG in req_parsers:
-            parents.append(master_org_parser)
+            parents.append(template_org_parser)
 
         if bp.REPO_DISCOVERY in req_parsers:
             parents.append(_REPO_DISCOVERY_PARSER)
@@ -780,9 +782,9 @@ def _create_base_parsers(show_all_opts, config_file):
             "each line to form groups."
         )
     )
-    master_org_help = (
+    template_org_help = (
         argparse.SUPPRESS
-        if hide_configurable_arg("master_org_name")
+        if hide_configurable_arg("template_org_name")
         else (
             "Name of the organization containing the master repos. "
             "Defaults to the same value as `-o|--org-name` if left "
@@ -849,16 +851,16 @@ def _create_base_parsers(show_all_opts, config_file):
         nargs="+",
     )
 
-    master_org_parser = argparse.ArgumentParser(add_help=False)
-    master_org_parser.add_argument(
+    template_org_parser = argparse.ArgumentParser(add_help=False)
+    template_org_parser.add_argument(
         "--mo",
         "--master-org-name",
-        help=master_org_help,
-        default=default("master_org_name"),
-        dest="master_org_name",
+        help=template_org_help,
+        default=default("template_org_name"),
+        dest="template_org_name",
     )
 
-    return (base_parser, base_student_parser, master_org_parser)
+    return (base_parser, base_student_parser, template_org_parser)
 
 
 def _add_traceback_arg(parser):

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -637,7 +637,7 @@ def _add_extension_parsers(
             parents.append(base_parser)
         if bp.STUDENTS in req_parsers:
             parents.append(base_student_parser)
-        if bp.TEMPLATE_ORG in req_parsers:
+        if bp.MASTER_ORG in req_parsers:
             parents.append(template_org_parser)
 
         if bp.REPO_DISCOVERY in req_parsers:

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -786,7 +786,7 @@ def _create_base_parsers(show_all_opts, config_file):
         argparse.SUPPRESS
         if hide_configurable_arg("template_org_name")
         else (
-            "Name of the organization containing the master repos. "
+            "Name of the organization containing the template repos. "
             "Defaults to the same value as `-o|--org-name` if left "
             "unspecified. Note that config values take precedence "
             "over this default."
@@ -853,8 +853,8 @@ def _create_base_parsers(show_all_opts, config_file):
 
     template_org_parser = argparse.ArgumentParser(add_help=False)
     template_org_parser.add_argument(
-        "--mo",
-        "--master-org-name",
+        "--to",
+        "--template-org-name",
         help=template_org_help,
         default=default("template_org_name"),
         dest="template_org_name",

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -102,7 +102,7 @@ def _parse_args(
     args_dict["issue"] = (
         util.read_issue(args.issue) if "issue" in args and args.issue else None
     )
-    args_dict.setdefault("master_org_name", None)
+    args_dict.setdefault("template_org_name", None)
     args_dict.setdefault("title_regex", None)
     args_dict.setdefault("state", None)
     args_dict.setdefault("show_body", None)
@@ -146,16 +146,16 @@ def _process_args(
     """
     api = _connect_to_api(args.base_url, args.token, args.org_name, args.user)
 
-    master_org_name = args.org_name
-    if "master_org_name" in args and args.master_org_name is not None:
-        master_org_name = args.master_org_name
+    template_org_name = args.org_name
+    if "template_org_name" in args and args.template_org_name is not None:
+        template_org_name = args.template_org_name
 
     repos = master_names = master_urls = None
     if "discover_repos" in args and args.discover_repos:
         repos = _discover_repos(args.students, api)
     elif "assignments" in args:
         master_names = args.assignments
-        master_urls = _repo_names_to_urls(master_names, master_org_name, api)
+        master_urls = _repo_names_to_urls(master_names, template_org_name, api)
         repos = _repo_tuple_generator(master_names, args.students, api)
         assert master_urls and master_names
 

--- a/src/_repobee/constants.py
+++ b/src/_repobee/constants.py
@@ -31,7 +31,7 @@ ORDERED_CONFIGURABLE_ARGS = (
     "user",
     "base_url",
     "org_name",
-    "master_org_name",
+    "template_org_name",
     "token",
     "students_file",
     "plugins",

--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -411,7 +411,7 @@ class GitHubAPI(plug.PlatformAPI):
         org_name: str,
         base_url: str,
         token: str,
-        master_org_name: Optional[str] = None,
+        template_org_name: Optional[str] = None,
     ) -> None:
         """See :py:meth:`repobee_plug.PlatformAPI.verify_settings`."""
         plug.echo("Verifying settings ...")
@@ -462,8 +462,8 @@ class GitHubAPI(plug.PlatformAPI):
         plug.echo("SUCCESS: access token scopes look okay")
 
         GitHubAPI._verify_org(org_name, user, g)
-        if master_org_name:
-            GitHubAPI._verify_org(master_org_name, user, g)
+        if template_org_name:
+            GitHubAPI._verify_org(template_org_name, user, g)
 
         plug.echo("GREAT SUCCESS: all settings check out!")
 

--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -387,7 +387,7 @@ class GitLabAPI(plug.PlatformAPI):
         org_name: str,
         base_url: str,
         token: str,
-        master_org_name: Optional[str] = None,
+        template_org_name: Optional[str] = None,
     ):
         """See :py:meth:`repobee_plug.PlatformAPI.verify_settings`."""
         plug.echo("GitLabAPI is verifying settings ...")
@@ -417,8 +417,8 @@ class GitLabAPI(plug.PlatformAPI):
         )
 
         GitLabAPI._verify_group(org_name, gl)
-        if master_org_name:
-            GitLabAPI._verify_group(master_org_name, gl)
+        if template_org_name:
+            GitLabAPI._verify_group(template_org_name, gl)
 
         plug.echo("GREAT SUCCESS: All settings check out!")
 

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -105,7 +105,7 @@ class BaseParser(enum.Enum):
     STUDENTS = "students"
     REPO_NAMES = "repo-names"
     REPO_DISCOVERY = "repo-discovery"
-    TEMPLATE_ORG = "master-org"
+    MASTER_ORG = "master-org"
 
 
 class ImmutableMixin:

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -97,7 +97,7 @@ class BaseParser(enum.Enum):
         REPO_DISCOVERY: Represents the repo discovery parser, which adds
             both the ``--assignments`` and the ``--discover-repos``
             arguments.
-        MASTER_ORG: Represents the master organization parser, which includes
+        TEMPLATE_ORG: Represents the master organization parser, which includes
             the ``--master-org`` argument.
     """
 
@@ -105,7 +105,7 @@ class BaseParser(enum.Enum):
     STUDENTS = "students"
     REPO_NAMES = "repo-names"
     REPO_DISCOVERY = "repo-discovery"
-    MASTER_ORG = "master-org"
+    TEMPLATE_ORG = "master-org"
 
 
 class ImmutableMixin:

--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -394,7 +394,7 @@ class _APISpec:
         org_name: str,
         base_url: str,
         token: str,
-        master_org_name: Optional[str] = None,
+        template_org_name: Optional[str] = None,
     ):
         """Verify the following (to the extent that is possible and makes sense
         for the specific platform):
@@ -402,10 +402,10 @@ class _APISpec:
         1. Base url is correct
         2. The token has sufficient access privileges
         3. Target organization (specifiend by ``org_name``) exists
-            - If master_org_name is supplied, this is also checked to
+            - If template_org_name is supplied, this is also checked to
               exist.
         4. User is owner in organization (verify by getting
-            - If master_org_name is supplied, user is also checked to be an
+            - If template_org_name is supplied, user is also checked to be an
               owner of it.
         organization member list and checking roles)
 

--- a/src/repobee_testhelpers/fixtures.py
+++ b/src/repobee_testhelpers/fixtures.py
@@ -54,5 +54,5 @@ def with_student_repos(platform_url):
         f"--base-url {platform_url} "
         f"--user {TEACHER} "
         f"--org-name {TARGET_ORG_NAME} "
-        f"--master-org-name {TEMPLATE_ORG_NAME}"
+        f"--template-org-name {TEMPLATE_ORG_NAME}"
     )

--- a/src/repobee_testhelpers/funcs.py
+++ b/src/repobee_testhelpers/funcs.py
@@ -47,8 +47,8 @@ def run_repobee(
 
     This function will by default use a config file that sets appropriate
     values for ``students_file``, ``user``, ``org_name`` and
-    ``master_org_name`` for use with the :py:class:`~fakeapi.FakeAPI` platform
-    API. If you wish to use a different config, simply pass
+    ``template_org_name`` for use with the :py:class:`~fakeapi.FakeAPI`
+    platform API. If you wish to use a different config, simply pass
     ``config_file="/path/to/your/config"`` to the function, or
     ``config_file=""`` to not use a config file at all.
 
@@ -78,7 +78,7 @@ def run_repobee(
 students_file = {students_file}
 org_name = {const.TARGET_ORG_NAME}
 user = {const.TEACHER}
-master_org_name = {const.TEMPLATE_ORG_NAME}
+template_org_name = {const.TEMPLATE_ORG_NAME}
 token = {const.TOKEN}
 """
         )

--- a/src/repobee_testhelpers/localapi.py
+++ b/src/repobee_testhelpers/localapi.py
@@ -275,7 +275,7 @@ class LocalAPI(plug.PlatformAPI):
         org_name: str,
         base_url: str,
         token: str,
-        master_org_name: Optional[str] = None,
+        template_org_name: Optional[str] = None,
     ) -> None:
         pass
 

--- a/tests/integration_tests/README.md
+++ b/tests/integration_tests/README.md
@@ -86,8 +86,8 @@ Replace `<TOKEN>` with [this token](token).
 [repobee]
 base_url = https://gitlab.integrationtest.local
 token = <TOKEN>
-org_name = repobee-testing
-master_org_name = repobee-master
+org_name = dd1337-fall2020
+template_org_name = dd1337-master
 user = oauth2
 plugins = gitlab
 ```

--- a/tests/integration_tests/_helpers/const.py
+++ b/tests/integration_tests/_helpers/const.py
@@ -13,7 +13,7 @@ BASE_URL = "https://" + BASE_DOMAIN
 LOCAL_DOMAIN = "localhost:50443"
 LOCAL_BASE_URL = "https://" + LOCAL_DOMAIN
 ORG_NAME = "dd1337-fall2020"
-MASTER_ORG_NAME = "dd1337-master"
+TEMPLATE_ORG_NAME = "dd1337-master"
 TEACHER = "ric"
 assignment_names = [
     p.name
@@ -31,7 +31,7 @@ BASE_ARGS_NO_TB = ["--bu", BASE_URL, "-o", ORG_NAME, "-t", TOKEN]
 BASE_ARGS = [*BASE_ARGS_NO_TB, "--tb"]
 STUDENTS_ARG = ["-s", " ".join(STUDENT_TEAM_NAMES)]
 MASTER_REPOS_ARG = ["-a", " ".join(assignment_names)]
-MASTER_ORG_ARG = ["--mo", MASTER_ORG_NAME]
+TEMPLATE_ORG_ARG = ["--mo", TEMPLATE_ORG_NAME]
 TASK_CONTENTS_SHAS = {
     "task-1": b"\xb0\xb0,t\xd1\xe9a bu\xdfX\xcf,\x98\xd2\x04\x1a\xe8\x88",
     "task-2": b"\x1d\xdc\xa6A\xd7\xec\xdc\xc6FSN\x01\xdf|\x95`U\xb5\xdc\x9d",

--- a/tests/integration_tests/_helpers/const.py
+++ b/tests/integration_tests/_helpers/const.py
@@ -31,7 +31,7 @@ BASE_ARGS_NO_TB = ["--bu", BASE_URL, "-o", ORG_NAME, "-t", TOKEN]
 BASE_ARGS = [*BASE_ARGS_NO_TB, "--tb"]
 STUDENTS_ARG = ["-s", " ".join(STUDENT_TEAM_NAMES)]
 MASTER_REPOS_ARG = ["-a", " ".join(assignment_names)]
-TEMPLATE_ORG_ARG = ["--mo", TEMPLATE_ORG_NAME]
+TEMPLATE_ORG_ARG = ["--template-org-name", TEMPLATE_ORG_NAME]
 TASK_CONTENTS_SHAS = {
     "task-1": b"\xb0\xb0,t\xd1\xe9a bu\xdfX\xcf,\x98\xd2\x04\x1a\xe8\x88",
     "task-2": b"\x1d\xdc\xa6A\xd7\xec\xdc\xc6FSN\x01\xdf|\x95`U\xb5\xdc\x9d",

--- a/tests/integration_tests/_helpers/helpers.py
+++ b/tests/integration_tests/_helpers/helpers.py
@@ -13,7 +13,7 @@ from .const import (
     ORG_NAME,
     LOCAL_BASE_URL,
     TOKEN,
-    MASTER_ORG_NAME,
+    TEMPLATE_ORG_NAME,
     BASE_DOMAIN,
     LOCAL_DOMAIN,
     TEACHER,
@@ -30,7 +30,7 @@ def gitlab_and_groups():
     target group.
     """
     gl = gitlab.Gitlab(LOCAL_BASE_URL, private_token=TOKEN, ssl_verify=False)
-    master_group = gl.groups.list(search=MASTER_ORG_NAME)[0]
+    master_group = gl.groups.list(search=TEMPLATE_ORG_NAME)[0]
     target_group = gl.groups.list(search=ORG_NAME)[0]
     return gl, master_group, target_group
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -19,7 +19,7 @@ from _helpers.const import (
     COVERAGE_VOLUME_DST,
     REPOBEE_GITLAB,
     BASE_ARGS,
-    MASTER_ORG_ARG,
+    TEMPLATE_ORG_ARG,
     MASTER_REPOS_ARG,
     STUDENTS_ARG,
     STUDENT_TEAMS,
@@ -124,7 +124,7 @@ def with_student_repos(restore):
             REPOBEE_GITLAB,
             *str(repobee_plug.cli.CoreCommand.repos.setup).split(),
             *BASE_ARGS,
-            *MASTER_ORG_ARG,
+            *TEMPLATE_ORG_ARG,
             *MASTER_REPOS_ARG,
             *STUDENTS_ARG,
         ]

--- a/tests/integration_tests/gitlabmanager.py
+++ b/tests/integration_tests/gitlabmanager.py
@@ -10,7 +10,7 @@ from typing import List
 import gitlab
 
 from _helpers.const import (
-    MASTER_ORG_NAME,
+    TEMPLATE_ORG_NAME,
     ORG_NAME,
     TEACHER,
     STUDENT_TEAM_NAMES,
@@ -92,7 +92,7 @@ def restore():
     create_groups_and_projects(
         local_master_repos=LOCAL_MASTER_REPOS,
         teacher=TEACHER,
-        master_group_name=MASTER_ORG_NAME,
+        master_group_name=TEMPLATE_ORG_NAME,
         course_round_group_name=ORG_NAME,
         token=TOKEN,
     )

--- a/tests/integration_tests/integration_tests.py
+++ b/tests/integration_tests/integration_tests.py
@@ -26,7 +26,7 @@ from _helpers.const import (
     BASE_DOMAIN,
     LOCAL_DOMAIN,
     ORG_NAME,
-    MASTER_ORG_NAME,
+    TEMPLATE_ORG_NAME,
     assignment_names,
     STUDENT_TEAMS,
     STUDENT_TEAM_NAMES,
@@ -35,7 +35,7 @@ from _helpers.const import (
     BASE_ARGS,
     STUDENTS_ARG,
     MASTER_REPOS_ARG,
-    MASTER_ORG_ARG,
+    TEMPLATE_ORG_ARG,
     TEACHER,
 )
 from _helpers.helpers import (
@@ -186,7 +186,7 @@ class TestSetup:
                 REPOBEE_GITLAB,
                 *repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(),
                 *BASE_ARGS,
-                *MASTER_ORG_ARG,
+                *TEMPLATE_ORG_ARG,
                 *MASTER_REPOS_ARG,
                 *STUDENTS_ARG,
             ]
@@ -204,7 +204,7 @@ class TestSetup:
                 REPOBEE_GITLAB,
                 *repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(),
                 *BASE_ARGS,
-                *MASTER_ORG_ARG,
+                *TEMPLATE_ORG_ARG,
                 *MASTER_REPOS_ARG,
                 *STUDENTS_ARG,
             ]
@@ -231,7 +231,7 @@ class TestUpdate:
             [
                 REPOBEE_GITLAB,
                 *repobee_plug.cli.CoreCommand.repos.update.as_name_tuple(),
-                *MASTER_ORG_ARG,
+                *TEMPLATE_ORG_ARG,
                 *BASE_ARGS,
                 "-a",
                 master_repo,
@@ -263,7 +263,7 @@ class TestUpdate:
             [
                 REPOBEE_GITLAB,
                 *repobee_plug.cli.CoreCommand.repos.update.as_name_tuple(),
-                *MASTER_ORG_ARG,
+                *TEMPLATE_ORG_ARG,
                 *BASE_ARGS,
                 "-a",
                 master_repo,
@@ -289,7 +289,7 @@ class TestMigrate:
         """Clone the master repos to disk. The restore fixture is explicitly
         included as it must be run before this fixture.
         """
-        api = api_instance(MASTER_ORG_NAME)
+        api = api_instance(TEMPLATE_ORG_NAME)
         master_repo_urls = [
             url.replace(LOCAL_DOMAIN, BASE_DOMAIN)
             for url in api.get_repo_urls(assignment_names)

--- a/tests/unit_tests/repobee/conftest.py
+++ b/tests/unit_tests/repobee/conftest.py
@@ -238,7 +238,7 @@ def empty_config_mock(mocker, isfile_mock, tmpdir, monkeypatch):
 _config_user = "user = {}".format(constants.USER)
 _config_base = "base_url = {}".format(constants.BASE_URL)
 _config_org = "org_name = {}".format(constants.ORG_NAME)
-_config_master_org = "master_org_name = {}".format(constants.MASTER_ORG_NAME)
+_config_master_org = "master_org_name = {}".format(constants.TEMPLATE_ORG_NAME)
 
 
 @pytest.fixture(params=["--bu", "-u", "--sf", "-o", "--mo"])
@@ -271,7 +271,7 @@ def config_mock(empty_config_mock, students_file):
             "base_url = {}".format(constants.BASE_URL),
             "user = {}".format(constants.USER),
             "org_name = {}".format(constants.ORG_NAME),
-            "master_org_name = {}".format(constants.MASTER_ORG_NAME),
+            "master_org_name = {}".format(constants.TEMPLATE_ORG_NAME),
             "students_file = {!s}".format(students_file),
             "plugins = {!s}".format(",".join(constants.PLUGINS)),
             "token = {}".format(constants.CONFIG_TOKEN),

--- a/tests/unit_tests/repobee/conftest.py
+++ b/tests/unit_tests/repobee/conftest.py
@@ -67,7 +67,7 @@ class DummyAPI(plug.PlatformAPI):
         org_name: str,
         base_url: str,
         token: str,
-        master_org_name: Optional[str] = None,
+        template_org_name: Optional[str] = None,
     ) -> None:
         pass
 
@@ -238,7 +238,9 @@ def empty_config_mock(mocker, isfile_mock, tmpdir, monkeypatch):
 _config_user = "user = {}".format(constants.USER)
 _config_base = "base_url = {}".format(constants.BASE_URL)
 _config_org = "org_name = {}".format(constants.ORG_NAME)
-_config_master_org = "master_org_name = {}".format(constants.TEMPLATE_ORG_NAME)
+_config_template_org = "template_org_name = {}".format(
+    constants.TEMPLATE_ORG_NAME
+)
 
 
 @pytest.fixture(params=["--bu", "-u", "--sf", "-o", "--mo"])
@@ -255,7 +257,7 @@ def config_missing_option(request, empty_config_mock, students_file):
     if not missing_option == "-u":
         config_contents.append(_config_user)
     if not missing_option == "--mo":
-        config_contents.append(_config_master_org)
+        config_contents.append(_config_template_org)
 
     empty_config_mock.write(os.linesep.join(config_contents))
 
@@ -271,7 +273,7 @@ def config_mock(empty_config_mock, students_file):
             "base_url = {}".format(constants.BASE_URL),
             "user = {}".format(constants.USER),
             "org_name = {}".format(constants.ORG_NAME),
-            "master_org_name = {}".format(constants.TEMPLATE_ORG_NAME),
+            "template_org_name = {}".format(constants.TEMPLATE_ORG_NAME),
             "students_file = {!s}".format(students_file),
             "plugins = {!s}".format(",".join(constants.PLUGINS)),
             "token = {}".format(constants.CONFIG_TOKEN),

--- a/tests/unit_tests/repobee/conftest.py
+++ b/tests/unit_tests/repobee/conftest.py
@@ -243,7 +243,7 @@ _config_template_org = "template_org_name = {}".format(
 )
 
 
-@pytest.fixture(params=["--bu", "-u", "--sf", "-o", "--mo"])
+@pytest.fixture(params=["--bu", "-u", "--sf", "-o", "--to"])
 def config_missing_option(request, empty_config_mock, students_file):
     missing_option = request.param
 
@@ -256,7 +256,7 @@ def config_missing_option(request, empty_config_mock, students_file):
         config_contents.append("students_file = {!s}".format(students_file))
     if not missing_option == "-u":
         config_contents.append(_config_user)
-    if not missing_option == "--mo":
+    if not missing_option == "--to":
         config_contents.append(_config_template_org)
 
     empty_config_mock.write(os.linesep.join(config_contents))

--- a/tests/unit_tests/repobee/constants.py
+++ b/tests/unit_tests/repobee/constants.py
@@ -8,7 +8,7 @@ import repobee_plug as plug
 
 USER = "slarse"
 ORG_NAME = "test-org"
-MASTER_ORG_NAME = "test-master-org"
+TEMPLATE_ORG_NAME = "test-master-org"
 HOST_URL = "https://some_enterprise_host"
 BASE_URL = "{}/api/v3".format(HOST_URL)
 

--- a/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
@@ -442,7 +442,7 @@ class TestVerifySettings:
                 org_name=TARGET_GROUP,
                 base_url=BASE_URL,
                 token=TOKEN,
-                master_org_name=non_existing_group,
+                template_org_name=non_existing_group,
             )
 
         assert "Could not find group with slug {}".format(
@@ -466,7 +466,7 @@ class TestVerifySettings:
             org_name=TARGET_GROUP,
             base_url=BASE_URL,
             token=TOKEN,
-            master_org_name=MASTER_GROUP,
+            template_org_name=MASTER_GROUP,
         )
 
         log_mock.assert_called_with("GREAT SUCCESS: All settings check out!")

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -49,7 +49,7 @@ COMPLETE_PUSH_ARGS = [*BASE_ARGS, *BASE_PUSH_ARGS]
 # parsed args without subparser
 VALID_PARSED_ARGS = dict(
     org_name=ORG_NAME,
-    master_org_name=TEMPLATE_ORG_NAME,
+    template_org_name=TEMPLATE_ORG_NAME,
     base_url=BASE_URL,
     user=USER,
     master_repo_urls=REPO_URLS,
@@ -392,7 +392,7 @@ class TestDispatchCommand:
             base_url=BASE_URL,
             token=TOKEN,
             org_name=ORG_NAME,
-            master_org_name=None
+            template_org_name=None
         )
         mock_verify_settings = mock.MagicMock(
             spec=dummyapi_class.verify_settings
@@ -407,7 +407,7 @@ class TestDispatchCommand:
             args.user, args.org_name, args.base_url, TOKEN, None
         )
 
-    def test_verify_settings_called_with_master_org_name(
+    def test_verify_settings_called_with_template_org_name(
         self, dummyapi_class, monkeypatch
     ):
         args = argparse.Namespace(
@@ -416,7 +416,7 @@ class TestDispatchCommand:
             base_url=BASE_URL,
             org_name=ORG_NAME,
             token=TOKEN,
-            master_org_name=TEMPLATE_ORG_NAME
+            template_org_name=TEMPLATE_ORG_NAME
         )
         mock_verify_settings = mock.MagicMock(
             spec=dummyapi_class.verify_settings
@@ -517,7 +517,7 @@ class TestBaseParsing:
             repobee_plug.cli.CoreCommand.repos.update,
         ],
     )
-    def test_master_org_overrides_target_org_for_master_repos(
+    def test_template_org_overrides_target_org_for_master_repos(
         self, command_mock, dummyapi_instance, students_file, action
     ):
         print(plug.manager.get_plugins())
@@ -546,7 +546,7 @@ class TestBaseParsing:
             repobee_plug.cli.CoreCommand.repos.update,
         ],
     )
-    def test_master_org_name_defaults_to_org_name(
+    def test_template_org_name_defaults_to_org_name(
         self, dummyapi_instance, students_file, action
     ):
         parsed_args, _ = _repobee.cli.parsing.handle_args(

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -32,7 +32,7 @@ STUDENTS_STRING = " ".join([str(s) for s in STUDENTS])
 ISSUE_PATH = constants.ISSUE_PATH
 ISSUE = constants.ISSUE
 generate_repo_url = functions.generate_repo_url
-MASTER_ORG_NAME = constants.MASTER_ORG_NAME
+TEMPLATE_ORG_NAME = constants.TEMPLATE_ORG_NAME
 TOKEN = constants.TOKEN
 
 EMPTY_PATH = pathlib.Path(".")
@@ -49,7 +49,7 @@ COMPLETE_PUSH_ARGS = [*BASE_ARGS, *BASE_PUSH_ARGS]
 # parsed args without subparser
 VALID_PARSED_ARGS = dict(
     org_name=ORG_NAME,
-    master_org_name=MASTER_ORG_NAME,
+    master_org_name=TEMPLATE_ORG_NAME,
     base_url=BASE_URL,
     user=USER,
     master_repo_urls=REPO_URLS,
@@ -416,7 +416,7 @@ class TestDispatchCommand:
             base_url=BASE_URL,
             org_name=ORG_NAME,
             token=TOKEN,
-            master_org_name=MASTER_ORG_NAME
+            master_org_name=TEMPLATE_ORG_NAME
         )
         mock_verify_settings = mock.MagicMock(
             spec=dummyapi_class.verify_settings
@@ -428,7 +428,7 @@ class TestDispatchCommand:
         _repobee.cli.dispatch.dispatch_command(args, None, EMPTY_PATH)
 
         mock_verify_settings.assert_called_once_with(
-            args.user, args.org_name, args.base_url, TOKEN, MASTER_ORG_NAME
+            args.user, args.org_name, args.base_url, TOKEN, TEMPLATE_ORG_NAME
         )
 
 
@@ -528,13 +528,13 @@ class TestBaseParsing:
                 "--sf",
                 str(students_file),
                 "--mo",
-                MASTER_ORG_NAME,
+                TEMPLATE_ORG_NAME,
             ]
         )
 
         assert all(
             [
-                "/" + MASTER_ORG_NAME + "/" in url
+                "/" + TEMPLATE_ORG_NAME + "/" in url
                 for url in parsed_args.master_repo_urls
             ]
         )

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -485,7 +485,7 @@ class TestBaseParsing:
         assert "--user" in captured.out
         assert "--base-url" in captured.out
         assert "--org-name" in captured.out
-        assert "--master-org-name" in captured.out
+        assert "--template-org-name" in captured.out
         assert "--students-file" in captured.out
         assert "--token" in captured.out
 
@@ -506,7 +506,7 @@ class TestBaseParsing:
         assert "--user" not in captured.out
         assert "--base-url" not in captured.out
         assert "--org-name" not in captured.out
-        assert "--master-org-name" not in captured.out
+        assert "--template-org-name" not in captured.out
         assert "--students-file" not in captured.out
         assert "--token" not in captured.out
 
@@ -527,7 +527,7 @@ class TestBaseParsing:
                 *COMPLETE_PUSH_ARGS,
                 "--sf",
                 str(students_file),
-                "--mo",
+                "--to",
                 TEMPLATE_ORG_NAME,
             ]
         )
@@ -917,8 +917,8 @@ class TestConfig:
         """Test that a config that is missing one option (that is not
         specified on the command line) causes a SystemExit on parsing.
         """
-        # --mo is not required
-        if config_missing_option == "--mo":
+        # --to is not required
+        if config_missing_option == "--to":
             return
 
         sys_args = [

--- a/tests/unit_tests/repobee/test_config.py
+++ b/tests/unit_tests/repobee/test_config.py
@@ -46,7 +46,7 @@ class TestGetConfiguredDefaults:
         assert defaults["org_name"] == ORG_NAME
         assert defaults["students_file"] == str(students_file)
         assert defaults["plugins"] == ",".join(PLUGINS)
-        assert defaults["master_org_name"] == TEMPLATE_ORG_NAME
+        assert defaults["template_org_name"] == TEMPLATE_ORG_NAME
         assert defaults["token"] == CONFIG_TOKEN
 
     def test_token_in_env_variable_overrides_configuration_file(
@@ -65,7 +65,7 @@ class TestGetConfiguredDefaults:
                 "base_url = {}".format(BASE_URL),
                 "user = {}".format(USER),
                 "org_name = {}".format(ORG_NAME),
-                "master_org_name = {}".format(TEMPLATE_ORG_NAME),
+                "template_org_name = {}".format(TEMPLATE_ORG_NAME),
                 "students_file = {!s}".format(students_file),
                 "plugins = {!s}".format(PLUGINS),
                 "{} = whatever".format(invalid_key),

--- a/tests/unit_tests/repobee/test_config.py
+++ b/tests/unit_tests/repobee/test_config.py
@@ -13,7 +13,7 @@ STUDENTS = constants.STUDENTS
 USER = constants.USER
 BASE_URL = constants.BASE_URL
 ORG_NAME = constants.ORG_NAME
-MASTER_ORG_NAME = constants.MASTER_ORG_NAME
+TEMPLATE_ORG_NAME = constants.TEMPLATE_ORG_NAME
 PLUGINS = constants.PLUGINS
 CONFIG_TOKEN = constants.CONFIG_TOKEN
 
@@ -46,7 +46,7 @@ class TestGetConfiguredDefaults:
         assert defaults["org_name"] == ORG_NAME
         assert defaults["students_file"] == str(students_file)
         assert defaults["plugins"] == ",".join(PLUGINS)
-        assert defaults["master_org_name"] == MASTER_ORG_NAME
+        assert defaults["master_org_name"] == TEMPLATE_ORG_NAME
         assert defaults["token"] == CONFIG_TOKEN
 
     def test_token_in_env_variable_overrides_configuration_file(
@@ -65,7 +65,7 @@ class TestGetConfiguredDefaults:
                 "base_url = {}".format(BASE_URL),
                 "user = {}".format(USER),
                 "org_name = {}".format(ORG_NAME),
-                "master_org_name = {}".format(MASTER_ORG_NAME),
+                "master_org_name = {}".format(TEMPLATE_ORG_NAME),
                 "students_file = {!s}".format(students_file),
                 "plugins = {!s}".format(PLUGINS),
                 "{} = whatever".format(invalid_key),


### PR DESCRIPTION
Fix #437 

This renames `master org name` to `template org name`

### Breaking changes
* The `--mo|--master-org-name` argument is now `--to|--template-org-name`
* The `master_org_name` config file key is now named `template_org_name`