### PR TITLE
[misc] Make dist plugins load even when --no-plugins is specified

### DIFF
--- a/src/_repobee/main.py
+++ b/src/_repobee/main.py
@@ -194,16 +194,18 @@ def _initialize_plugins(parsed_preparser_args: argparse.Namespace) -> None:
     plug.log.debug("Initializing default plugins")
     plugin.initialize_default_plugins()
 
-    if not parsed_preparser_args.no_plugins:
+    if distinfo.DIST_INSTALL:
+        plug.log.debug("Initializing dist plugins")
+        plugin.initialize_dist_plugins()
 
+    if not parsed_preparser_args.no_plugins:
         if distinfo.DIST_INSTALL:
-            plug.log.debug("Initializing dist plugins")
-            plugin.initialize_dist_plugins()
+            plug.log.debug("Initializing active plugins")
             plugin.initialize_plugins(
                 disthelpers.get_active_plugins(), allow_filepath=True
             )
 
-        plug.log.debug("Initializing user plugins")
+        plug.log.debug("Initializing preparser-specified plugins")
         plugin_names = parsed_preparser_args.plug or []
         plugin.initialize_plugins(plugin_names, allow_filepath=True)
 

--- a/tests/unit_tests/repobee/test_main.py
+++ b/tests/unit_tests/repobee/test_main.py
@@ -215,6 +215,29 @@ def test_dist_plugins_are_loaded_when_dist_install(monkeypatch):
     assert qualnames.issuperset(dist_plugin_qualnames)
 
 
+def test_dist_plugins_are_loaded_when_dist_install_and_no_plugins(monkeypatch):
+    """Even with --no-plugins specified, the default dist plugins should be
+    loaded.
+    """
+    dist_plugin_qualnames = plugin.get_qualified_module_names(
+        _repobee.ext.dist
+    )
+    sys_args = "repobee --no-plugins -h".split()
+    monkeypatch.setattr("_repobee.distinfo.DIST_INSTALL", True)
+
+    with pytest.raises(SystemExit):
+        # calling -h always causes a SystemExit
+        main.main(sys_args, unload_plugins=False)
+
+    qualnames = {
+        p.__name__
+        for p in plug.manager.get_plugins()
+        if isinstance(p, types.ModuleType)
+    }
+
+    assert qualnames.issuperset(dist_plugin_qualnames)
+
+
 def test_plugin_with_subparser_name(
     handle_args_mock, dispatch_command_mock, init_plugins_mock
 ):


### PR DESCRIPTION
Fix #666 

This is to let users deactivate or uninstall faulty plugins.