### PR TITLE
[break] Remove the --show-all-opts functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,6 @@ usage: repobee [-h] [-v] {repos,teams,issues,reviews,config,plugin,manage} ...
 A CLI tool for administrating large amounts of git repositories on GitHub and
 GitLab instances. Read the docs at: https://repobee.readthedocs.io
 
-CLI options that are set in the config file are suppressed in help sections,
-run with pre-parser option --show-all-opts to unsuppress.
-Example: repobee --show-all-opts setup -h
-
 Loaded plugins: distmanager-3.0.0-alpha.7, pluginmanager-3.0.0-alpha.7
 
 positional arguments:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -73,10 +73,6 @@ You can view all available categories like so.
     A CLI tool for administrating large amounts of git repositories on GitHub and
     GitLab instances. Read the docs at: https://repobee.readthedocs.io
 
-    CLI options that are set in the config file are suppressed in help sections,
-    run with pre-parser option --show-all-opts to unsuppress.
-    Example: repobee --show-all-opts setup -h
-
     Loaded plugins: distmanager-3.0.0-beta.1, pluginmanager-3.0.0-beta.1
 
     positional arguments:

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -18,6 +18,7 @@ import sys
 import enum
 from typing import Iterable, Optional, List, Tuple
 
+import argcomplete
 import daiquiri
 import repobee_plug as plug
 from repobee_plug.cli import categorization
@@ -39,7 +40,6 @@ class _ArgsProcessing(enum.Enum):
 
 def handle_args(
     sys_args: Iterable[str],
-    show_all_opts: bool = False,
     config_file: pathlib.Path = constants.DEFAULT_CONFIG_FILE,
 ) -> Tuple[argparse.Namespace, Optional[plug.PlatformAPI]]:
     """Parse and process command line arguments and instantiate the platform
@@ -49,15 +49,11 @@ def handle_args(
     Args:
         sys_args: Raw command line arguments for the primary parser.
         config_file: Path to the config file.
-        show_all_opts: If False, help sections for options that have
-            configured defaults are suppressed. Otherwise, all options are
-            shown.
-
     Returns:
         A tuple of a namespace with parsed and processed arguments, and an
         instance of the platform API if it is required for the command.
     """
-    args, processing = _parse_args(sys_args, config_file, show_all_opts)
+    args, processing = _parse_args(sys_args, config_file)
     plug.manager.hook.handle_parsed_args(args=args)
 
     if processing == _ArgsProcessing.CORE:
@@ -70,9 +66,7 @@ def handle_args(
 
 
 def _parse_args(
-    sys_args: Iterable[str],
-    config_file: pathlib.Path,
-    show_all_opts: bool = False,
+    sys_args: Iterable[str], config_file: pathlib.Path,
 ) -> Tuple[argparse.Namespace, _ArgsProcessing]:
     """Parse the command line arguments with some light processing. Any
     processing that requires external resources (such as a network connection)
@@ -81,14 +75,12 @@ def _parse_args(
     Args:
         sys_args: A list of command line arguments.
         config_file: Path to the config file.
-        show_all_opts: If False, CLI arguments that are configure in the
-            configuration file are not shown in help menus.
-
     Returns:
         A namespace of parsed arpuments and a boolean that specifies whether or
         not further processing is required.
     """
-    parser = cli.mainparser.create_parser(show_all_opts, config_file)
+    parser = cli.mainparser.create_parser(config_file)
+    argcomplete.autocomplete(parser)
 
     args = parser.parse_args(_handle_deprecation(sys_args))
 

--- a/src/_repobee/cli/preparser.py
+++ b/src/_repobee/cli/preparser.py
@@ -2,11 +2,10 @@
 
 The preparser runs before the primary parser
 (see :py:mod:`_repobee.cli.mainparser`). The reason for this somewhat
-convoluted setup is that:
-
-1. Plugins need to be able to add options to the CLI, which is only
-possible if a separate parser runs before the primary parser.
-2. Certain options affect how the CLI behaves, such as ``--show-all-opts``.
+convoluted setup is that plugins need to be able to add options to the CLI.
+As we want to be able to specify plugins on the command line, which may
+add options to the command line, this becomes a chicken or egg problem.
+The preparser solves this.
 
 .. module:: preparser
     :synopsis: The preparser for RepoBee.
@@ -26,9 +25,8 @@ PRE_PARSER_CONFIG_OPTS = ["-c", "--config-file"]
 PRE_PARSER_OPTS = PRE_PARSER_PLUG_OPTS + PRE_PARSER_CONFIG_OPTS
 
 PRE_PARSER_NO_PLUGS = "--no-plugins"
-PRE_PARSER_SHOW_ALL_OPTS = "--show-all-opts"
 # this list should include all pre-parser flags
-PRE_PARSER_FLAGS = [PRE_PARSER_NO_PLUGS, PRE_PARSER_SHOW_ALL_OPTS]
+PRE_PARSER_FLAGS = [PRE_PARSER_NO_PLUGS]
 
 
 def parse_args(sys_args: List[str]) -> argparse.Namespace:
@@ -49,11 +47,6 @@ def parse_args(sys_args: List[str]) -> argparse.Namespace:
         help="Specify path to the config file to use.",
         type=pathlib.Path,
         default=_repobee.constants.DEFAULT_CONFIG_FILE,
-    )
-    parser.add_argument(
-        PRE_PARSER_SHOW_ALL_OPTS,
-        help="Unsuppress all options in help menus",
-        action="store_true",
     )
 
     mutex_grp = parser.add_mutually_exclusive_group()

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -149,7 +149,7 @@ def _extract_flat_cli_options(
     return itertools.chain.from_iterable(map(_flatten_arg, cli_args))
 
 
-def _attach_options(self, config, show_all_opts, parser):
+def _attach_options(self, config, parser):
     parser = (
         parser
         if not isinstance(self, cli.CommandExtension)
@@ -172,7 +172,7 @@ def _attach_options(self, config, show_all_opts, parser):
                 f"Plugin '{self.plugin_name}' does not allow "
                 f"'{name}' to be configured"
             )
-        _add_option(name, opt, configured_value, show_all_opts, parser)
+        _add_option(name, opt, configured_value, parser)
 
     return parser
 
@@ -209,7 +209,6 @@ def _add_option(
     name: str,
     opt: Union[Option, MutuallyExclusiveGroup],
     configured_value: str,
-    show_all_opts: bool,
     parser: Union[argparse.ArgumentParser, argparse._MutuallyExclusiveGroup],
 ) -> None:
     """Add an option to the parser based on the cli option."""
@@ -219,11 +218,7 @@ def _add_option(
         )
         for (mutex_opt_name, mutex_opt) in opt.options:
             _add_option(
-                mutex_opt_name,
-                mutex_opt,
-                configured_value,
-                show_all_opts,
-                mutex_parser,
+                mutex_opt_name, mutex_opt, configured_value, mutex_parser,
             )
         return
 
@@ -234,11 +229,7 @@ def _add_option(
     if opt.converter:
         kwargs["type"] = opt.converter
 
-    kwargs["help"] = (
-        argparse.SUPPRESS
-        if (configured_value and not show_all_opts)
-        else opt.help or ""
-    )
+    kwargs["help"] = opt.help or ""
 
     if opt.argument_type in [cli.ArgumentType.OPTION, cli.ArgumentType.FLAG]:
         if opt.short_name:

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -468,48 +468,6 @@ def test_create_parser_for_docs(no_plugins):
 class TestBaseParsing:
     """Test the basic functionality of parsing."""
 
-    def test_show_all_opts_true_shows_configured_args(
-        self, config_mock, capsys
-    ):
-        """Test that configured args are shown when show_all_opts is True."""
-        with pytest.raises(SystemExit):
-            _repobee.cli.parsing.handle_args(
-                [
-                    *repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(),
-                    "-h",
-                ],
-                show_all_opts=True,
-            )
-
-        captured = capsys.readouterr()
-        assert "--user" in captured.out
-        assert "--base-url" in captured.out
-        assert "--org-name" in captured.out
-        assert "--template-org-name" in captured.out
-        assert "--students-file" in captured.out
-        assert "--token" in captured.out
-
-    def test_show_all_opts_false_hides_configured_args(
-        self, config_mock, capsys
-    ):
-        """Test that configured args are hidden when show_all_opts is False."""
-        with pytest.raises(SystemExit):
-            _repobee.cli.parsing.handle_args(
-                [
-                    *repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(),
-                    "-h",
-                ],
-                show_all_opts=False,
-            )
-
-        captured = capsys.readouterr()
-        assert "--user" not in captured.out
-        assert "--base-url" not in captured.out
-        assert "--org-name" not in captured.out
-        assert "--template-org-name" not in captured.out
-        assert "--students-file" not in captured.out
-        assert "--token" not in captured.out
-
     @pytest.mark.parametrize(
         "action",
         [

--- a/tests/unit_tests/repobee/test_main.py
+++ b/tests/unit_tests/repobee/test_main.py
@@ -100,9 +100,7 @@ def test_happy_path(
     main.main(sys_args)
 
     handle_args_mock.assert_called_once_with(
-        sys_args[1:],
-        show_all_opts=False,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
+        sys_args[1:], config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
     dispatch_command_mock.assert_called_once_with(
         PARSED_ARGS, api_instance_mock, _repobee.constants.DEFAULT_CONFIG_FILE
@@ -121,9 +119,7 @@ def test_exit_status_1_on_exception_in_parsing(
 
     assert exc_info.value.code == 1
     handle_args_mock.assert_called_once_with(
-        sys_args[1:],
-        show_all_opts=False,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
+        sys_args[1:], config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
     assert not dispatch_command_mock.called
 
@@ -141,9 +137,7 @@ def test_exit_status_1_on_exception_in_handling_parsed_args(
 
     assert exc_info.value.code == 1
     handle_args_mock.assert_called_once_with(
-        sys_args[1:],
-        show_all_opts=False,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
+        sys_args[1:], config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
 
 
@@ -163,9 +157,7 @@ def test_plugins_args(
         any_order=True,
     )
     handle_args_mock.assert_called_once_with(
-        CLONE_ARGS,
-        show_all_opts=False,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
+        CLONE_ARGS, config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
 
 
@@ -183,9 +175,7 @@ def test_no_plugins_arg(
         DEFAULT_PLUGIN_NAMES, allow_qualified=True
     )
     handle_args_mock.assert_called_once_with(
-        CLONE_ARGS,
-        show_all_opts=False,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
+        CLONE_ARGS, config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
 
 
@@ -203,9 +193,7 @@ def test_no_plugins_with_configured_plugins(
         DEFAULT_PLUGIN_NAMES, allow_qualified=True
     )
     handle_args_mock.assert_called_once_with(
-        CLONE_ARGS,
-        show_all_opts=False,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
+        CLONE_ARGS, config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
 
 
@@ -244,9 +232,7 @@ def test_plugin_with_subparser_name(
         any_order=True,
     )
     handle_args_mock.assert_called_once_with(
-        CLONE_ARGS,
-        show_all_opts=False,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
+        CLONE_ARGS, config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
     )
 
 
@@ -327,44 +313,7 @@ def test_logs_traceback_on_exception_in_dispatch_if_traceback(
     assert logger_exception_mock.called
     handle_args_mock.assert_called_once_with(
         [*CLONE_ARGS, "--traceback"],
-        show_all_opts=False,
         config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
-    )
-
-
-def test_show_all_opts_correctly_separated(
-    handle_args_mock, parse_preparser_options_mock, no_config_mock
-):
-    msg = "expected exit"
-
-    def _raise_sysexit(*args, **kwargs):
-        raise SystemExit(msg)
-
-    parse_preparser_options_mock.return_value = argparse.Namespace(
-        show_all_opts=True,
-        no_plugins=False,
-        plug=None,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
-    )
-    handle_args_mock.side_effect = _raise_sysexit
-    sys_args = [
-        "repobee",
-        _repobee.cli.preparser.PRE_PARSER_SHOW_ALL_OPTS,
-        *repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(),
-        "-h",
-    ]
-
-    with pytest.raises(SystemExit) as exc_info:
-        main.main(sys_args)
-
-    assert msg in str(exc_info.value)
-    handle_args_mock.assert_called_once_with(
-        [*repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(), "-h"],
-        show_all_opts=True,
-        config_file=_repobee.constants.DEFAULT_CONFIG_FILE,
-    )
-    parse_preparser_options_mock.assert_called_once_with(
-        [_repobee.cli.preparser.PRE_PARSER_SHOW_ALL_OPTS]
     )
 
 

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -138,9 +138,7 @@ class TestDeclarativeExtensionCommand:
         """Test the parser that's generated automatically."""
         plugin_instance = basic_greeting_command("g")
         parser = argparse.ArgumentParser()
-        plugin_instance.attach_options(
-            config={}, show_all_opts=False, parser=parser
-        )
+        plugin_instance.attach_options(config={}, parser=parser)
         args = parser.parse_args("--name Eve".split())
 
         assert args.name == "Eve"
@@ -162,9 +160,7 @@ class TestDeclarativeExtensionCommand:
         config = {plugin_name: {"name": configured_name}}
         plugin_instance = Greeting("greeting")
         parser = argparse.ArgumentParser()
-        plugin_instance.attach_options(
-            config=config, show_all_opts=False, parser=parser
-        )
+        plugin_instance.attach_options(config=config, parser=parser)
         args = parser.parse_args([])
 
         assert args.name == configured_name
@@ -229,9 +225,7 @@ class TestDeclarativeExtensionCommand:
         parser = argparse.ArgumentParser()
 
         with pytest.raises(plug.PlugError) as exc_info:
-            plugin_instance.attach_options(
-                config=config, show_all_opts=False, parser=parser
-            )
+            plugin_instance.attach_options(config=config, parser=parser)
 
         assert (
             f"Plugin '{plugin_name}' does not allow 'name' to be configured"
@@ -256,9 +250,7 @@ class TestDeclarativeExtensionCommand:
 
         plugin_instance = Greeting("g")
         parser = argparse.ArgumentParser()
-        plugin_instance.attach_options(
-            config={}, show_all_opts=False, parser=parser
-        )
+        plugin_instance.attach_options(config={}, parser=parser)
         name = "Alice"
 
         short_opt_args = parser.parse_args(f"-n {name}".split())
@@ -277,9 +269,7 @@ class TestDeclarativeExtensionCommand:
 
         plugin_instance = Greeting("g")
         parser = argparse.ArgumentParser()
-        plugin_instance.attach_options(
-            config={}, show_all_opts=False, parser=parser
-        )
+        plugin_instance.attach_options(config={}, parser=parser)
 
         name = "Alice"
         age = 33
@@ -305,9 +295,7 @@ class TestDeclarativeExtensionCommand:
 
         plugin_instance = Greeting("g")
         parser = argparse.ArgumentParser()
-        plugin_instance.attach_options(
-            config={}, show_all_opts=False, parser=parser
-        )
+        plugin_instance.attach_options(config={}, parser=parser)
 
         with pytest.raises(SystemExit):
             parser.parse_args("--age 12 --old".split())
@@ -348,9 +336,7 @@ class TestDeclarativeExtensionCommand:
 
         plugin_instance = Greeting("g")
         parser = argparse.ArgumentParser()
-        plugin_instance.attach_options(
-            config={}, show_all_opts=False, parser=parser
-        )
+        plugin_instance.attach_options(config={}, parser=parser)
 
         parsed_args = parser.parse_args(["--old"])
 


### PR DESCRIPTION
Fix #634 

This turned out to cause massive issues in conjunction with plugins and tab completion. The only reasonable thing to do is to remove `--show-all-opts` and just show all options by default. It was after all just a dirty fix to a messy CLI. The CLI should be ordered in argument groups instead, for clarity.

Technically this is breaking and should lead to the release of RepoBee 4.0, but as RepoBee 3.0 has been out for just a few hours, I'm going to make an exception for this fix. It is after all a fix for a critical error.