### PR TITLE
[break] Remove plugins from config file

### DIFF
--- a/src/_repobee/config.py
+++ b/src/_repobee/config.py
@@ -11,7 +11,7 @@ Contains the code required for pre-configuring user interfaces.
 import os
 import pathlib
 import configparser
-from typing import Union, List, Mapping
+from typing import Union, Mapping
 
 import repobee_plug as plug
 
@@ -55,31 +55,6 @@ def check_defaults(
                 ", ".join(configured - constants.CONFIGURABLE_ARGS),
             )
         )
-
-
-def get_plugin_names(config_file: Union[str, pathlib.Path]) -> List[str]:
-    """Return a list of unqualified names of plugins listed in the config. The
-    order of the plugins is preserved.
-
-    Args:
-        config_file: path to the config file.
-
-    Returns:
-        a list of unqualified names of plugin modules, or an empty list if no
-        plugins are listed.
-    """
-    config_file = (
-        pathlib.Path(config_file)
-        if isinstance(config_file, str)
-        else config_file
-    )
-    if not config_file.is_file():
-        return []
-    config = _read_config(config_file)
-    plugin_string = config.get(
-        constants.CORE_SECTION_HDR, "plugins", fallback=""
-    )
-    return [name.strip() for name in plugin_string.split(",") if name]
 
 
 def execute_config_hooks(config_file: Union[str, pathlib.Path]) -> None:

--- a/src/_repobee/constants.py
+++ b/src/_repobee/constants.py
@@ -34,7 +34,6 @@ ORDERED_CONFIGURABLE_ARGS = (
     "template_org_name",
     "token",
     "students_file",
-    "plugins",
 )
 CONFIGURABLE_ARGS = set(ORDERED_CONFIGURABLE_ARGS)
 

--- a/src/_repobee/main.py
+++ b/src/_repobee/main.py
@@ -209,10 +209,7 @@ def _initialize_plugins(parsed_preparser_args: argparse.Namespace) -> None:
             )
 
         plug.log.debug("Initializing user plugins")
-        plugin_names = (
-            parsed_preparser_args.plug
-            or config.get_plugin_names(parsed_preparser_args.config_file)
-        ) or []
+        plugin_names = parsed_preparser_args.plug or []
         plugin.initialize_plugins(plugin_names, allow_filepath=True)
 
 

--- a/tests/unit_tests/repobee/conftest.py
+++ b/tests/unit_tests/repobee/conftest.py
@@ -275,7 +275,6 @@ def config_mock(empty_config_mock, students_file):
             "org_name = {}".format(constants.ORG_NAME),
             "template_org_name = {}".format(constants.TEMPLATE_ORG_NAME),
             "students_file = {!s}".format(students_file),
-            "plugins = {!s}".format(",".join(constants.PLUGINS)),
             "token = {}".format(constants.CONFIG_TOKEN),
         ]
     )

--- a/tests/unit_tests/repobee/test_config.py
+++ b/tests/unit_tests/repobee/test_config.py
@@ -45,7 +45,6 @@ class TestGetConfiguredDefaults:
         assert defaults["base_url"] == BASE_URL
         assert defaults["org_name"] == ORG_NAME
         assert defaults["students_file"] == str(students_file)
-        assert defaults["plugins"] == ",".join(PLUGINS)
         assert defaults["template_org_name"] == TEMPLATE_ORG_NAME
         assert defaults["token"] == CONFIG_TOKEN
 
@@ -67,7 +66,6 @@ class TestGetConfiguredDefaults:
                 "org_name = {}".format(ORG_NAME),
                 "template_org_name = {}".format(TEMPLATE_ORG_NAME),
                 "students_file = {!s}".format(students_file),
-                "plugins = {!s}".format(PLUGINS),
                 "{} = whatever".format(invalid_key),
             ]
         )
@@ -101,40 +99,6 @@ class TestGetConfiguredDefaults:
         assert "does not contain the required [repobee] header" in str(
             exc_info.value
         )
-
-
-class TestGetPluginNames:
-    """Tests for get_plugin_names."""
-
-    def test_with_full_config(self, config_mock):
-        """Test that plugins are read correctly from a full config file."""
-        plugin_names = config.get_plugin_names(str(config_mock))
-
-        assert plugin_names == PLUGINS
-
-    @pytest.mark.parametrize(
-        "plugins_string, expected_plugins",
-        [
-            (",".join(PLUGINS), PLUGINS),
-            (", ".join(PLUGINS), PLUGINS),
-            ("javac", ["javac"]),
-            ("", []),
-        ],
-    )
-    def test_with_only_plugins(
-        self, plugins_string, expected_plugins, empty_config_mock
-    ):
-        contents = os.linesep.join(
-            [
-                "[{}]".format(_repobee.constants.CORE_SECTION_HDR),
-                "plugins = " + plugins_string,
-            ]
-        )
-        empty_config_mock.write(contents)
-
-        plugin_names = config.get_plugin_names(str(empty_config_mock))
-
-        assert plugin_names == expected_plugins
 
 
 class TestExecuteConfigHooks:

--- a/tests/unit_tests/repobee/test_main.py
+++ b/tests/unit_tests/repobee/test_main.py
@@ -209,27 +209,6 @@ def test_no_plugins_with_configured_plugins(
     )
 
 
-def test_configured_plugins_are_loaded(
-    handle_args_mock, dispatch_command_mock, init_plugins_mock, config_mock
-):
-    sys_args = ["repobee", *CLONE_ARGS]
-
-    main.main(sys_args)
-
-    init_plugins_mock.assert_has_calls(
-        [
-            call(["javac", "pylint"], allow_filepath=True),
-            call(DEFAULT_PLUGIN_NAMES, allow_qualified=True),
-        ],
-        any_order=True,
-    )
-    handle_args_mock.assert_called_once_with(
-        CLONE_ARGS,
-        show_all_opts=False,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
-    )
-
-
 def test_dist_plugins_are_loaded_when_dist_install(monkeypatch):
     dist_plugin_qualnames = plugin.get_qualified_module_names(
         _repobee.ext.dist


### PR DESCRIPTION
Fix #585 

### Breaking changes
* The `plugins` option in the config file is no longer available. Plugins should be configured in the installation.