### PR TITLE
[break] Rename MASTER_ORG and REPO_NAMES base parsers

### DIFF
--- a/.travis/upload_coverage.sh
+++ b/.travis/upload_coverage.sh
@@ -2,7 +2,7 @@
 
 if [[ $SYSTEM_TEST == "true" ]];
 then
-    cd tests/integration_tests
+    cd system_tests
     rm -f .coverage_files/.coverage
     codecov --file .coverage_files/coverage.xml
 else

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -637,7 +637,7 @@ def _add_extension_parsers(
             parents.append(base_parser)
         if bp.STUDENTS in req_parsers:
             parents.append(base_student_parser)
-        if bp.MASTER_ORG in req_parsers:
+        if bp.TEMPLATE_ORG in req_parsers:
             parents.append(template_org_parser)
 
         if bp.REPO_DISCOVERY in req_parsers:

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -642,7 +642,7 @@ def _add_extension_parsers(
 
         if bp.REPO_DISCOVERY in req_parsers:
             parents.append(_REPO_DISCOVERY_PARSER)
-        elif bp.REPO_NAMES in req_parsers:
+        elif bp.ASSIGNMENTS in req_parsers:
             parents.append(repo_name_parser)
 
         if (

--- a/src/_repobee/ext/query.py
+++ b/src/_repobee/ext/query.py
@@ -24,7 +24,7 @@ class Query(plug.Plugin, plug.cli.Command):
     __settings__ = plug.cli.command_settings(
         help="Query a hook results JSON file for information.",
         description="Query a hook results JSON file for information.",
-        base_parsers=[plug.BaseParser.STUDENTS, plug.BaseParser.REPO_NAMES],
+        base_parsers=[plug.BaseParser.STUDENTS, plug.BaseParser.ASSIGNMENTS],
     )
 
     hook_results_file = plug.cli.option(

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -92,7 +92,7 @@ class BaseParser(enum.Enum):
             ``--org-name``, ``--base-url`` and ``--token`` arguments.
         STUDENTS: Represents the students parser, which includes the
             ``--students`` and `--students-file`` arguments.
-        REPO_NAMES: Represents the repo names parser, which includes the
+        ASSIGNMENTS: Represents the assignments parser, which includes the
             ``--assignments`` argument.
         REPO_DISCOVERY: Represents the repo discovery parser, which adds
             both the ``--assignments`` and the ``--discover-repos``
@@ -103,7 +103,7 @@ class BaseParser(enum.Enum):
 
     BASE = "base"
     STUDENTS = "students"
-    REPO_NAMES = "repo-names"
+    ASSIGNMENTS = "assignments"
     REPO_DISCOVERY = "repo-discovery"
     TEMPLATE_ORG = "template-org"
 

--- a/src/repobee_plug/_containers.py
+++ b/src/repobee_plug/_containers.py
@@ -105,7 +105,7 @@ class BaseParser(enum.Enum):
     STUDENTS = "students"
     REPO_NAMES = "repo-names"
     REPO_DISCOVERY = "repo-discovery"
-    MASTER_ORG = "master-org"
+    TEMPLATE_ORG = "template-org"
 
 
 class ImmutableMixin:


### PR DESCRIPTION
Fix #582 

This PR also contains an entirely unrelated fix to the system test coverage uploading. I just had to get it in there.

### Breaking changes
* The `BaseParser.MASTER_ORG` parser is now called `BaseParser.TEMPLATE_ORG`
* The `BaseParser.REPO_NAMES` parser is now called `BaseParser.ASSIGNMENTS`