### PR TITLE
[feat] Add support for default branch names other than master

### DIFF
--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -359,7 +359,7 @@ def migrate_repos(
                 git.Push(
                     local_path=template_repo.path,
                     repo_url=api.insert_auth(template_repo.url),
-                    branch=git.active_branch(template_repo.repo_path),
+                    branch=git.active_branch(template_repo.path),
                 )
                 for template_repo in remote_templates
             ]

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -131,7 +131,7 @@ def _create_push_tuples(
         yield git.Push(
             local_path=template_repo.path,
             repo_url=api.insert_auth(repo.url),
-            branch="master",
+            branch=git.active_branch(template_repo.path),
         )
 
 
@@ -359,7 +359,7 @@ def migrate_repos(
                 git.Push(
                     local_path=template_repo.path,
                     repo_url=api.insert_auth(template_repo.url),
-                    branch="master",
+                    branch=git.active_branch(template_repo.repo_path),
                 )
                 for template_repo in remote_templates
             ]

--- a/src/_repobee/git.py
+++ b/src/_repobee/git.py
@@ -15,6 +15,7 @@ import shutil
 from typing import Iterable, List, Any, Callable, Tuple
 
 import more_itertools
+import git
 
 import repobee_plug as plug
 
@@ -80,7 +81,10 @@ def captured_run(*args, **kwargs):
 
 
 def clone_single(repo_url: str, branch: str = "", cwd: str = "."):
-    """Clone a git repository.
+    """Clone a git repository with ``git clone``.
+
+    This should only be used for temporary cloning, as any secure tokens in the
+    repo URL are stored in the repository.
 
     Args:
         repo_url: HTTPS url to repository on the form
@@ -88,10 +92,13 @@ def clone_single(repo_url: str, branch: str = "", cwd: str = "."):
         branch: The branch to clone.
         cwd: Working directory. Defaults to the current directory.
     """
-    rc, stderr = _pull_clone(repo_url, branch, cwd)
+    command = [*"git clone --single-branch".split(), repo_url] + (
+        [branch] if branch else []
+    )
+    rc, _, stderr = captured_run(command, cwd=cwd)
     if rc != 0:
         raise exception.CloneFailedError(
-            "Failed to clone", rc, stderr, repo_url
+            "Failed to clone", rc, stderr, repo_url,
         )
 
 
@@ -310,3 +317,14 @@ async def _batch_execution_async(
         plug.log.error(str(exc))
 
     return exceptions
+
+
+def active_branch(repo_path: pathlib.Path) -> str:
+    """Get the active branch from the given repo.
+
+    Args:
+        repo_path: Path to a repo.
+    Returns:
+        The active branch of the repo.
+    """
+    return git.Repo(repo_path).active_branch.name

--- a/src/_repobee/git.py
+++ b/src/_repobee/git.py
@@ -44,20 +44,10 @@ def _git_init(dirpath):
     captured_run(["git", "init"], cwd=str(dirpath))
 
 
-def _pull_clone(repo_url: str, branch: str = "", cwd: str = "."):
+async def _pull_clone_async(repo_url: str, branch: str = "", cwd: str = "."):
     """Simulate a clone with a pull to avoid writing remotes (that could
     include secure tokens) to disk.
     """
-    dirpath = _ensure_repo_dir_exists(repo_url, cwd)
-
-    pull_command = "git pull {} {}".format(repo_url, branch).strip().split()
-
-    rc, _, stderr = captured_run(pull_command, cwd=str(dirpath))
-    return rc, stderr
-
-
-async def _pull_clone_async(repo_url: str, branch: str = "", cwd: str = "."):
-    """Same as _pull_clone, but asynchronously."""
     dirpath = _ensure_repo_dir_exists(repo_url, cwd)
 
     pull_command = "git pull {} {}".format(repo_url, branch).strip().split()

--- a/tests/unit_tests/repobee/test_git.py
+++ b/tests/unit_tests/repobee/test_git.py
@@ -110,12 +110,14 @@ def test_clone_single_raises_on_non_zero_exit_from_git_pull(env_setup, mocker):
 
 
 def test_clone_single_issues_correct_command_with_defaults(env_setup):
-    expected_command = "git pull {}".format(env_setup.expected_url).split()
+    expected_command = (
+        f"git clone --single-branch {env_setup.expected_url}".split()
+    )
 
     git.clone_single(URL_TEMPLATE.format(""))
     subprocess.run.assert_any_call(
         expected_command,
-        cwd=str(pathlib.Path(".") / REPO_NAME),
+        cwd=".",
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
@@ -123,15 +125,15 @@ def test_clone_single_issues_correct_command_with_defaults(env_setup):
 
 def test_clone_single_issues_correct_command_non_default_branch(env_setup):
     branch = "other-branch"
-    expected_command = "git pull {} {}".format(
-        env_setup.expected_url, branch
-    ).split()
+    expected_command = (
+        f"git clone --single-branch {env_setup.expected_url} {branch}".split()
+    )
 
     git.clone_single(URL_TEMPLATE.format(""), branch=branch)
 
     subprocess.run.assert_any_call(
         expected_command,
-        cwd=str(pathlib.Path(".") / REPO_NAME),
+        cwd=".",
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )
@@ -140,14 +142,14 @@ def test_clone_single_issues_correct_command_non_default_branch(env_setup):
 def test_clone_single_issues_correct_command_with_cwd(env_setup):
     working_dir = "some/working/dir"
     branch = "other-branch"
-    expected_command = "git pull {} {}".format(
-        env_setup.expected_url, branch
-    ).split()
+    expected_command = (
+        f"git clone --single-branch {env_setup.expected_url} {branch}".split()
+    )
 
     git.clone_single(URL_TEMPLATE.format(""), branch=branch, cwd=working_dir)
     subprocess.run.assert_called_once_with(
         expected_command,
-        cwd=str(pathlib.Path(working_dir) / REPO_NAME),
+        cwd=str(working_dir),
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
     )


### PR DESCRIPTION
Fix #467 

The `setup`, `update` and `migrate` commands now use the default branch name of the template repo, instead of using "master".

There is a little quirk to this: cloned student repos will still always display Git's default branch name, which currently is "master". The reason for this is that student repos are "cloned" with a pull, and that simply feeds the default branch of the remote repo into the active branch of the local repo (which is always Git's default). 

This CAN be solved by first runing `git ls-remote --symref <REPO_URL>`, but that's an extra network call that I'd like to avoid.