### PR TITLE
[feat] Add a `--quiet` option to silence stdout, warnings and errors

### DIFF
--- a/src/_repobee/cli/argparse_ext.py
+++ b/src/_repobee/cli/argparse_ext.py
@@ -43,7 +43,7 @@ class RepobeeParser(argparse.ArgumentParser):
             "--user",
             "--base-url",
         }
-        debug_args = {"--traceback"}
+        debug_args = {"--traceback", "--quiet"}
         alpha_args = {"--hook-results-file"}
 
         for arg in args:

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -342,7 +342,7 @@ def _add_config_parsers(base_parser, template_org_parser, add_parser):
         help="show secrets in the config file that are otherwise sanitized",
         action="store_true",
     )
-    _add_traceback_arg(show_config)
+    _add_debug_args(show_config)
 
     add_parser(
         plug.cli.CoreCommand.config.verify,
@@ -621,7 +621,7 @@ def _add_extension_parsers(
         )
 
         try:
-            _add_traceback_arg(ext_parser)
+            _add_debug_args(ext_parser)
         except argparse.ArgumentError:
             pass
 
@@ -741,7 +741,7 @@ def _create_base_parsers(config_file):
         default=default("token"),
     )
 
-    _add_traceback_arg(base_parser)
+    _add_debug_args(base_parser)
     # base parser for when student lists are involved
     base_student_parser = RepobeeParser(is_core_command=True, add_help=False)
     students = base_student_parser.add_argument_group(
@@ -775,11 +775,19 @@ def _create_base_parsers(config_file):
     return (base_parser, base_student_parser, template_org_parser)
 
 
-def _add_traceback_arg(parser):
+def _add_debug_args(parser):
     parser.add_argument(
         "--tb",
         "--traceback",
-        help="Show the full traceback of critical exceptions.",
+        help="show the full traceback of critical exceptions",
         action="store_true",
         dest="traceback",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        help="silence output (stacks up to 3 times: x1=only warnings "
+        "and errors, x2=only errors, x3=complete and utter silence)",
+        action="count",
+        default=0,
     )

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -362,9 +362,12 @@ def _filter_tokens():
     logging.setLogRecordFactory(record_factory)
 
 
-def setup_logging() -> None:
+def setup_logging(terminal_level: int = logging.WARNING) -> None:
     """Setup logging by creating the required log directory and setting up
     the logger.
+
+    Args:
+        terminal_level: The logging level to use for printing to stderr.
     """
     try:
         os.makedirs(str(constants.LOG_DIR), exist_ok=True)
@@ -377,11 +380,11 @@ def setup_logging() -> None:
         level=logging.DEBUG,
         outputs=(
             daiquiri.output.Stream(
-                sys.stdout,
+                sys.stderr,
                 formatter=daiquiri.formatter.ColorFormatter(
                     fmt="%(color)s[%(levelname)s] %(message)s%(color_stop)s"
                 ),
-                level=logging.WARNING,
+                level=terminal_level,
             ),
             daiquiri.output.File(
                 filename=str(

--- a/src/_repobee/git.py
+++ b/src/_repobee/git.py
@@ -6,12 +6,13 @@
 .. moduleauthor:: Simon Larsén
 """
 import asyncio
-import os
-import subprocess
 import collections
-import pathlib
 import enum
+import os
+import pathlib
 import shutil
+import subprocess
+import sys
 from typing import Iterable, List, Any, Callable, Tuple
 
 import more_itertools
@@ -296,7 +297,7 @@ async def _batch_execution_async(
             for arg in args_chunk
         ]
         for coro in tqdm.asyncio.tqdm_asyncio.as_completed(
-            tasks, desc=f"Progress batch {batch}"
+            tasks, desc=f"Progress batch {batch}", file=sys.stdout,
         ):
             try:
                 await coro

--- a/src/repobee_plug/cli/io.py
+++ b/src/repobee_plug/cli/io.py
@@ -1,4 +1,5 @@
 """IO functionality for plugins."""
+import sys
 
 from typing import Iterable
 from typing import TypeVar
@@ -42,4 +43,4 @@ def progress_bar(it: Iterable[T], *args, **kwargs) -> Iterable[T]:
         An iterable object that returns elements from ``it``, and also updates
         a progress bar in the terminal.
     """
-    return tqdm.tqdm(it, *args, **kwargs)
+    return tqdm.tqdm(it, *args, file=sys.stdout, **kwargs)


### PR DESCRIPTION
Fix #625 

The option stacks up to three times.

* `-q` silences stdout (so everything but warnings and errors)
* `-qq` also silences warnings
* `-qqq` also silences errors

A side note is that logging output that was previously on stdout now goes to stderr. It was actually supposed to go to stderr as of RepoBee 3 but I forgot about it. Additionally, the progress bars that previously went to stderr now go to stdout. I was not aware that they defaulted to stderr, and when they do silencing them requires separate handling, so they go to stdout instead. You're not meant to capture output from RepoBee commands anyway, that's what the logfile is for.