### PR TITLE
[feat] Add plugin for managing teacher/TA read access

### DIFF
--- a/src/_repobee/ext/tamanager.py
+++ b/src/_repobee/ext/tamanager.py
@@ -1,0 +1,84 @@
+"""Plugin for managing teaching assistants' access to student repos."""
+from typing import Optional
+
+import repobee_plug as plug
+
+
+TEACHERS_TEAM_NAME = "repobee-teachers"
+
+PLUGIN_DESCRIPTION = """Manager plugin for adding and removing
+teachers/teaching assistants from the taget organization. Teachers are granted
+read access to all repositories in the organization. This plugin only supports
+GitHub. (NOTE: This plugin is not stable yet and may
+change without notice)""".replace(
+    "\n", " "
+)
+
+
+class AddTeachers(plug.Plugin, plug.cli.Command):
+    __settings__ = plug.cli.command_settings(
+        category=plug.cli.CoreCommand.teams,
+        action="add-teachers",
+        help="add teachers/teaching assistants to the organization, with read "
+        "access to all repositories",
+        description="Add teachers/teaching assistants to the "
+        "`repobee-teachers` team, which in turn is granted read access to "
+        "all repositories in the target organization.",
+    )
+
+    teachers = plug.cli.option(
+        help="one or more teachers to add", argparse_kwargs=dict(nargs="+")
+    )
+
+    def command(self, api: plug.PlatformAPI) -> Optional[plug.Result]:
+        teachers_team = _get_or_create_team(TEACHERS_TEAM_NAME, api)
+        existing_members = teachers_team.members
+        new_members = list(set(self.teachers) - set(existing_members))
+
+        api.assign_members(
+            teachers_team, new_members, permission=plug.TeamPermission.PULL
+        )
+
+        for repo in plug.cli.io.progress_bar(
+            api.get_repos(), desc="Granting read access to repos"
+        ):
+            api.assign_repo(
+                repo=repo,
+                team=teachers_team,
+                permission=plug.TeamPermission.PULL,
+            )
+
+        msg = (
+            f"Added {', '.join(new_members)} to the '{TEACHERS_TEAM_NAME}' "
+            "team"
+        )
+        return plug.Result(
+            name="add-teachers", status=plug.Status.SUCCESS, msg=msg
+        )
+
+    def post_setup(self, repo: plug.StudentRepo, api: plug.PlatformAPI):
+        """Add a created student repo to the teachers team."""
+        platform_repo = next(iter(api.get_repos([repo.url])))
+        teachers_team = _get_or_create_team(TEACHERS_TEAM_NAME, api)
+
+        api.assign_repo(
+            team=teachers_team,
+            repo=platform_repo,
+            permission=plug.TeamPermission.PULL,
+        )
+        return plug.Result(
+            name="tamanager",
+            status=plug.Status.SUCCESS,
+            msg=f"Added to the {TEACHERS_TEAM_NAME} team",
+        )
+
+
+def _get_or_create_team(team_name: str, api: plug.PlatformAPI) -> plug.Team:
+    matches = api.get_teams(team_names=[team_name])
+
+    try:
+        return next(iter(matches))
+    except StopIteration:
+        return api.create_team(
+            TEACHERS_TEAM_NAME, permission=plug.TeamPermission.PULL
+        )

--- a/src/_repobee/ext/tamanager.py
+++ b/src/_repobee/ext/tamanager.py
@@ -14,6 +14,16 @@ yet and may change without notice)""".replace(
     "\n", " "
 )
 
+_ADD_TEACHERS_DESCRIPTION = f"""
+Add teachers/teaching assistants to the `{TEACHERS_TEAM_NAME}` team. This team
+is in turn granted read access to all repositories in the organization. The
+point of this is to allow a course responsible to allow teaching assistants to
+access student repositories without being able to manipulate them. To revoke
+read access, simply manually remove users from `{TEACHERS_TEAM_NAME}`.
+""".replace(
+    "\n", " "
+)
+
 
 class AddTeachers(plug.Plugin, plug.cli.Command):
     __settings__ = plug.cli.command_settings(
@@ -21,9 +31,7 @@ class AddTeachers(plug.Plugin, plug.cli.Command):
         action="add-teachers",
         help="add teachers/teaching assistants to the organization, with read "
         "access to all repositories",
-        description="Add teachers/teaching assistants to the "
-        "`repobee-teachers` team, which in turn is granted read access to "
-        "all repositories in the target organization.",
+        description=_ADD_TEACHERS_DESCRIPTION,
     )
 
     teachers = plug.cli.option(

--- a/src/_repobee/ext/tamanager.py
+++ b/src/_repobee/ext/tamanager.py
@@ -8,9 +8,9 @@ TEACHERS_TEAM_NAME = "repobee-teachers"
 
 PLUGIN_DESCRIPTION = """Manager plugin for adding and removing
 teachers/teaching assistants from the taget organization. Teachers are granted
-read access to all repositories in the organization. This plugin only supports
-GitHub. (NOTE: This plugin is not stable yet and may
-change without notice)""".replace(
+read access to all repositories in the organization. This plugin should not be
+used with GitLab due to performance issues. (NOTE: This plugin is not stable
+yet and may change without notice)""".replace(
     "\n", " "
 )
 

--- a/src/_repobee/plugin.py
+++ b/src/_repobee/plugin.py
@@ -386,7 +386,7 @@ def execute_clone_tasks(
     Returns:
         A mapping from repo name to hook result.
     """
-    return _execute_tasks(repos, plug.manager.hook.post_clone, api, cwd)
+    return execute_tasks(repos, plug.manager.hook.post_clone, api, cwd)
 
 
 def execute_setup_tasks(
@@ -403,16 +403,17 @@ def execute_setup_tasks(
     Returns:
         A mapping from repo name to hook result.
     """
-    return _execute_tasks(repos, plug.manager.hook.pre_setup, api, cwd)
+    return execute_tasks(repos, plug.manager.hook.pre_setup, api, cwd)
 
 
-def _execute_tasks(
+def execute_tasks(
     repos: Iterable[Union[plug.StudentRepo, plug.TemplateRepo]],
     hook_function: Callable[
         [pathlib.Path, plug.PlatformAPI], Optional[plug.Result]
     ],
     api: plug.PlatformAPI,
     cwd: Optional[pathlib.Path],
+    copy_repos: bool = True,
 ) -> Mapping[str, List[plug.Result]]:
     """Execute plugin tasks on the provided repos."""
     cwd = cwd or pathlib.Path(".")
@@ -422,8 +423,10 @@ def _execute_tasks(
 
         plug.log.info("Executing tasks ...")
         results = collections.defaultdict(list)
-        for repo in _copy_repos(repos, basedir=copies_root):
-            plug.log.info("Processing {}".format(repo.path.name))
+        for repo in (
+            _copy_repos(repos, basedir=copies_root) if copy_repos else repos
+        ):
+            plug.log.info("Processing {}".format(repo.name))
 
             for result in hook_function(repo=repo, api=api):  # type: ignore
                 if result:

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -117,6 +117,26 @@ class SetupHook:
             for the hook.
         """
 
+    @hookspec
+    def post_setup(
+        self, repo: StudentRepo, api: PlatformAPI
+    ) -> Optional[Result]:
+        """Operate on a student repo after the setup command has executed.
+
+        .. important::
+
+            This hook is only called on freshly created student repos that did
+            not already exist when the setup command was invoked.
+
+        Args:
+            repo: A student repository.
+            api: An instance of the platform API.
+        Returns:
+            Optionally returns a Result for reporting the outcome of the hook.
+            May also return None, in which case no reporting will be performed
+            for the hook.
+        """
+
 
 class ConfigHook:
     """Hook functions related to configuration."""

--- a/src/repobee_testhelpers/localapi.py
+++ b/src/repobee_testhelpers/localapi.py
@@ -208,7 +208,9 @@ class LocalAPI(plug.PlatformAPI):
         """See :py:meth:`repobee_plug.PlatformAPI.get_repos`."""
         repo_names = map(self.extract_repo_name, repo_urls or [])
         unfiltered_repos = (
-            self._repos[self._org_name].get(name) for name in repo_names
+            (self._repos[self._org_name].get(name) for name in repo_names)
+            if repo_urls
+            else self._repos[self._org_name].values()
         )
         return [repo.to_plug_repo() for repo in unfiltered_repos if repo]
 

--- a/tests/new_integration_tests/test_tamanager.py
+++ b/tests/new_integration_tests/test_tamanager.py
@@ -1,0 +1,106 @@
+"""Integration tests for the tamanager plugin."""
+from typing import List
+
+from repobee_testhelpers import funcs
+from repobee_testhelpers import const
+from repobee_testhelpers import localapi
+
+from _repobee.ext import tamanager
+
+
+def test_post_setup_adds_student_repos_to_teacher_team(platform_url):
+    """The post_setup hook should add freshly created student repos to the
+    teachers team.
+    """
+    funcs.run_repobee(
+        f"repos setup -a {const.TEMPLATE_REPOS_ARG} "
+        f"--base-url {platform_url}",
+        plugins=[tamanager],
+    )
+
+    teachers_team = get_teachers_team(platform_url)
+    num_expected_repos = len(const.STUDENT_TEAMS) * len(
+        const.TEMPLATE_REPO_NAMES
+    )
+    assert len(teachers_team.repos) == num_expected_repos
+    expected_repo_names = [r.name for r in funcs.get_repos(platform_url)]
+    actual_repo_names = [r.name for r in teachers_team.repos]
+    assert sorted(expected_repo_names) == sorted(actual_repo_names)
+
+
+def test_add_teachers_command_happy_path(platform_url):
+    """The add-teachers command should add all existing repos to the teachers
+    team, as well as the specified teachers.
+    """
+    # arrange
+    teachers = ["gork", "mork", "slanesh"]
+    setup_student_repos_and_user_accounts(teachers, platform_url)
+
+    # act
+    funcs.run_repobee(
+        f"teams add-teachers --teachers {' '.join(teachers)} "
+        f"--base-url {platform_url}",
+        plugins=[tamanager],
+    )
+
+    # assert
+    teachers_team = get_teachers_team(platform_url)
+    num_expected_repos = len(const.STUDENT_TEAMS) * len(
+        const.TEMPLATE_REPO_NAMES
+    )
+    assert len(teachers_team.repos) == num_expected_repos
+    expected_repo_names = [r.name for r in funcs.get_repos(platform_url)]
+    actual_repo_names = [r.name for r in teachers_team.repos]
+    assert sorted(expected_repo_names) == sorted(actual_repo_names)
+    assert sorted([m.username for m in teachers_team.members]) == sorted(
+        teachers
+    )
+
+
+def test_add_teachers_twice(platform_url):
+    """The effect of running add-teachers once or twice should be identical."""
+    # arrange
+    teachers = ["gork", "mork", "slanesh"]
+    setup_student_repos_and_user_accounts(teachers, platform_url)
+
+    # act
+    for _ in range(2):
+        funcs.run_repobee(
+            f"teams add-teachers --teachers {' '.join(teachers)} "
+            f"--base-url {platform_url}",
+            plugins=[tamanager],
+        )
+
+    # assert
+    teachers_team = get_teachers_team(platform_url)
+    num_expected_repos = len(const.STUDENT_TEAMS) * len(
+        const.TEMPLATE_REPO_NAMES
+    )
+    assert len(teachers_team.repos) == num_expected_repos
+    expected_repo_names = [r.name for r in funcs.get_repos(platform_url)]
+    actual_repo_names = [r.name for r in teachers_team.repos]
+    assert sorted(expected_repo_names) == sorted(actual_repo_names)
+    assert sorted([m.username for m in teachers_team.members]) == sorted(
+        teachers
+    )
+
+
+def setup_student_repos_and_user_accounts(
+    usernames: List[str], platform_url: str
+):
+    funcs.run_repobee(
+        f"repos setup -a {const.TEMPLATE_REPOS_ARG} "
+        f"--base-url {platform_url}",
+    )
+    api = funcs.get_api(platform_url)
+    api._add_users(usernames)
+
+
+def get_teachers_team(platform_url: str) -> localapi.Team:
+    """Helpe function to fetch the teachers team."""
+    return next(
+        filter(
+            lambda team: team.name == tamanager.TEACHERS_TEAM_NAME,
+            funcs.get_teams(platform_url),
+        )
+    )

--- a/tests/unit_tests/repobee/test_git.py
+++ b/tests/unit_tests/repobee/test_git.py
@@ -181,9 +181,10 @@ class TestPush:
             for local_repo, url, branch in push_tuples
         ]
 
-        failed_urls = git.push(push_tuples)
+        successful_pts, failed_pts = git.push(push_tuples)
 
-        assert not failed_urls
+        assert not failed_pts
+        assert successful_pts == push_tuples
         aio_subproc.create_subprocess.assert_has_calls(expected_calls)
 
     def test_tries_all_calls_despite_exceptions(
@@ -203,11 +204,11 @@ class TestPush:
             )
 
         mocker.patch("_repobee.git._push_async", side_effect=raise_)
-        expected_failed_urls = [pt.repo_url for pt in push_tuples]
 
-        failed_urls = git.push(push_tuples, tries=tries)
+        successful_pts, failed_pts = git.push(push_tuples, tries=tries)
 
-        assert sorted(failed_urls) == sorted(expected_failed_urls)
+        assert not successful_pts
+        assert failed_pts == push_tuples
         git._push_async.assert_has_calls(expected_calls, any_order=True)
 
     def test_stops_retrying_when_failed_pushes_succeed(


### PR DESCRIPTION
Fix #416 

This PR adds the `tamanager` plugin. It does three things:

* Adds the `add-teachers` command to the `teams` category.
    - The command creates a `repobee-teachers` team, and adds the specified teachers to it
    - All repositories in the organization are added with read access to `repobee-teachers`
    - There is no `remove-teachers` command, as it's easier to just remove them manually from the `repobee-teachers` team.
* Adds a new hook, the `post_setup` hook, that is called on recently created student repositories
* Implements the `post_setup` hook such that any newly created student repositories are added to the `repobee-teachers` team.