### PR TITLE
[fact] Remove hook classes

### DIFF
--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -19,13 +19,6 @@ from repobee_plug.hook import Status, Result
 # Review stuff
 from repobee_plug.reviews import Review, ReviewAllocation
 
-# Hook functions
-from repobee_plug._corehooks import PeerReviewHook as _peer_hook
-from repobee_plug._corehooks import APIHook as _api_hook
-from repobee_plug._exthooks import CloneHook as _clone_hook
-from repobee_plug._exthooks import SetupHook as _setup_hook
-from repobee_plug._exthooks import ConfigHook as _config_hook
-
 # Helpers
 from repobee_plug.deprecation import deprecate, deprecated_hooks, Deprecation
 from repobee_plug.serialize import (
@@ -65,12 +58,13 @@ from repobee_plug.exceptions import (
 # Local representations
 from repobee_plug.localreps import StudentTeam, StudentRepo, TemplateRepo
 
+# Hook functions
+import repobee_plug._corehooks
+import repobee_plug._exthooks
+
 manager = pluggy.PluginManager(__package__)
-manager.add_hookspecs(_clone_hook)
-manager.add_hookspecs(_setup_hook)
-manager.add_hookspecs(_peer_hook)
-manager.add_hookspecs(_api_hook)
-manager.add_hookspecs(_config_hook)
+manager.add_hookspecs(repobee_plug._corehooks)
+manager.add_hookspecs(repobee_plug._exthooks)
 
 __all__ = [
     # Plugin stuff

--- a/src/repobee_plug/_corehooks.py
+++ b/src/repobee_plug/_corehooks.py
@@ -14,74 +14,79 @@ from typing import List, Tuple
 from repobee_plug import localreps, hook, reviews
 
 
-class PeerReviewHook:
-    """Hook functions related to allocating peer reviews."""
-
-    @hook.hookspec(firstresult=True)
-    def generate_review_allocations(
-        self, teams: List[localreps.StudentTeam], num_reviews: int
-    ) -> List[reviews.ReviewAllocation]:
-        """Generate :py:class:`~repobee_plug.ReviewAllocation`
-        tuples from the provided teams, given that this concerns reviews for a
-        single master repo.
-
-        The provided teams of students should be treated as units. That is to
-        say, if there are multiple members in a team, they should always be
-        assigned to the same review team. The best way to merge two teams
-        ``team_a`` and ``team_b`` into one review team is to simply do:
-
-        .. code-block:: python
-
-            team_c = plug.StudentTeam(members=team_a.members + team_b.members)
-
-        This can be scaled to however many teams you would like to merge. As a
-        practical example, if teams ``team_a`` and ``team_b`` are to review
-        ``team_c``, then the following
-        :py:class:`~repobee_plug.ReviewAllocation` tuple, here
-        called ``allocation``, should be contained in the returned list.
-
-        .. code-block:: python
-
-            review_team = plug.StudentTeam(
-                members=team_a.members + team_b.members
-            )
-            allocation = plug.ReviewAllocation(
-                review_team=review_team,
-                reviewed_team=team_c,
-            )
-
-        .. note::
-
-            Respecting the ``num_reviews`` argument is optional: only do it if
-            it makes sense. It's good practice to issue a warning if
-            num_reviews is ignored, however.
-
-        Args:
-            team: A list of student teams.
-            num_reviews: Amount of reviews each student should perform (and
-                consequently amount of reviewers per repo)
-        Returns:
-            A list of review allocations tuples.
-        """
+#####################
+# Hooks for reviews #
+#####################
 
 
-class APIHook:
-    """Hooks related to platform APIs."""
+@hook.hookspec(firstresult=True)
+def generate_review_allocations(
+    teams: List[localreps.StudentTeam], num_reviews: int
+) -> List[reviews.ReviewAllocation]:
+    """Generate :py:class:`~repobee_plug.ReviewAllocation`
+    tuples from the provided teams, given that this concerns reviews for a
+    single master repo.
 
-    @hook.hookspec(firstresult=True)
-    def get_api_class(self):
-        """Return an API platform class. Must be a subclass of apimeta.API.
+    The provided teams of students should be treated as units. That is to
+    say, if there are multiple members in a team, they should always be
+    assigned to the same review team. The best way to merge two teams
+    ``team_a`` and ``team_b`` into one review team is to simply do:
 
-        Returns:
-            An apimeta.API subclass.
-        """
+    .. code-block:: python
 
-    @hook.hookspec(firstresult=True)
-    def api_init_requires(self) -> Tuple[str]:
-        """Return which of the arguments to apimeta._APISpec.__init__ that the
-        given API requires. For example, the GitHubAPI requires all, but the
-        GitLabAPI does not require ``user``.
+        team_c = plug.StudentTeam(members=team_a.members + team_b.members)
 
-        Returns:
-            Names of the required arguments.
-        """
+    This can be scaled to however many teams you would like to merge. As a
+    practical example, if teams ``team_a`` and ``team_b`` are to review
+    ``team_c``, then the following
+    :py:class:`~repobee_plug.ReviewAllocation` tuple, here
+    called ``allocation``, should be contained in the returned list.
+
+    .. code-block:: python
+
+        review_team = plug.StudentTeam(
+            members=team_a.members + team_b.members
+        )
+        allocation = plug.ReviewAllocation(
+            review_team=review_team,
+            reviewed_team=team_c,
+        )
+
+    .. note::
+
+        Respecting the ``num_reviews`` argument is optional: only do it if
+        it makes sense. It's good practice to issue a warning if
+        num_reviews is ignored, however.
+
+    Args:
+        team: A list of student teams.
+        num_reviews: Amount of reviews each student should perform (and
+            consequently amount of reviewers per repo)
+    Returns:
+        A list of review allocations tuples.
+    """
+
+
+##############################
+# Hooks for the platform API #
+##############################
+
+
+@hook.hookspec(firstresult=True)
+def get_api_class():
+    """Return an API platform class. Must be a subclass of apimeta.API.
+
+    Returns:
+        An apimeta.API subclass.
+    """
+
+
+@hook.hookspec(firstresult=True)
+def api_init_requires() -> Tuple[str]:
+    """Return which of the arguments to apimeta._APISpec.__init__ that the
+    given API requires. For example, the GitHubAPI requires all, but the
+    GitLabAPI does not require ``user``.
+
+    Returns:
+        Names of the required arguments.
+    """

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -20,135 +20,132 @@ from repobee_plug.deprecation import deprecate
 from repobee_plug.localreps import StudentRepo, TemplateRepo
 
 
-class CloneHook:
-    """Hook functions related to cloning repos."""
-
-    @hookspec
-    def post_clone(
-        self, repo: StudentRepo, api: PlatformAPI
-    ) -> Optional[Result]:
-        """Operate on a student repository after it has been cloned.
-
-        Args:
-            repo: A local representation of a student repo. The ``path``
-                attribute is always set to a valid directory containing the
-                repo.
-            api: An instance of the platform API.
-        Returns:
-            Optionally returns a Result for reporting the outcome of the hook.
-            May also return None, in which case no reporting will be performed
-            for the hook.
-        """
-
-    @deprecate(remove_by_version="3.0.0", replacement="handle_parsed_args")
-    @hookspec
-    def clone_parser_hook(self, clone_parser: argparse.ArgumentParser) -> None:
-        """Do something with the clone repos subparser before it is used used to
-        parse CLI options. The typical task is to add options to it.
-
-        .. danger::
-
-            This hook no longer has any effect, it is only kept for testing
-            purposes.
-
-        .. deprecated:: 0.12.0
-
-            This hook is has been replaced by
-            :py:meth:`CloneHook.handle_parsed_args` and
-            :py:meth:`CloneHook.handle_processed_args`. Once all known,
-            existing plugins have been migrated to the new hook, this hook will
-            be removed.
-
-        Args:
-            clone_parser: The ``clone`` subparser.
-        """
-
-    @hookspec
-    def handle_parsed_args(self, args: argparse.Namespace) -> None:
-        """Handle the parsed args from the parser, before any processing is
-        applied.
-
-        Args:
-            args: The full namespace returned by
-                :py:func:`argparse.ArgumentParser.parse_args`
-        """
-
-    @hookspec
-    def handle_processed_args(self, args: argparse.Namespace) -> None:
-        """Handle the parsed command line arguments after RepoBee has applied
-        processing.
-
-        Args:
-            args: A processed version of the parsed CLI arguments.
-        """
-
-    @hookspec
-    def config_hook(self, config_parser: configparser.ConfigParser) -> None:
-        """Hook into the config file parsing.
-
-        Args:
-            config: the config parser after config has been read.
-        """
+#########################
+# Hooks for repos clone #
+#########################
 
 
-class SetupHook:
-    """Hook functions related to setting up repos."""
+@hookspec
+def post_clone(repo: StudentRepo, api: PlatformAPI) -> Optional[Result]:
+    """Operate on a student repository after it has been cloned.
 
-    @hookspec
-    def pre_setup(
-        self, repo: TemplateRepo, api: PlatformAPI
-    ) -> Optional[Result]:
-        """Operate on a template repository before it is distributed to
-        students.
-
-        .. note::
-
-            Structural changes to the master repo are not currently supported.
-            Changes to the repository during the callback will not be reflected
-            in the generated repositories. Support for preprocessing is not
-            planned as it is technically difficult to implement.
-
-        Args:
-            repo: Representation of a local template repo.
-            api: An instance of the platform API.
-        Returns:
-            Optionally returns a Result for reporting the outcome of the hook.
-            May also return None, in which case no reporting will be performed
-            for the hook.
-        """
-
-    @hookspec
-    def post_setup(
-        self, repo: StudentRepo, api: PlatformAPI
-    ) -> Optional[Result]:
-        """Operate on a student repo after the setup command has executed.
-
-        .. important::
-
-            This hook is only called on freshly created student repos that did
-            not already exist when the setup command was invoked.
-
-        Args:
-            repo: A student repository.
-            api: An instance of the platform API.
-        Returns:
-            Optionally returns a Result for reporting the outcome of the hook.
-            May also return None, in which case no reporting will be performed
-            for the hook.
-        """
+    Args:
+        repo: A local representation of a student repo. The ``path``
+            attribute is always set to a valid directory containing the
+            repo.
+        api: An instance of the platform API.
+    Returns:
+        Optionally returns a Result for reporting the outcome of the hook.
+        May also return None, in which case no reporting will be performed
+        for the hook.
+    """
 
 
-class ConfigHook:
-    """Hook functions related to configuration."""
+@deprecate(remove_by_version="3.0.0", replacement="handle_parsed_args")
+@hookspec
+def clone_parser_hook(clone_parser: argparse.ArgumentParser) -> None:
+    """Do something with the clone repos subparser before it is used used to
+    parse CLI options. The typical task is to add options to it.
 
-    @hookspec
-    def get_configurable_args(self) -> ConfigurableArguments:
-        """Get the configurable arguments for a plugin.
+    .. danger::
 
-        .. danger::
+        This hook no longer has any effect, it is only kept for testing
+        purposes.
 
-            This is not a public hook, don't implement this manually!
+    Args:
+        clone_parser: The ``clone`` subparser.
+    """
 
-        Returns:
-            The configurable arguments of a plugin.
-        """
+
+#########################
+# Hooks for repos setup #
+#########################
+
+
+@hookspec
+def pre_setup(repo: TemplateRepo, api: PlatformAPI) -> Optional[Result]:
+    """Operate on a template repository before it is distributed to
+    students.
+
+    .. note::
+
+        Structural changes to the master repo are not currently supported.
+        Changes to the repository during the callback will not be reflected
+        in the generated repositories. Support for preprocessing is not
+        planned as it is technically difficult to implement.
+
+    Args:
+        repo: Representation of a local template repo.
+        api: An instance of the platform API.
+    Returns:
+        Optionally returns a Result for reporting the outcome of the hook.
+        May also return None, in which case no reporting will be performed
+        for the hook.
+    """
+
+
+@hookspec
+def post_setup(repo: StudentRepo, api: PlatformAPI) -> Optional[Result]:
+    """Operate on a student repo after the setup command has executed.
+
+    .. important::
+
+        This hook is only called on freshly created student repos that did
+        not already exist when the setup command was invoked.
+
+    Args:
+        repo: A student repository.
+        api: An instance of the platform API.
+    Returns:
+        Optionally returns a Result for reporting the outcome of the hook.
+        May also return None, in which case no reporting will be performed
+        for the hook.
+    """
+
+
+############################
+# Hooks for config/parsing #
+############################
+
+
+@hookspec
+def get_configurable_args() -> ConfigurableArguments:
+    """Get the configurable arguments for a plugin.
+
+    .. danger::
+
+        This is not a public hook, don't implement this manually!
+
+    Returns:
+        The configurable arguments of a plugin.
+    """
+
+
+@hookspec
+def config_hook(config_parser: configparser.ConfigParser) -> None:
+    """Hook into the config file parsing.
+
+    Args:
+        config: the config parser after config has been read.
+    """
+
+
+@hookspec
+def handle_parsed_args(args: argparse.Namespace) -> None:
+    """Handle the parsed args from the parser, before any processing is
+    applied.
+
+    Args:
+        args: The full namespace returned by
+            :py:func:`argparse.ArgumentParser.parse_args`
+    """
+
+
+@hookspec
+def handle_processed_args(args: argparse.Namespace) -> None:
+    """Handle the parsed command line arguments after RepoBee has applied
+    processing.
+
+    Args:
+        args: A processed version of the parsed CLI arguments.
+    """

--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -15,11 +15,7 @@ from repobee_plug.cli.args import _Option, _MutuallyExclusiveGroup
 _HOOK_METHODS = {
     key: value
     for key, value in itertools.chain(
-        _exthooks.CloneHook.__dict__.items(),
-        _exthooks.SetupHook.__dict__.items(),
-        _exthooks.ConfigHook.__dict__.items(),
-        _corehooks.PeerReviewHook.__dict__.items(),
-        _corehooks.APIHook.__dict__.items(),
+        _corehooks.__dict__.items(), _exthooks.__dict__.items(),
     )
     if callable(value) and not key.startswith("_")
 }

--- a/tests/unit_tests/repobee_plug/test_pluginmeta.py
+++ b/tests/unit_tests/repobee_plug/test_pluginmeta.py
@@ -202,8 +202,7 @@ class TestDeclarativeExtensionCommand:
         plugin_instance = Greeting("greeting")
 
         assert not hasattr(
-            plugin_instance,
-            plug._exthooks.ConfigHook.get_configurable_args.__name__,
+            plugin_instance, plug._exthooks.get_configurable_args.__name__,
         )
 
     def test_raises_when_non_configurable_value_is_configured(self):


### PR DESCRIPTION
Fix #671 

This is a pure refactor. It simplifies things, as there is no longer need to register hooks from all of the different classes. It's enough to just register the modules.