### PR TITLE
[misc] Print more specific error message on crash in plugin

### DIFF
--- a/src/_repobee/main.py
+++ b/src/_repobee/main.py
@@ -138,6 +138,9 @@ def main(sys_args: List[str], unload_plugins: bool = True):
     """
     try:
         _main(sys_args, unload_plugins)
+    except plug.PlugError:
+        plug.log.error("A plugin exited with an error")
+        sys.exit(1)
     except Exception:
         plug.log.error(
             "RepoBee exited unexpectedly. "

--- a/tests/new_integration_tests/test_plugins.py
+++ b/tests/new_integration_tests/test_plugins.py
@@ -205,3 +205,23 @@ def test_repo_discovery_parser_requires_student_parser():
     assert "REPO_DISCOVERY parser requires STUDENT parser" in str(
         exc_info.value
     )
+
+
+def test_plugin_crash_error_message(capsys, tmp_path_factory):
+    """"""
+    workdir = tmp_path_factory.mktemp("workdir")
+    crash_py = workdir / "crash.py"
+    crash_py.write_text(
+        """
+import repobee_plug as plug
+class Crash(plug.Plugin, plug.cli.Command):
+    def command(self):
+        raise plug.PlugError("this is an error")
+""",
+        encoding="utf8",
+    )
+
+    with pytest.raises(SystemExit):
+        _repobee.main.main(["repobee", "-p", str(crash_py), "crash"])
+
+    assert "A plugin exited with an error" in str(capsys.readouterr().err)


### PR DESCRIPTION
Fix #744 

Instead of printing the "repobee exited unexpectedly" message on a plug error, print "A plugin exited with an error"