### PR TITLE
[docs] Add labels to builtin plugin docs

### DIFF
--- a/docs/_ext/generate_package_docs.py
+++ b/docs/_ext/generate_package_docs.py
@@ -7,12 +7,16 @@ The line is removed from the file, and the docstrings of the modules in package
 <package_name> are appended to the file like so (without the backticks).
 
 ```
+.. _auto_<module_name>:
+
 <module_name>
 -------------
 <docstring>
 ```
 
-This applies recursively to modules in subpackages of <package_name>.
+This applies recursively to modules in subpackages of <package_name>. Note that
+both labels and headings will clash if there is a duplicate module name in any
+subpackage.
 """
 
 import importlib
@@ -83,6 +87,13 @@ def process_package(pkg_qualname: types.ModuleType) -> List[str]:
 def process_module(mod: types.ModuleType) -> List[str]:
     modname = mod.__name__.split(".")[-1]
     docstring_lines = mod.__doc__.split("\n")
-    label = f".. _builtin_plugin_{modname}:\n\n"
-    content = [label, modname, "-" * len(modname), *docstring_lines, "\n"]
+    label = f".. _auto_{modname}:"
+    content = [
+        label,
+        "\n\n",
+        modname,
+        "-" * len(modname),
+        *docstring_lines,
+        "\n",
+    ]
     return content

--- a/docs/_ext/generate_package_docs.py
+++ b/docs/_ext/generate_package_docs.py
@@ -24,7 +24,7 @@ import itertools
 import pathlib
 import types
 
-from typing import List
+from typing import List, Iterable
 
 import pkgutil
 
@@ -53,7 +53,7 @@ def source_read(
         source[0] = "\n".join(content)
 
 
-def process_package(pkg_qualname: types.ModuleType) -> List[str]:
+def process_package(pkg_qualname: str) -> Iterable[str]:
     pkg = importlib.import_module(pkg_qualname)
     pkg_init_path = pathlib.Path(pkg.__file__)
     if pkg_init_path.name != "__init__.py":

--- a/docs/_ext/generate_package_docs.py
+++ b/docs/_ext/generate_package_docs.py
@@ -83,5 +83,6 @@ def process_package(pkg_qualname: types.ModuleType) -> List[str]:
 def process_module(mod: types.ModuleType) -> List[str]:
     modname = mod.__name__.split(".")[-1]
     docstring_lines = mod.__doc__.split("\n")
-    content = [modname, "-" * len(modname), *docstring_lines, "\n"]
+    label = f".. _builtin_plugin_{modname}:\n\n"
+    content = [label, modname, "-" * len(modname), *docstring_lines, "\n"]
     return content


### PR DESCRIPTION
Fix #730 

Adds labels on the form `.. _auto_<module_name>:` to the package doc generator, meaning that all builtin plugins can now be referenced. For example, the `tamanager` plugin can be referenced in documentation with `:ref:auto_tamanager`.