### PR TITLE
[feat] Add --update-local flag to clone command

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -88,7 +88,7 @@ def _dispatch_repos_command(
         command.migrate_repos(args.template_repo_urls, api)
         return None
     elif action == repos.clone:
-        return command.clone_repos(args.repos, api)
+        return command.clone_repos(args.repos, args.update_local, api)
     _raise_illegal_action_error(args)
 
 

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -152,7 +152,7 @@ def _add_subparsers(parser, config_file):
 
     def _create_category_parsers(category, help, description):
         category_command = subparsers.add_parser(
-            name=category.name, help=help, description=description,
+            name=category.name, help=help, description=description
         )
         category_parsers = category_command.add_subparsers(dest=ACTION)
         category_parsers.required = True
@@ -281,7 +281,7 @@ def _add_repo_parsers(
         type=str,
     )
 
-    add_parser(
+    clone = add_parser(
         plug.cli.CoreCommand.repos.clone,
         help="clone student repos",
         description="Clone student repos asynchronously in bulk.",
@@ -292,6 +292,11 @@ def _add_repo_parsers(
             _HOOK_RESULTS_PARSER,
         ],
         formatter_class=OrderedFormatter,
+    )
+    clone.add_argument(
+        "--update-local",
+        help="attempt to update local student repositories (beta feature)",
+        action="store_true",
     )
 
     add_parser(
@@ -548,9 +553,7 @@ def _add_extension_parsers(
     for cmd in command_extension_plugins:
         for action in cmd.__settings__.actions:
             parser = parsers_mapping[action]
-            cmd.attach_options(
-                config=parsed_config, parser=parser,
-            )
+            cmd.attach_options(config=parsed_config, parser=parser)
 
     command_plugins = [
         p
@@ -659,9 +662,7 @@ def _add_extension_parsers(
                 dest="category",
             )
 
-        cmd.attach_options(
-            config=parsed_config, parser=ext_parser,
-        )
+        cmd.attach_options(config=parsed_config, parser=ext_parser)
 
         settings_dict = settings._asdict()
         settings_dict.update(dict(action=action, category=category))

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -359,7 +359,9 @@ def _open_issue_by_urls(
 
 
 def clone_repos(
-    repos: Iterable[plug.StudentRepo], api: plug.PlatformAPI
+    repos: Iterable[plug.StudentRepo],
+    update_local: bool,
+    api: plug.PlatformAPI,
 ) -> Mapping[str, List[plug.Result]]:
     """Clone all student repos related to the provided master repos and student
     teams.
@@ -367,6 +369,8 @@ def clone_repos(
     Args:
         repos: The repos to be cloned. This function does not use the
             ``implementation`` attribute, so it does not need to be set.
+        update_local: Whether or nut to attempt to update student repos
+            that already exist locally.
         api: An implementation of :py:class:`repobee_plug.PlatformAPI` used to
             interface with the platform (e.g. GitHub or GitLab) instance.
     Returns:
@@ -375,7 +379,9 @@ def clone_repos(
 
     plug.echo("Cloning into student repos ...")
     with tempfile.TemporaryDirectory() as tmpdir:
-        local_repos = _clone_repos_no_check(repos, pathlib.Path(tmpdir), api)
+        local_repos = _clone_repos_no_check(
+            repos, pathlib.Path(tmpdir), update_local, api
+        )
 
     for p in plug.manager.get_plugins():
         if "post_clone" in dir(p):
@@ -389,6 +395,7 @@ def clone_repos(
 def _clone_repos_no_check(
     repos: Iterable[plug.StudentRepo],
     dst_dirpath: pathlib.Path,
+    update_local: bool,
     api: plug.PlatformAPI,
 ) -> Iterable[plug.StudentRepo]:
     """Clone the specified repo urls into the destination directory without
@@ -401,7 +408,9 @@ def _clone_repos_no_check(
         repo.with_path(cur_dir / repo.team.name / repo.name) for repo in repos
     ]
 
-    cloned_repos = git.clone_student_repos(pathed_repos, dst_dirpath, api)
+    cloned_repos = git.clone_student_repos(
+        pathed_repos, dst_dirpath, update_local, api
+    )
     return [repo for _, repo in cloned_repos]
 
 

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -411,6 +411,16 @@ def _clone_repos_no_check(
     cloned_repos = git.clone_student_repos(
         pathed_repos, dst_dirpath, update_local, api
     )
+
+    non_updated_local = (
+        git.CloneStatus.EXISTED in [stat for stat, _ in cloned_repos]
+        and not update_local
+    )
+    if non_updated_local:
+        plug.log.warning(
+            "Local repos were not updated, use `--update-local` to update"
+        )
+
     return [repo for _, repo in cloned_repos]
 
 

--- a/src/_repobee/git.py
+++ b/src/_repobee/git.py
@@ -5,7 +5,6 @@
 
 .. moduleauthor:: Simon Larsén
 """
-import functools
 import asyncio
 import enum
 import os
@@ -200,9 +199,8 @@ def _update_local_repos(
     local: List[plug.StudentRepo], api: plug.PlatformAPI
 ) -> None:
     expected_basedir = local[0].path.parent.parent
-    assert functools.reduce(
-        lambda lhs, rhs: lhs.path.parent.parent == expected_basedir and rhs,
-        local,
+    assert all(
+        map(lambda repo: repo.path.parent.parent == expected_basedir, local)
     )
     specs = [
         CloneSpec(repo_url=api.insert_auth(repo.url), dest=repo.path)

--- a/src/repobee_testhelpers/funcs.py
+++ b/src/repobee_testhelpers/funcs.py
@@ -4,7 +4,7 @@ import pathlib
 import shutil
 import shlex
 import contextlib
-from typing import Mapping, List, Union, ContextManager
+from typing import Mapping, List, Union, Iterator
 
 import repobee
 import git  # type: ignore
@@ -194,7 +194,7 @@ def get_student_teams(
 
 
 @contextlib.contextmanager
-def update_repository(repo_url: str) -> ContextManager[pathlib.Path]:
+def update_repository(repo_url: str) -> Iterator[pathlib.Path]:
     """Context manager for updating a Git repository. Clones the repository
     from the given url, yields the path to the cloned directory, and then
     commits and pushes any changes after the context has been exited.

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -649,6 +649,7 @@ class TestClone:
 
         # assert
         local_repo_path = list(workdir.rglob(target_repo.name))[0]
+        assert local_repo_path.parent.parent == workdir
         local_new_file = local_repo_path / new_file_name
         assert local_new_file.is_file()
         assert local_new_file.read_text() == new_file_name

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -623,6 +623,75 @@ class TestClone:
 
         return task_name
 
+    def test_update_local(
+        self, platform_url, with_student_repos, tmp_path_factory
+    ):
+        """Test cloning an updated repository that already exists locally, when
+        there are no incompatible changes between the remote copy and the local
+        copy and --update-local is specified.
+        """
+        # arrange
+        new_file_name = "suspicious_file.txt"
+        workdir = tmp_path_factory.mktemp("workdir")
+        target_repo = funcs.get_repos(platform_url)[-1]
+        self._clone_all_student_repos(platform_url, workdir)
+
+        with funcs.update_repository(target_repo.url) as repo_path:
+            (repo_path / new_file_name).write_text(new_file_name)
+
+        # act
+        funcs.run_repobee(
+            f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
+            f"--update-local "
+            f"--base-url {platform_url}",
+            workdir=workdir,
+        )
+
+        # assert
+        local_repo_path = list(workdir.rglob(target_repo.name))[0]
+        local_new_file = local_repo_path / new_file_name
+        assert local_new_file.is_file()
+        assert local_new_file.read_text() == new_file_name
+
+    def test_does_not_update_local_by_default(
+        self, platform_url, with_student_repos, tmp_path_factory, capsys
+    ):
+        """Test that cloning an update repository that exists locally does not
+        cause it to be updated by default.
+        """
+        # arrange
+        new_file_name = "suspicious_file.txt"
+        workdir = tmp_path_factory.mktemp("workdir")
+        target_repo = funcs.get_repos(platform_url)[-1]
+        self._clone_all_student_repos(platform_url, workdir)
+
+        with funcs.update_repository(target_repo.url) as repo_path:
+            (repo_path / new_file_name).write_text(new_file_name)
+
+        # act
+        funcs.run_repobee(
+            f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
+            f"--base-url {platform_url}",
+            workdir=workdir,
+        )
+
+        # assert
+        local_repo_path = list(workdir.rglob(target_repo.name))[0]
+        local_new_file = local_repo_path / new_file_name
+        assert not local_new_file.is_file()
+        assert "--update-local" in capsys.readouterr().err
+
+    @staticmethod
+    def _clone_all_student_repos(
+        platform_url: str, workdir: pathlib.Path
+    ) -> None:
+        funcs.run_repobee(
+            f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
+            f"--base-url {platform_url} ",
+            workdir=workdir,
+        )
+        assert list(workdir.iterdir())
+
 
 class TestUpdate:
     """Tests for the ``repos update`` command."""

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -76,6 +76,7 @@ VALID_PARSED_ARGS = dict(
         for team, master_name in itertools.product(STUDENTS, ASSIGNMENT_NAMES)
     ],
     secrets=False,
+    update_local=False,
 )
 
 
@@ -380,7 +381,7 @@ class TestDispatchCommand:
         )
 
         command_mock.clone_repos.assert_called_once_with(
-            args.repos, dummyapi_instance
+            args.repos, False, dummyapi_instance
         )
 
     def test_verify_settings_called_with_correct_args(


### PR DESCRIPTION
Fix #693 

Adds the `--update-local` flag to the `repos clone` command, which allows local student repositories to be updated after having already been cloned.