### PR TITLE
[misc] Limit size of logfile to 10 MiB

### DIFF
--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -412,7 +412,7 @@ def _ensure_size_less(path: pathlib.Path, max_size: int) -> None:
         with open(path, mode="rb") as f:
             cur = target
             f.seek(cur)
-            while f.read(1) != "\n" and cur < file_size:
+            while f.read(1) != b"\n" and cur < file_size:
                 cur += 1
                 f.seek(cur)
 

--- a/src/_repobee/constants.py
+++ b/src/_repobee/constants.py
@@ -22,6 +22,7 @@ LOG_DIR = pathlib.Path(
         appname=_repobee._external_package_name, appauthor=_repobee.__author__
     )
 )
+MAX_LOGFILE_SIZE = 1024 * 1024 * 10  # 10 MiB
 CORE_SECTION_HDR = "repobee"
 DEFAULT_CONFIG_FILE = CONFIG_DIR / "config.ini"
 assert DEFAULT_CONFIG_FILE.is_absolute()

--- a/tests/new_integration_tests/test_log.py
+++ b/tests/new_integration_tests/test_log.py
@@ -1,0 +1,25 @@
+"""Tests for the logging facilities."""
+import pytest
+
+from repobee_testhelpers import funcs
+
+
+def test_auto_truncates_log_file(monkeypatch, tmp_path_factory):
+    """The log file should be truncated by any command when it gets too large.
+    """
+    # arrange
+    log_dir = tmp_path_factory.mktemp("logs")
+    logfile = log_dir / "repobee.log"
+    max_size = 1024 * 10
+
+    logfile.write_bytes(b"a\n" * max_size * 10)
+
+    monkeypatch.setattr("_repobee.constants.LOG_DIR", log_dir)
+    monkeypatch.setattr("_repobee.constants.MAX_LOGFILE_SIZE", max_size)
+
+    # act
+    with pytest.raises(SystemExit):
+        funcs.run_repobee("-h")
+
+    # assert
+    assert 0 < len(logfile.read_bytes()) < max_size

--- a/tests/new_integration_tests/test_log.py
+++ b/tests/new_integration_tests/test_log.py
@@ -23,3 +23,31 @@ def test_auto_truncates_log_file(monkeypatch, tmp_path_factory):
 
     # assert
     assert 0 < len(logfile.read_bytes()) < max_size
+
+
+def test_auto_truncation_retains_final_lines(monkeypatch, tmp_path_factory):
+    """The log file should be truncated by any command when it gets too large.
+    """
+    # arrange
+    log_dir = tmp_path_factory.mktemp("logs")
+    logfile = log_dir / "repobee.log"
+    max_size = 1024 * 10
+
+    logfile.write_bytes(b"a\n" * max_size * 10)
+    last_lines = [b"these are", b"the last lines", b"of the log"]
+
+    with open(logfile, mode="ab") as f:
+        for line in last_lines:
+            f.write(line)
+
+    monkeypatch.setattr("_repobee.constants.LOG_DIR", log_dir)
+    monkeypatch.setattr("_repobee.constants.MAX_LOGFILE_SIZE", max_size)
+
+    # act
+    with pytest.raises(SystemExit):
+        funcs.run_repobee("-h")
+
+    # assert
+    log_contents = logfile.read_bytes()
+    for line in last_lines:
+        assert line in log_contents


### PR DESCRIPTION
Fix #648 

Automatically limits the size of the logfile to 10 MiB. Whenever it exceeds that, (roughly) the first half is removed.