### PR TITLE
[fix] Fix crash on using local template repos

### DIFF
--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -18,7 +18,7 @@ import re
 import os
 import sys
 import tempfile
-from typing import Iterable, List, Optional, Mapping
+from typing import Iterable, List, Optional, Mapping, Union
 
 import repobee_plug as plug
 
@@ -75,9 +75,7 @@ def setup_student_repos(
         ]
 
         plug.log.info("Cloning into master repos ...")
-        _clone_all(
-            [api.insert_auth(r.url) for r in template_repos], cwd=tmpdir
-        )
+        _clone_all(template_repos, cwd=tmpdir, api=api)
         hook_results = plugin.execute_setup_tasks(
             template_repos, api, cwd=pathlib.Path(tmpdir)
         )
@@ -159,26 +157,36 @@ def _create_or_fetch_repo(
         return repo
 
 
-def _clone_all(repo_urls: str, cwd: pathlib.Path):
+def _clone_all(
+    repos: plug.TemplateRepo, cwd: pathlib.Path, api: plug.PlatformAPI
+):
     """Attempts to clone all repos sequentially.
 
     Args:
-        repo_urls: URLs to clone.
+        repos: Repos to clone.
         cwd: Working directory. Use temporary directory for automatic cleanup.
-    Returns:
-        The template repos with updated paths.
+        api: An instance of the platform API.
     """
-    if len(set(repo_urls)) != len(repo_urls):
-        raise ValueError("duplicated repo url repo")
     try:
-        for url in plug.cli.io.progress_bar(
-            repo_urls, desc="Cloning template repositories", unit="repos"
+        for repo in plug.cli.io.progress_bar(
+            repos, desc="Cloning template repositories", unit="repos"
         ):
+            url = _try_insert_auth(repo, api)
             plug.log.info(f"Cloning into '{url}'")
             git.clone_single(url, cwd=str(cwd))
     except exception.CloneFailedError:
         plug.log.error(f"Error cloning into {url}, aborting ...")
         raise
+
+
+def _try_insert_auth(
+    repo: Union[plug.TemplateRepo, plug.StudentRepo], api: plug.PlatformAPI
+) -> str:
+    """Try to insert authentication into the URL."""
+    try:
+        return api.insert_auth(repo.url)
+    except plug.InvalidURL:
+        return repo.url
 
 
 def update_student_repos(
@@ -212,9 +220,7 @@ def update_student_repos(
         ]
 
         plug.log.info("Cloning into master repos ...")
-        _clone_all(
-            [api.insert_auth(r.url) for r in template_repos], cwd=tmpdir
-        )
+        _clone_all(template_repos, cwd=tmpdir, api=api)
         hook_results = plugin.execute_setup_tasks(
             template_repos, api, cwd=pathlib.Path(tmpdir)
         )
@@ -343,11 +349,7 @@ def migrate_repos(
         ]
 
         _clone_all(
-            [
-                api.insert_auth(url) if url.startswith("https") else url
-                for url in template_repo_urls
-            ],
-            cwd=workdir,
+            template_repos, cwd=workdir, api=api,
         )
 
         git.push(

--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -374,10 +374,9 @@ class GitHubAPI(plug.PlatformAPI):
 
     def insert_auth(self, url: str) -> str:
         """See :py:meth:`repobee_plug.PlatformAPI.insert_auth`."""
-        if not url.startswith("https://"):
-            raise ValueError(
-                f"unsupported protocol in '{url}', please use https://"
-            )
+        html_base_url = self._org.html_url[: -len(self._org_name) - 1]
+        if html_base_url not in url:
+            raise plug.InvalidURL(f"url not found on platform: '{url}'")
         auth = "{}:{}".format(self._user, self.token)
         return url.replace("https://", f"https://{auth}@")
 

--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -234,6 +234,8 @@ class GitLabAPI(plug.PlatformAPI):
 
     def insert_auth(self, url: str) -> str:
         """See :py:meth:`repobee_plug.PlatformAPI.insert_auth`."""
+        if self._base_url not in url:
+            raise plug.InvalidURL("url not found on platform: '{url}'")
         return self._insert_auth(url)
 
     def create_issue(

--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -59,6 +59,7 @@ from repobee_plug.exceptions import (
     ServiceNotFoundError,
     BadCredentials,
     UnexpectedException,
+    InvalidURL,
 )
 
 # Local representations
@@ -106,6 +107,7 @@ __all__ = [
     "ServiceNotFoundError",
     "BadCredentials",
     "UnexpectedException",
+    "InvalidURL",
     # Helpers
     "json_to_result_mapping",
     "result_mapping_to_json",

--- a/src/repobee_plug/exceptions.py
+++ b/src/repobee_plug/exceptions.py
@@ -77,5 +77,11 @@ class UnexpectedException(PlatformError):
     """
 
 
+class InvalidURL(PlatformError):
+    """Error to raise if a URL is provided to the platform API, but it is not a
+    valid URL for the platform.
+    """
+
+
 class FileError(PlugError):
     """Raise if something goes wrong with reading from or writing to a file."""

--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -287,6 +287,9 @@ class _APISpec:
             url: A URL to the platform.
         Returns:
             The same url, but with authorization credentials inserted.
+        Raises:
+            :py:class:`exceptions.InvalidURL`: If the provided URL does not
+                point to anything on the platform.
         """
         _not_implemented()
 

--- a/src/repobee_testhelpers/localapi.py
+++ b/src/repobee_testhelpers/localapi.py
@@ -213,6 +213,8 @@ class LocalAPI(plug.PlatformAPI):
 
     def insert_auth(self, url: str) -> str:
         """See :py:meth:`repobee_plug.PlatformAPI.insert_auth`."""
+        if f"file://{self._repodir}" not in url:
+            raise ValueError(f"Not a platform repo url: {url}")
         return url
 
     def create_issue(

--- a/src/repobee_testhelpers/localapi.py
+++ b/src/repobee_testhelpers/localapi.py
@@ -214,7 +214,7 @@ class LocalAPI(plug.PlatformAPI):
     def insert_auth(self, url: str) -> str:
         """See :py:meth:`repobee_plug.PlatformAPI.insert_auth`."""
         if f"file://{self._repodir}" not in url:
-            raise ValueError(f"Not a platform repo url: {url}")
+            raise plug.InvalidURL(f"url not found on platform: '{url}'")
         return url
 
     def create_issue(

--- a/system_tests/test_gitlab_system.py
+++ b/system_tests/test_gitlab_system.py
@@ -291,13 +291,12 @@ class TestMigrate:
         """
         api = api_instance(TEMPLATE_ORG_NAME)
         template_repo_urls = [
-            url.replace(LOCAL_DOMAIN, BASE_DOMAIN)
+            api.insert_auth(url).replace(LOCAL_DOMAIN, BASE_DOMAIN)
             for url in api.get_repo_urls(assignment_names)
         ]
         # clone the master repos to disk first first
         git_commands = [
-            "git clone {}".format(api.insert_auth(url))
-            for url in template_repo_urls
+            "git clone {}".format(url) for url in template_repo_urls
         ]
         result = run_in_docker(
             " && ".join(git_commands), extra_args=extra_args

--- a/tests/unit_tests/repobee/plugin_tests/test_github.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_github.py
@@ -335,6 +335,23 @@ class TestInit:
         assert isinstance(api, plug.PlatformAPI)
 
 
+class TestInsertAuth:
+    """Tests for insert_auth."""
+
+    def test_inserts_into_https_url(self, api):
+        url = f"{BASE_URL}/some/repo"
+        authed_url = api.insert_auth(url)
+        assert authed_url.startswith(f"https://{USER}:{TOKEN}")
+
+    def test_raises_on_non_platform_url(self, api):
+        url = "https://somedomain.com"
+
+        with pytest.raises(plug.InvalidURL) as exc_info:
+            api.insert_auth(url)
+
+        assert "url not found on platform" in str(exc_info)
+
+
 class TestGetRepoUrls:
     """Tests for get_repo_urls."""
 

--- a/tests/unit_tests/repobee/plugin_tests/test_github.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_github.py
@@ -349,7 +349,7 @@ class TestInsertAuth:
         with pytest.raises(plug.InvalidURL) as exc_info:
             api.insert_auth(url)
 
-        assert "url not found on platform" in str(exc_info)
+        assert "url not found on platform" in str(exc_info.value)
 
 
 class TestGetRepoUrls:

--- a/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
@@ -391,6 +391,23 @@ class TestGetRepoUrls:
         assert sorted(actual_urls) == sorted(expected_urls)
 
 
+class TestInsertAuth:
+    """Tests for insert_auth."""
+
+    def test_inserts_into_https_url(self, api):
+        url = f"{BASE_URL}/some/repo"
+        authed_url = api.insert_auth(url)
+        assert authed_url.startswith(f"https://oauth2:{TOKEN}")
+
+    def test_raises_on_non_platform_url(self, api):
+        url = "https://somedomain.com"
+
+        with pytest.raises(plug.InvalidURL) as exc_info:
+            api.insert_auth(url)
+
+        assert "url not found on platform" in str(exc_info)
+
+
 class TestVerifySettings:
     def test_raises_if_token_is_empty(self):
         with pytest.raises(plug.BadCredentials):

--- a/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
@@ -405,7 +405,7 @@ class TestInsertAuth:
         with pytest.raises(plug.InvalidURL) as exc_info:
             api.insert_auth(url)
 
-        assert "url not found on platform" in str(exc_info)
+        assert "url not found on platform" in str(exc_info.value)
 
 
 class TestVerifySettings:


### PR DESCRIPTION
Fix #626 

This also defines new behavior for the `insert_auth` function. Now, it must raise `plug.InvalidURL` if the URL provided does not belong to the target platform.