### PR TITLE
[fix] Fix repos setup/update semantics

### DIFF
--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -277,7 +277,7 @@ def _create_update_push_tuples(
     for repo in api.get_repos(urls_to_templates.keys()):
         template = urls_to_templates[repo.url]
         branch = git.active_branch(template.path)
-        yield git.Push(template.path, repo.url, branch)
+        yield git.Push(template.path, api.insert_auth(repo.url), branch)
 
 
 def _open_issue_by_urls(

--- a/src/repobee_testhelpers/funcs.py
+++ b/src/repobee_testhelpers/funcs.py
@@ -14,11 +14,21 @@ from repobee_testhelpers import localapi
 from repobee_testhelpers import const
 
 
-def initialize_repo(path: pathlib.Path) -> git.Repo:
-    """Initialize the directory to a Git repo and commit all files in it."""
+def initialize_repo(
+    path: pathlib.Path, default_branch: str = "master"
+) -> git.Repo:
+    """Initialize the directory to a Git repo and commit all files in it.
+
+    Args:
+        path: Path to the directory to turn into a Git repository.
+        default_branch: Name of the default branch to use.
+    Returns:
+        A repo.
+    """
     repo = git.Repo.init(path)
     repo.git.config("user.name", const.TEACHER)
     repo.git.config("user.email", f"{const.TEACHER}@repobee.org")
+    repo.git.checkout("-b", default_branch)
     repo.git.add(".", "--force")
     repo.git.commit("-m", "Initial commit")
     return repo


### PR DESCRIPTION
Fix #630 

* `repos setup` does not try to push to existing repos anymore
* `repos update` does not create non-existing repos anymore