### PR TITLE
[fix] Remove usage of capture_output in subprocess calls

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,3 +7,4 @@ pylint
 pytest-cov>=2.6.1
 pytest-mock
 pytest>=5.0.0
+virtualenv

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,10 @@
 #! /bin/bash
 
-REPOBEE_INSTALL_DIR="$HOME/.repobee"
+if [ -z "$REPOBEE_INSTALL_DIR" ]; then
+    REPOBEE_INSTALL_DIR="$HOME/.repobee"
+fi
+
+echo "Using install dir '$REPOBEE_INSTALL_DIR'"
 REPOBEE_BIN_DIR="$REPOBEE_INSTALL_DIR/bin"
 REPOBEE_REPO_DIR="$REPOBEE_INSTALL_DIR/repobee_git"
 REPOBEE_HTTPS_URL="https://github.com/repobee/repobee"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,7 +59,9 @@ function install_repobee() {
     version=$1
     echo "Installing RepoBee at $REPOBEE_INSTALL_DIR"
 
-    $(find_python) -m venv "$VENV_DIR" &> /dev/null || {
+    # virtualenv works better in CI as it properly copies pip from another
+    # virtualenv while venv doesn't appear to do that. So we try both.
+    $(find_python) -m virtualenv "$VENV_DIR" &> /dev/null || $(find_python) -m venv "$VENV_DIR" &> /dev/null || {
         printf "\nFailed to create a virtual environment for RepoBee.\n"
         echo "This is typically caused by the venv package not being installed."
         printf "If you run Ubuntu/Debian, try running the following commands:\n\n"
@@ -69,6 +71,7 @@ function install_repobee() {
         printf "\nThen re-execute this script."
         exit 1
     }
+
     source "$REPOBEE_ENV_ACTIVATE"
     ensure_pip_installed
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ test_requirements = [
     "pytest-cov>=2.6.1",
     "pytest-mock",
     "pytest>=4.0.0",
+    "virtualenv",
 ]
 docs_requirements = [
     "sphinx>=1.8.2",

--- a/src/_repobee/disthelpers.py
+++ b/src/_repobee/disthelpers.py
@@ -1,8 +1,10 @@
 """Helper functions for the distribution."""
-import pathlib
-import json
-import types
 import importlib
+import json
+import pathlib
+import subprocess
+import sys
+import types
 
 from typing import Optional, List
 
@@ -120,3 +122,26 @@ def get_builtin_plugins(ext_pkg: types.ModuleType = _repobee.ext) -> dict:
         )
         for name in plugin.get_module_names(ext_pkg)
     }
+
+
+def pip(*args, **kwargs) -> subprocess.CompletedProcess:
+    """Thin wrapper around the ``pip`` executable in the distribution's virtual
+    environment.
+
+    Args:
+        args: Positional arguments to ``pip``, passed in order. Flags should
+            also be passed here (e.g. `--pre`)
+        kwargs: Keyword arguments to ``pip``, passed as ``--key=value`` to the
+            CLI.
+    Returns:
+        True iff the command exited with a zero exit status.
+    """
+    cmd = [
+        str(get_pip_path()),
+        *args,
+        *[f"--{key}={val}" for key, val in kwargs.items()],
+    ]
+    proc = subprocess.run(cmd, capture_output=True)
+    if proc.returncode != 0:
+        plug.log.error(proc.stderr.decode(sys.getdefaultencoding()))
+    return proc

--- a/src/_repobee/disthelpers.py
+++ b/src/_repobee/disthelpers.py
@@ -141,7 +141,7 @@ def pip(*args, **kwargs) -> subprocess.CompletedProcess:
         *args,
         *[f"--{key}={val}" for key, val in kwargs.items()],
     ]
-    proc = subprocess.run(cmd, capture_output=True)
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if proc.returncode != 0:
         plug.log.error(proc.stderr.decode(sys.getdefaultencoding()))
     return proc

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -6,8 +6,6 @@ tooling.
     This plugin should only be used when using an installed version of RepoBee.
 """
 import pathlib
-import subprocess
-import sys
 import textwrap
 
 import typing as ty
@@ -118,17 +116,10 @@ def _select_plugin(plugins: dict) -> ty.Tuple[str, str]:
 
 def _install_plugin(name: str, version: str, plugins: dict) -> None:
     install_url = f"git+{plugins[name]['url']}@{version}"
-
-    cmd = [
-        str(disthelpers.get_pip_path()),
-        "install",
-        "--upgrade",
-        install_url,
-    ]
-    proc = subprocess.run(cmd, capture_output=True)
-
-    if proc.returncode != 0:
-        plug.log.error(proc.stderr.decode(sys.getdefaultencoding()))
+    installed = (
+        disthelpers.pip("install", "--upgrade", install_url).returncode == 0
+    )
+    if not installed:
         raise plug.PlugError(f"could not install {name} {version}")
 
 
@@ -182,16 +173,11 @@ def _uninstall_plugin(plugin_name: str, installed_plugins: dict):
 
 
 def _pip_uninstall_plugin(plugin_name: str) -> None:
-    cmd = [
-        str(disthelpers.get_pip_path()),
-        "uninstall",
-        "-y",
-        f"repobee-{plugin_name}",
-    ]
-    proc = subprocess.run(cmd, capture_output=True)
-
-    if proc.returncode != 0:
-        plug.log.error(proc.stderr.decode(sys.getdefaultencoding()))
+    uninstalled = (
+        disthelpers.pip("uninstall", "-y", "repobee-{plugin_name}").returncode
+        == 0
+    )
+    if not uninstalled:
         raise plug.PlugError(f"could not uninstall {plugin_name}")
 
 

--- a/src/_repobee/main.py
+++ b/src/_repobee/main.py
@@ -116,7 +116,9 @@ def run(
     with _in_requested_workdir():
         try:
             _repobee.cli.parsing.setup_logging()
-            plugin.initialize_default_plugins()
+            # FIXME calling _initialize_plugins like this is ugly, should be
+            # refactored
+            _initialize_plugins(argparse.Namespace(no_plugins=False, plug=[]))
             plugin.register_plugins(wrapped_plugins)
             parsed_args, api = _parse_args(cmd, config_file, show_all_opts)
             return _repobee.cli.dispatch.dispatch_command(

--- a/system_tests/gitlabmanager.py
+++ b/system_tests/gitlabmanager.py
@@ -228,7 +228,8 @@ def get_gitlab_status():
     return (
         subprocess.run(
             "docker inspect -f {{.State.Health.Status}} gitlab".split(),
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         .stdout.decode(sys.getdefaultencoding())
         .strip()

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -25,7 +25,7 @@ def install_dir(monkeypatch):
         env = dict(os.environ)
         env["REPOBEE_INSTALL_DIR"] = str(install_dir)
 
-        if "VIRTUAL_ENV" in env:
+        if "VIRTUAL_ENV" in env and "TRAVIS" not in env:
             # remove any paths that lead to a virtual environment such that the
             # global Python interpreter is used to create the new venv
             virtualenv_dir = env["VIRTUAL_ENV"]

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -1,0 +1,47 @@
+"""Tests for the RepoBee installable distribution."""
+
+import pytest
+import tempfile
+import pathlib
+import subprocess
+import os
+
+INSTALL_SCRIPT = (
+    pathlib.Path(__file__).parent.parent.parent / "scripts" / "install.sh"
+)
+assert INSTALL_SCRIPT.is_file(), "unable to find install script"
+
+
+@pytest.fixture(autouse=True)
+def install_dir():
+    """Install the RepoBee distribution into a temporary directory."""
+    with tempfile.TemporaryDirectory() as install_dirname:
+        install_dir = pathlib.Path(install_dirname)
+        env = dict(os.environ)
+        env["REPOBEE_INSTALL_DIR"] = str(install_dir)
+
+        # remove any paths from the path that lead to a virtual environment
+        # such that the global Python interpreter is used to create the new
+        # venv
+        virtualenv_dir = env["VIRTUAL_ENV"]
+        paths = [
+            path
+            for path in env["PATH"].split(":")
+            if not path.startswith(virtualenv_dir)
+        ]
+        env["PATH"] = ":".join(paths)
+
+        subprocess.run("which python".split(), env=env)
+
+        proc = subprocess.Popen(str(INSTALL_SCRIPT), env=env,)
+        proc.communicate("n")  # 'n' in answering whether or not to add to PATH
+        assert proc.returncode == 0
+
+        yield install_dir
+
+
+def test_install_dist(install_dir):
+    """Test that the distribution is installed correctly."""
+    assert (install_dir / "bin" / "repobee").is_file()
+    assert (install_dir / "installed_plugins.json").is_file()
+    assert (install_dir / "env" / "bin" / "pip").is_file()

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -5,6 +5,11 @@ import tempfile
 import pathlib
 import subprocess
 import os
+import sys
+import json
+
+import repobee
+from _repobee import disthelpers
 
 INSTALL_SCRIPT = (
     pathlib.Path(__file__).parent.parent.parent / "scripts" / "install.sh"
@@ -13,29 +18,32 @@ assert INSTALL_SCRIPT.is_file(), "unable to find install script"
 
 
 @pytest.fixture(autouse=True)
-def install_dir():
+def install_dir(monkeypatch):
     """Install the RepoBee distribution into a temporary directory."""
     with tempfile.TemporaryDirectory() as install_dirname:
         install_dir = pathlib.Path(install_dirname)
         env = dict(os.environ)
         env["REPOBEE_INSTALL_DIR"] = str(install_dir)
 
-        # remove any paths from the path that lead to a virtual environment
-        # such that the global Python interpreter is used to create the new
-        # venv
-        virtualenv_dir = env["VIRTUAL_ENV"]
-        paths = [
-            path
-            for path in env["PATH"].split(":")
-            if not path.startswith(virtualenv_dir)
-        ]
-        env["PATH"] = ":".join(paths)
+        if "VIRTUAL_ENV" in env:
+            # remove any paths that lead to a virtual environment such that the
+            # global Python interpreter is used to create the new venv
+            virtualenv_dir = env["VIRTUAL_ENV"]
+            del env["VIRTUAL_ENV"]
+            paths = [
+                path
+                for path in env["PATH"].split(":")
+                if not path.startswith(virtualenv_dir)
+            ]
+            env["PATH"] = ":".join(paths)
 
-        subprocess.run("which python".split(), env=env)
-
-        proc = subprocess.Popen(str(INSTALL_SCRIPT), env=env,)
+        proc = subprocess.Popen(str(INSTALL_SCRIPT), env=env)
         proc.communicate("n")  # 'n' in answering whether or not to add to PATH
         assert proc.returncode == 0
+
+        # moneypatch the distinfo module to make RepoBee think it's installed
+        monkeypatch.setattr("_repobee.distinfo.DIST_INSTALL", True)
+        monkeypatch.setattr("_repobee.distinfo.INSTALL_DIR", install_dir)
 
         yield install_dir
 
@@ -45,3 +53,28 @@ def test_install_dist(install_dir):
     assert (install_dir / "bin" / "repobee").is_file()
     assert (install_dir / "installed_plugins.json").is_file()
     assert (install_dir / "env" / "bin" / "pip").is_file()
+    assert (install_dir / "completion" / "bash_completion.sh").is_file()
+
+
+class TestInstallPlugin:
+    """Tests for the ``plugin install`` command.
+
+    Unfortunately, we must mock a bit here as the UI is hard to interface with.
+    """
+
+    def test_install_junit4_plugin(self, mocker):
+        version = "v1.0.0"
+        mocker.patch("bullet.Bullet.launch", side_effect=["junit4", version])
+
+        repobee.run("plugin install".split())
+
+        pip_proc = disthelpers.pip("list", format="json")
+        installed_packages = {
+            pkg_info["name"]: pkg_info
+            for pkg_info in json.loads(
+                pip_proc.stdout.decode(sys.getdefaultencoding())
+            )
+        }
+        assert installed_packages["repobee-junit4"][
+            "version"
+        ] == version.lstrip("v")

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -25,18 +25,6 @@ def install_dir(monkeypatch):
         env = dict(os.environ)
         env["REPOBEE_INSTALL_DIR"] = str(install_dir)
 
-        if "VIRTUAL_ENV" in env and "TRAVIS" not in env:
-            # remove any paths that lead to a virtual environment such that the
-            # global Python interpreter is used to create the new venv
-            virtualenv_dir = env["VIRTUAL_ENV"]
-            del env["VIRTUAL_ENV"]
-            paths = [
-                path
-                for path in env["PATH"].split(":")
-                if not path.startswith(virtualenv_dir)
-            ]
-            env["PATH"] = ":".join(paths)
-
         proc = subprocess.Popen(str(INSTALL_SCRIPT), env=env)
         proc.communicate("n")  # 'n' in answering whether or not to add to PATH
         assert proc.returncode == 0


### PR DESCRIPTION
Fix #603 

The cause of the bug was that `capture_output` was used in calls to subprocess functions. And that argument was added in 3.7. Silly.

This PR also adds a test for the `plugin install` command, and a test file that makes it easy to test other dist plugins. It's rather slow-running as it depends on installing the distribution. This could possibly be sped up by not actually installing everything (because all that's needed is really the virtual environment and `installed_plugins.json`). But that's a topic for another day.

Oh, and the install script now accepts `REPOBEE_INSTALL_DIR` to be defined externally, and only defaults to `~/.repobee` if `REPOBEE_INSTALL_DIR` is not already defined.