### PR TITLE
[misc] Improve user feedback from post_clone hook execution

### DIFF
--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -295,7 +295,10 @@ def clone_repos(
 
     for p in plug.manager.get_plugins():
         if "post_clone" in dir(p):
-            return plugin.execute_clone_tasks(local_repos, api)
+            local_repos_progress = plug.cli.io.progress_bar(
+                local_repos, desc="Executing post_clone hooks",
+            )
+            return plugin.execute_clone_tasks(local_repos_progress, api)
     return {}
 
 


### PR DESCRIPTION
Fix #593 

There's now a progress bar for post clone execution, and the results summary uses the repo names instead of the path names (which are just hashes nowadays).