### PR TITLE
[misc] Add Dockerfile for public image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.8-alpine
+
+RUN apk update
+RUN apk add git bash
+
+RUN addgroup -S repobee && adduser -S repobee -G repobee
+USER repobee
+ENV PATH=${PATH}:/home/repobee/.repobee/bin
+
+COPY . /home/repobee/repobee
+
+RUN mkdir -p /home/repobee/.config/repobee
+RUN mkdir /home/repobee/workdir
+WORKDIR /home/repobee/workdir
+
+RUN bash ~/repobee/scripts/install.sh ~/repobee


### PR DESCRIPTION
#735 

This is a draft for the Dockerfile for the public image of RepoBee. To use a config, one can mount a directory containing the config like so:

```bash
$ docker run --rm \
    -v /path/to/dir/with/config:/home/repobee/.config/repobee/ \
    -t repobee:latest \
    repobee config show
```

My currently best idea for making the install directory persistent (to allow for using plugins) is something like this.

```bash
# first copy the contents of the container's install directory into a host machine directory
$ docker run --rm -v install_dir:/home/repobee/install_dir \
    -t repobee:latest \
    cp -r /home/repobee/.repobee/* /home/repobee/install_dir
# then mount the host machine directory to the container's install dir
$ docker run --rm -v install_dir:/home/repobee/.repobee \
    -it repobee:latest \
    repobee plugin install
```
It's a bit awkward, but it seems to work.