### PR TITLE
[misc] Log ModuleNotFoundErrors when trying to load plugins

### DIFF
--- a/src/_repobee/plugin.py
+++ b/src/_repobee/plugin.py
@@ -123,7 +123,8 @@ def _try_load_module(qualname: str) -> Optional[ModuleType]:
     """
     try:
         return importlib.import_module(qualname)
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as exc:
+        plug.log.debug(str(exc))
         return None
 
 


### PR DESCRIPTION
Fix #419 

Only logs to log file, but it makes it easier to debug this stuff when a user reports an error.