### PR TITLE
[fix] Remove unnecessary INFO print after command

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -60,7 +60,8 @@ def dispatch_command(
         plug.cli.CoreCommand.repos.update,
         plug.cli.CoreCommand.repos.clone,
     ]:
-        plug.echo(formatters.format_hook_results_output(hook_results))
+        if hook_results:
+            plug.echo(formatters.format_hook_results_output(hook_results))
     if hook_results and "hook_results_file" in args and args.hook_results_file:
         _handle_hook_results(
             hook_results=hook_results, filepath=args.hook_results_file


### PR DESCRIPTION
Fix #423 

Repobee should no longer shove an empty line in your face whenever a command returns a result.