### PR TITLE
[fix] Clone student repos to specified path

### DIFF
--- a/src/_repobee/exception.py
+++ b/src/_repobee/exception.py
@@ -61,8 +61,8 @@ class GitError(RepoBeeException):
 class CloneFailedError(GitError):
     """An error to raise when cloning a repository fails."""
 
-    def __init__(self, msg: str, returncode: int, stderr: bytes, url: str):
-        self.url = url
+    def __init__(self, msg: str, returncode: int, stderr: bytes, clone_spec):
+        self.clone_spec = clone_spec
         super().__init__(msg, returncode, stderr)
 
 


### PR DESCRIPTION
Fix #574 

This fixes the issue of all student repos initially being cloned to the same directory, which can case name collisions when using discovery mode. This is also necessary for #721 to work out properly.