### PR TITLE
[misc] Group related CLI arguments

### DIFF
--- a/docs/code.rst
+++ b/docs/code.rst
@@ -34,6 +34,12 @@ preparser
 .. automodule:: _repobee.cli.preparser
     :members:
 
+argparse_ext
+------------
+
+.. automodule:: _repobee.cli.argparse_ext
+    :members:
+
 config
 ====================
 

--- a/src/_repobee/cli/argparse_ext.py
+++ b/src/_repobee/cli/argparse_ext.py
@@ -1,0 +1,115 @@
+"""RepoBee extensions of argparse."""
+import argparse
+
+from typing import Optional
+
+from _repobee import constants
+
+__all__ = ["RepobeeParser", "OrderedFormatter"]
+
+
+class RepobeeParser(argparse.ArgumentParser):
+    """A thin wrapper around :py:class:`argparse.ArgumentParser`. The primary
+    functionality of this class is to group the core CLI arguments into
+    argument groups such that the CLI doesn't get too cluttered.
+    """
+
+    def __init__(self, *args, is_core_command: bool = False, **kwargs):
+        self._is_core_command = is_core_command
+        super().__init__(*args, **kwargs)
+        self._platform_args_grp = self.add_argument_group(
+            title="platform arguments",
+            description="Arguments related to the platform "
+            "(e.g. GitHub or GitLab)",
+        )
+        self._debug_args_grp = self.add_argument_group(title="debug arguments")
+        self._alpha_args_grp = self.add_argument_group(
+            title="alpha arguments",
+            description="Arguments that are currently being trialed in alpha, "
+            "and may change without further notice",
+        )
+
+    def add_argument(self, *args, **kwargs):
+        """Add an argument to this parser, placing it in an appropriate
+        argument group.
+        """
+        if not self._is_core_command:
+            return super().add_argument(*args, **kwargs)
+
+        platform_args = {
+            "--token",
+            "--org-name",
+            "--template-org-name",
+            "--user",
+            "--base-url",
+        }
+        debug_args = {"--traceback"}
+        alpha_args = {"--hook-results-file"}
+
+        for arg in args:
+            if arg in platform_args:
+                return self._platform_args_grp.add_argument(*args, **kwargs)
+            elif arg in debug_args:
+                return self._debug_args_grp.add_argument(*args, **kwargs)
+            elif arg in alpha_args:
+                return self._alpha_args_grp.add_argument(*args, **kwargs)
+
+        return super().add_argument(*args, **kwargs)
+
+    def add_argument_group(
+        self, title: Optional[str] = None, description: Optional[str] = None
+    ) -> argparse._ArgumentGroup:
+        """Create a new argument group if the title does not exist, or return
+        an existing one if it does.
+        """
+        for grp in self._action_groups:
+            if grp.title == title:
+                if description is not None:
+                    grp.descripion = description
+                return grp
+        return super().add_argument_group(title, description)
+
+
+class OrderedFormatter(argparse.HelpFormatter):
+    """A formatter class for putting out the help section in a proper order.
+    All of the arguments that are configurable in the configuration file
+    should appear at the bottom (in arbitrary, but always the same, order).
+    Any other arguments should appear in the order they are added.
+
+    The internals of the formatter classes are technically not public,
+    so this class is "unsafe" when it comes to new versions of Python. It may
+    have to be disabled for future versions, but it works for 3.6, 3.7 and 3.8
+    at the time of writing. If this turns troublesome, it may be time to
+    switch to some other CLI library.
+    """
+
+    def add_arguments(self, actions):
+        """Order actions by the name  of the long argument, and then add them
+        as arguments.
+
+        The order is the following:
+
+        [ NON-CONFIGURABLE | CONFIGURABLE | DEBUG ]
+
+        Non-configurable arguments added without modification, which by
+        default is the order they are added to the parser. Configurable
+        arguments are added in the order defined by
+        :py:const:`constants.ORDERED_CONFIGURABLE_ARGS`. Finally, debug
+        commands (such as ``--traceback``) are added in arbitrary (but
+        consistent) order.
+        """
+        args_order = tuple(
+            "--" + name.replace("_", "-")
+            for name in constants.ORDERED_CONFIGURABLE_ARGS
+        ) + ("--traceback",)
+
+        def key(action):
+            if len(action.option_strings) < 2:
+                return -1
+            long_arg = action.option_strings[1]
+            if long_arg in args_order:
+                return args_order.index(long_arg)
+            return -1
+
+        actions = sorted(actions, key=key)
+        super().add_arguments(actions)

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -839,7 +839,6 @@ def _create_base_parsers(config_file):
     _add_traceback_arg(base_parser)
     # base parser for when student lists are involved
     base_student_parser = _RepobeeParser(is_core_command=True, add_help=False)
-    print("students")
     students = base_student_parser.add_argument_group(
         "core"
     ).add_mutually_exclusive_group(required=not configured("students_file"))

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -19,6 +19,7 @@ import _repobee.plugin
 import _repobee.ext.defaults.configwizard
 import repobee_plug.cli
 from _repobee.cli import mainparser
+from _repobee.cli import argparse_ext
 from _repobee import exception
 
 import constants
@@ -440,7 +441,7 @@ def test_help_calls_add_arguments(monkeypatch, action):
     removed or changed in future versions of Python.
     """
     called = False
-    add_arguments = mainparser._OrderedFormatter.add_arguments
+    add_arguments = argparse_ext.OrderedFormatter.add_arguments
 
     def wrapper(self, *args, **kwargs):
         nonlocal called
@@ -448,7 +449,7 @@ def test_help_calls_add_arguments(monkeypatch, action):
         add_arguments(self, *args, **kwargs)
 
     monkeypatch.setattr(
-        "_repobee.cli.mainparser._OrderedFormatter.add_arguments", wrapper
+        "_repobee.cli.argparse_ext.OrderedFormatter.add_arguments", wrapper
     )
 
     with pytest.raises(SystemExit) as exc_info:


### PR DESCRIPTION
Fix #638 

This update is purely cosmetic, there are no functional changes.

The CLI help sections are now much better organized and looks something like this:

```
$ repobee repos clone -h
usage: repobee repos clone [-h] [-u USER] [-o ORG_NAME] [--bu BASE_URL] [-t TOKEN] [--tb] (--sf STUDENTS_FILE | -s STUDENTS [STUDENTS ...]) (-a ASSIGNMENTS [ASSIGNMENTS ...] | --discover-repos) [--hook-results-file HOOK_RESULTS_FILE]

Clone student repos asynchronously in bulk.

optional arguments:
  -h, --help            show this help message and exit
  -s STUDENTS [STUDENTS ...], --students STUDENTS [STUDENTS ...]
                        One or more whitespace separated student usernames.
  -a ASSIGNMENTS [ASSIGNMENTS ...], --assignments ASSIGNMENTS [ASSIGNMENTS ...]
                        one or more names of assignments
  --discover-repos      discover all repositories for the specified students (NOTE: expensive in terms of API calls)
  --sf STUDENTS_FILE, --students-file STUDENTS_FILE
                        path to a list of student usernames or groups of students

platform arguments:
  Arguments related to the platform (e.g. GitHub or GitLab)

  -u USER, --user USER  your username
  --bu BASE_URL, --base-url BASE_URL
                        Base url to a platform API. Must be HTTPS. For example, with github.com, the base url is https://api.github.com, and with GitHub enterprise, the url is https://<ENTERPRISE_HOST>/api/v3
  -o ORG_NAME, --org-name ORG_NAME
                        name of the target organization
  -t TOKEN, --token TOKEN
                        access token for the platform instance

debug arguments:
  --tb, --traceback     Show the full traceback of critical exceptions.

alpha arguments:
  Arguments that are currently being trialed in alpha, and may change without further notice

  --hook-results-file HOOK_RESULTS_FILE
                        path to a .json file to store results from plugin hooks in

```

instead of the old version, that looked like this:

```
$ repobee repos clone -h
usage: repobee repos clone [-h] [-u USER] [-o ORG_NAME] [--bu BASE_URL] [-t TOKEN] [--tb] (--sf STUDENTS_FILE | -s STUDENTS [STUDENTS ...]) (-a ASSIGNMENTS [ASSIGNMENTS ...] | --discover-repos) [--hook-results-file HOOK_RESULTS_FILE]

Clone student repos asynchronously in bulk.

optional arguments:
  -h, --help            show this help message and exit
  -s STUDENTS [STUDENTS ...], --students STUDENTS [STUDENTS ...]
                        One or more whitespace separated student usernames.
  -a ASSIGNMENTS [ASSIGNMENTS ...], --assignments ASSIGNMENTS [ASSIGNMENTS ...]
                        one or more names of assignments
  --discover-repos      discover all repositories for the specified students (NOTE: expensive in terms of API calls)
  --hook-results-file HOOK_RESULTS_FILE
                        path to a .json file to store results from plugin hooks in
  -u USER, --user USER  your username
  --bu BASE_URL, --base-url BASE_URL
                        Base url to a platform API. Must be HTTPS. For example, with github.com, the base url is https://api.github.com, and with GitHub enterprise, the url is https://<ENTERPRISE_HOST>/api/v3
  -o ORG_NAME, --org-name ORG_NAME
                        name of the target organization
  -t TOKEN, --token TOKEN
                        access token for the platform instance
  --sf STUDENTS_FILE, --students-file STUDENTS_FILE
                        path to a list of student usernames or groups of students
  --tb, --traceback     Show the full traceback of critical exceptions.
```