### PR TITLE
[feat] Add ghclassroom plugin

### DIFF
--- a/src/_repobee/ext/ghclassroom.py
+++ b/src/_repobee/ext/ghclassroom.py
@@ -1,0 +1,45 @@
+"""Interoperability plugin for using RepoBee with repositories created with
+GitHub Classroom.
+
+.. warning::
+
+    This plugin is in alpha and may change without notice.
+
+RepoBee's default naming scheme is ``<team_name>-<assignment_name>``, whereas
+GitHub Classroom's naming scheme is ``<assignment_name>-<team_name>``. This
+plugin changes RepoBee's naming scheme to conform to the latter, which allows
+RepoBee to be used with repositories created by GitHub Classroom.
+
+.. important::
+
+    The first time you use RepoBee with GitHub Classroom-created repositories,
+    you should run the ``repos setup`` command. This creates the teams that
+    RepoBee needs to find repositories, and allocates the GitHub
+    Classroom-created repositories to them.
+
+.. important::
+
+    You should not use this plugin to create repositories, and expect GitHub
+    Classroom to recognize them as student repositories. To be very clear,
+    Classroom *does not* recognize repositories created by RepoBee as student
+    repositories.
+"""
+from typing import Union
+
+import repobee_plug as plug
+
+
+PLUGIN_DESCRIPTION = """Allows interoperability with repositories created
+by GitHub Classroom by changing RepoBee's naming scheme to conform to that
+of Classroom. On first time use, you should run `repos setup` to allocate
+the teams that RepoBee needs to find repositories. (NOTE: This plugin is in
+alpha state and may change without notice)""".replace(
+    "\n", " "
+)
+
+
+@plug.repobee_hook
+def generate_repo_name(
+    team_name: Union[str, plug.StudentTeam, plug.Team], assignment_name: str
+) -> str:
+    return f"{assignment_name}-{team_name}"

--- a/tests/new_integration_tests/test_plugins.py
+++ b/tests/new_integration_tests/test_plugins.py
@@ -3,6 +3,7 @@ import tempfile
 import pathlib
 
 import _repobee
+import _repobee.ext.ghclassroom
 import repobee_plug as plug
 
 from repobee_testhelpers import funcs
@@ -71,3 +72,25 @@ class HelloWorld(plug.Plugin, plug.cli.Command):
         _repobee.main.main(["repobee", "-p", str(hello_py), "helloworld"])
 
     assert "Hello, world!" in capsys.readouterr().out
+
+
+def test_ghclassroom_plugin_changes_repo_name_generation():
+    """Test that the ghclassroom plugin correctly changes the repo name
+    generation even for other plugins."""
+    assignment = "task"
+    student = "eve"
+    expected_repo_name = f"{assignment}-{student}"
+    actual_repo_name = None
+
+    class RecordName(plug.Plugin, plug.cli.Command):
+        def command(self):
+            nonlocal actual_repo_name
+            actual_repo_name = plug.generate_repo_name(
+                team_name=student, assignment_name=assignment
+            )
+
+    funcs.run_repobee(
+        f"recordname", plugins=[RecordName, _repobee.ext.ghclassroom]
+    )
+
+    assert actual_repo_name == expected_repo_name

--- a/tests/new_integration_tests/test_plugins.py
+++ b/tests/new_integration_tests/test_plugins.py
@@ -90,7 +90,7 @@ def test_ghclassroom_plugin_changes_repo_name_generation():
             )
 
     funcs.run_repobee(
-        f"recordname", plugins=[RecordName, _repobee.ext.ghclassroom]
+        "recordname", plugins=[RecordName, _repobee.ext.ghclassroom]
     )
 
     assert actual_repo_name == expected_repo_name


### PR DESCRIPTION
Fix #714  

This PR adds a GitHub Classroom interoperability plugin. All it currently does is change the naming scheme in RepoBee from the default `<team_name>-<assignment_name>` to GitHub Classroom's `<assignment_name>-<team_name>`.