### PR TITLE
[fix] Fix get_repos without argument in GitHub and GitLab APIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ required = [
     "python-gitlab==2.4.0",
     "tabulate",
     "tqdm>=4.48.2",
+    "typing-extensions",
 ]
 
 testhelper_resources_dir = pathlib.Path("src/repobee_testhelpers/resources")

--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -252,6 +252,9 @@ class GitHubAPI(plug.PlatformAPI):
         self, repo_urls: Optional[List[str]] = None
     ) -> Iterable[plug.Repo]:
         """See :py:meth:`repobee_plug.PlatformAPI.get_repos`."""
+        if not repo_urls:
+            return (self._wrap_repo(repo) for repo in self._org.get_repos())
+
         repo_names = map(self.extract_repo_name, repo_urls or [])
         return (
             self._wrap_repo(repo)

--- a/tests/unit_tests/repobee/plugin_tests/test_github.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_github.py
@@ -335,6 +335,14 @@ class TestInit:
         assert isinstance(api, plug.PlatformAPI)
 
 
+class TestGetRepos:
+    """Tests for get_repos."""
+
+    def test_get_all_repos(self, api, repos):
+        """Calling get_repos without an argument should return all repos."""
+        assert len(list(api.get_repos())) == len(repos)
+
+
 class TestInsertAuth:
     """Tests for insert_auth."""
 


### PR DESCRIPTION
Fix #665 

Also sneaks in the `typing-extensions` requirement into setup.py, as it was previously missing. Which caused issues.