### PR TITLE
[docs] Add README detailing how to build documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
 # Building the Documentation #
 
-To build the documentation to `repobee` simply follow the steps that can be found [Here!](https://repobee.readthedocs.io/en/stable/contributing.html#contributing-to-docs)
+To build the documentation to `repobee` simply follow the steps that can be 
+found [Here!](https://repobee.readthedocs.io/en/latest/contributing.html#contributing-to-docs)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Building the Documentation #
+
+To build the documentation to `repobee` simply follow the steps that can be found [Here!](https://repobee.readthedocs.io/en/stable/contributing.html#contributing-to-docs)


### PR DESCRIPTION
There is now a `README.md` file in `docs/` linking to the documentation detailing how to build the documentation.