### PR TITLE
[fix] Make get_repos fetch by url instead of names

### DIFF
--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -47,7 +47,7 @@ def list_issues(
     repo_names = [repo.name for repo in repos]
     max_repo_name_length = max(map(len, repo_names))
 
-    repos = api.get_repos(repo_names)
+    repos = api.get_repos([repo.url for repo in repos])
 
     issues_per_repo = _get_issue_generator(
         repos, title_regex=title_regex, author=author, state=state, api=api
@@ -197,8 +197,10 @@ def open_issue(
         api: An implementation of :py:class:`repobee_plug.PlatformAPI` used to
             interface with the platform (e.g. GitHub or GitLab) instance.
     """
-    repo_names = plug.generate_repo_names(teams, assignment_names)
-    repos = progresswrappers.get_repos(repo_names, api)
+    repo_urls = api.get_repo_urls(
+        team_names=[t.name for t in teams], assignment_names=assignment_names
+    )
+    repos = progresswrappers.get_repos(repo_urls, api)
     for repo in repos:
         issue = api.create_issue(issue.title, issue.body, repo)
         msg = f"Opened issue {repo.name}/#{issue.number}-'{issue.title}'"
@@ -218,8 +220,8 @@ def close_issue(
         api: An implementation of :py:class:`repobee_plug.PlatformAPI` used to
             interface with the platform (e.g. GitHub or GitLab) instance.
     """
-    repo_names = (repo.name for repo in repos)
-    repos = progresswrappers.get_repos(repo_names, api)
+    repo_urls = (repo.url for repo in repos)
+    repos = progresswrappers.get_repos(repo_urls, api)
     for repo in repos:
         to_close = [
             issue

--- a/src/_repobee/command/progresswrappers.py
+++ b/src/_repobee/command/progresswrappers.py
@@ -8,7 +8,7 @@ __all__ = ["get_repos"]
 
 
 def get_repos(
-    repo_names: Iterable[str],
+    repo_urls: Iterable[str],
     api: plug.PlatformAPI,
     desc: str = "Fetching repos",
     **kwargs: Any,
@@ -17,7 +17,7 @@ def get_repos(
     provides an auto-updating progress bar to the CLI.
 
     Args:
-        repo_names: An iterable of repo names.
+        repo_urls: An iterable of repo URLs.
         api: An instance of the platform API.
         desc: A description of the action.
         kwargs: Keyword arguments to the underlying implementation of the
@@ -25,9 +25,9 @@ def get_repos(
     Returns:
         An iterable of repos with an auto-updating CLI progress bar.
     """
-    repo_names = list(repo_names)
+    repo_urls = list(repo_urls)
     return plug.cli.io.progress_bar(
-        api.get_repos(repo_names), desc=desc, total=len(repo_names), **kwargs
+        api.get_repos(repo_urls), desc=desc, total=len(repo_urls), **kwargs
     )
 
 

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -265,8 +265,7 @@ def _open_issue_by_urls(
         api: An implementation of :py:class:`repobee_plug.PlatformAPI` used to
             interface with the platform (e.g. GitHub or GitLab) instance.
     """
-    repo_names = [util.repo_name(url) for url in repo_urls]
-    repos = progresswrappers.get_repos(repo_names, api)
+    repos = progresswrappers.get_repos(repo_urls, api)
     for repo in repos:
         issue = api.create_issue(issue.title, issue.body, repo)
         msg = f"Opened issue {repo.name}/#{issue.number}-'{issue.title}'"

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -14,6 +14,7 @@ program.
 """
 import itertools
 import pathlib
+import re
 import os
 import sys
 import tempfile
@@ -248,7 +249,10 @@ def update_student_repos(
 
     if failed_urls and issue:
         plug.echo("Opening issue in repos to which push failed")
-        _open_issue_by_urls(failed_urls, issue, api)
+        urls_without_auth = [
+            re.sub("https://.*?@", "https://", url) for url in failed_urls
+        ]
+        _open_issue_by_urls(urls_without_auth, issue, api)
 
     plug.log.info("Done!")
     return hook_results

--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -249,12 +249,13 @@ class GitHubAPI(plug.PlatformAPI):
         return self._wrap_repo(repo)
 
     def get_repos(
-        self, repo_names: Optional[List[str]] = None,
+        self, repo_urls: Optional[List[str]] = None,
     ) -> Iterable[plug.Repo]:
         """See :py:meth:`repobee_plug.PlatformAPI.get_repos`."""
+        repo_names = map(self.extract_repo_name, repo_urls or [])
         return (
             self._wrap_repo(repo)
-            for repo in self._get_repos_by_name(repo_names or [])
+            for repo in self._get_repos_by_name(repo_names)
         )
 
     def create_issue(

--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -221,8 +221,8 @@ class GitLabAPI(plug.PlatformAPI):
                     include_subgroups=True, search=name, all=True
                 )
                 for candidate in candidates:
-                    if candidate.attributes["http_url_to_repo"] == url:
-                        found_urls.append(candidate.url)
+                    if candidate.http_url_to_repo == url:
+                        found_urls.append(candidate.http_url_to_repo)
                         yield self._wrap_project(
                             self._gitlab.projects.get(candidate.id)
                         )

--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -248,14 +248,14 @@ class _APISpec:
         _not_implemented()
 
     def get_repos(
-        self, repo_names: Optional[List[str]] = None,
+        self, repo_urls: Optional[List[str]] = None,
     ) -> Iterable[Repo]:
         """Get repositories from the platform.
 
         Args:
-            repo_names: Repository names to filter the results by. Names that
-                do not exist on the platform are ignored. If
-                ``repo_names=None``, all repos are fetched.
+            repo_urls: Repository URLs to filter the results by. URLs that do
+                not exist on the platform are ignored. If ``repo_urls=None``,
+                all repos are fetched.
         Returns:
             Repositories matching the filters.
         Raises:

--- a/src/repobee_testhelpers/localapi.py
+++ b/src/repobee_testhelpers/localapi.py
@@ -202,9 +202,10 @@ class LocalAPI(plug.PlatformAPI):
         raise plug.NotFoundError(f"{team_name} has no repository {repo_name}")
 
     def get_repos(
-        self, repo_names: Optional[List[str]] = None,
+        self, repo_urls: Optional[List[str]] = None,
     ) -> Iterable[plug.Repo]:
         """See :py:meth:`repobee_plug.PlatformAPI.get_repos`."""
+        repo_names = map(self.extract_repo_name, repo_urls or [])
         unfiltered_repos = (
             self._repos[self._org_name].get(name) for name in repo_names
         )


### PR DESCRIPTION
Fix #568 

Now, repo urls are used to unambiguously define the repositories, rather than using repo names.

This is breaking in regards to previous alpha releases, but not to any major release, so I won't mark it as breaking.