### PR TITLE
[break] Add explicit option to allow use of local template repos

### DIFF
--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -61,6 +61,12 @@ _DISCOVERY_MUTEX_GRP.add_argument(
     "expensive in terms of API calls)",
     action="store_true",
 )
+_LOCAL_TEMPLATES_PARSER = argparse.ArgumentParser(add_help=False)
+_LOCAL_TEMPLATES_PARSER.add_argument(
+    "--allow-local-templates",
+    help="allow the use of template repos in the current working directory",
+    action="store_true",
+)
 
 
 def create_parser_for_docs() -> argparse.ArgumentParser:
@@ -259,6 +265,7 @@ def _add_repo_parsers(
             template_org_parser,
             _REPO_NAME_PARSER,
             _HOOK_RESULTS_PARSER,
+            _LOCAL_TEMPLATES_PARSER,
         ],
         formatter_class=_OrderedFormatter,
     )
@@ -277,6 +284,7 @@ def _add_repo_parsers(
             base_student_parser,
             template_org_parser,
             _REPO_NAME_PARSER,
+            _LOCAL_TEMPLATES_PARSER,
         ],
         formatter_class=_OrderedFormatter,
     )

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -317,7 +317,7 @@ def _add_repo_parsers(
             "The repos must be local on disk to be migrated. Note that "
             "migrated repos will be private."
         ),
-        parents=[_REPO_NAME_PARSER, base_parser],
+        parents=[_REPO_NAME_PARSER, base_parser, _LOCAL_TEMPLATES_PARSER],
         formatter_class=_OrderedFormatter,
     )
 

--- a/src/_repobee/main.py
+++ b/src/_repobee/main.py
@@ -176,6 +176,9 @@ def main(sys_args: List[str], unload_plugins: bool = True):
             "--no-plugins config-wizard` to remove any offending plugins."
         )
         sys.exit(1)
+    except exception.ParseError as exc:
+        plug.log.error(str(exc))
+        sys.exit(1)
     except Exception as exc:
         # FileErrors can occur during pre-init because of reading the config
         # and we don't want tracebacks for those (afaik at this time)

--- a/system_tests/test_gitlab_system.py
+++ b/system_tests/test_gitlab_system.py
@@ -315,6 +315,7 @@ class TestMigrate:
                 *repobee_plug.cli.CoreCommand.repos.migrate.as_name_tuple(),
                 *BASE_ARGS,
                 *MASTER_REPOS_ARG,
+                "--allow-local-templates",
             ]
         )
 

--- a/tests/new_integration_tests/test_teams.py
+++ b/tests/new_integration_tests/test_teams.py
@@ -1,0 +1,22 @@
+"""Tests for the teams category of commands."""
+
+from repobee_testhelpers import funcs
+from repobee_testhelpers import const
+
+
+class TestCreate:
+    """Tests for ``teams create``."""
+
+    def test_run_when_no_teams_exist(self, platform_url):
+        funcs.run_repobee(f"teams create --base-url {platform_url}")
+        assert sorted(funcs.get_student_teams(platform_url)) == sorted(
+            const.STUDENT_TEAMS
+        )
+
+    def test_run_twice(self, platform_url):
+        """It should be fine to create teams twice."""
+        funcs.run_repobee(f"teams create --base-url {platform_url}")
+        funcs.run_repobee(f"teams create --base-url {platform_url}")
+        assert sorted(funcs.get_student_teams(platform_url)) == sorted(
+            const.STUDENT_TEAMS
+        )

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -1037,6 +1037,7 @@ class TestMigrateParser:
             *BASE_ARGS,
             "-a",
             *self.NAMES,
+            "--allow-local-templates",
         ]
 
         parsed_args, _ = _repobee.cli.parsing.handle_args(sys_args)

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -1002,6 +1002,7 @@ class TestSetupAndUpdateParsers:
             *COMPLETE_PUSH_ARGS,
             "-s",
             *STUDENTS_STRING.split(),
+            "--allow-local-templates",
         ]
 
         parsed_args, _ = _repobee.cli.parsing.handle_args(sys_args)


### PR DESCRIPTION
Fix #627 

Adds the `--allow-local-templates` option to the `setup`, `update` and `migrate` commands. It currently doesn't make much sense for the migrate command as it's only function is to use local repos, but migrate should also be able to pull repos from the template organization.

If `--allow-local-templates` is not specified, and RepoBee finds local templates, an error is displayed listing the local templates and RepoBee exits.