### PR TITLE
[feat] Add hook to override generate_repo_name

### DIFF
--- a/src/repobee_plug/__init__.py
+++ b/src/repobee_plug/__init__.py
@@ -1,5 +1,3 @@
-import pluggy  # type: ignore
-
 from repobee_plug.__version import __version__  # noqa: F401
 
 from repobee_plug import types
@@ -59,10 +57,10 @@ from repobee_plug.exceptions import (
 from repobee_plug.localreps import StudentTeam, StudentRepo, TemplateRepo
 
 # Hook functions
+from repobee_plug.hookmanager import manager
 import repobee_plug._corehooks
 import repobee_plug._exthooks
 
-manager = pluggy.PluginManager(__package__)
 manager.add_hookspecs(repobee_plug._corehooks)
 manager.add_hookspecs(repobee_plug._exthooks)
 

--- a/src/repobee_plug/_corehooks.py
+++ b/src/repobee_plug/_corehooks.py
@@ -9,9 +9,9 @@ to allow for this dynamic override.
     :synopsis: Hookspecs for repobee core hooks.
 """
 
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
-from repobee_plug import localreps, hook, reviews
+from repobee_plug import localreps, hook, reviews, platform
 
 
 #####################
@@ -89,4 +89,28 @@ def api_init_requires() -> Tuple[str]:
 
     Returns:
         Names of the required arguments.
+    """
+
+
+############################
+# Hooks for naming schemes #
+############################
+
+
+@hook.hookspec(firstresult=True)
+def generate_repo_name(
+    team_name: Union[str, localreps.StudentTeam, platform.Team],
+    assignment_name: str,
+) -> str:
+    """This hook allows for overriding the behavior of
+    :py:func:`repobee_plug.name.generate_repo_name`.
+
+    .. danger::
+
+        The implementations of this hook should never be invoked other than in
+        :py:func:`repobee_plug.name.generate_repo_name`.
+
+    Args:
+        team_name: Name of the associated team.
+        assignment_name: Name of an assignment.
     """

--- a/src/repobee_plug/hookmanager.py
+++ b/src/repobee_plug/hookmanager.py
@@ -1,0 +1,4 @@
+"""Module solely for the hook manager"""
+import pluggy  # type: ignore
+
+manager = pluggy.PluginManager(__package__)

--- a/src/repobee_plug/name.py
+++ b/src/repobee_plug/name.py
@@ -7,6 +7,7 @@ from typing import Iterable, Union
 
 from repobee_plug import localreps
 from repobee_plug import platform
+from repobee_plug.hookmanager import manager
 
 
 def generate_repo_names(
@@ -39,11 +40,16 @@ def generate_repo_name(
 ) -> str:
     """Construct a repo name for a team.
 
+    The behavior of this function can be overridden by implementing the
+    :py:func:`repobee_plug._corehooks.generate_repo_name` hook.
+
     Args:
         team_name: Name of the associated team.
         assignment_name: Name of an assignment.
     """
-    return "{}-{}".format(team_name, assignment_name)
+    return manager.hook.generate_repo_name(
+        team_name=team_name, assignment_name=assignment_name
+    ) or "{}-{}".format(team_name, assignment_name)
 
 
 def generate_review_team_name(


### PR DESCRIPTION
#694  

This PR adds the `generate_repo_name` hook, which when implemented overrides the `generate_repo_name` function in RepoBee plug.

Usage is very simple. For example, to replicate GitHub Classroom's naming scheme, all that's needed is a plugin like this:

```python
# ghclassroom.py
import repobee_plug as plug

@plug.repobee_hook
def generate_repo_name(team_name, assignment_name):
    return f"{assignment_name}-{team_name}"
```

Which can then for example be used like so with the `repos setup` command.

```bash
repobee -p ghclassroom.py repos setup ...
```

To fully fix the issue described in #694, we also need a GH Classroom plugin that implements the naming scheme outlined above.