### PR TITLE
[fix] Crash early on path clash between non-Git directory and to-be-cloned student repo

### DIFF
--- a/src/_repobee/util.py
+++ b/src/_repobee/util.py
@@ -43,7 +43,7 @@ def repo_name(repo_url: str) -> str:
     return repo_name
 
 
-def is_git_repo(path: str) -> bool:
+def is_git_repo(path: Union[str, pathlib.Path]) -> bool:
     """Check if a directory has a .git subdirectory.
 
     Args:

--- a/system_tests/test_gitlab_system.py
+++ b/system_tests/test_gitlab_system.py
@@ -5,6 +5,7 @@ import re
 import pytest
 
 import repobee_plug as plug
+import repobee_testhelpers
 
 import _repobee.ext
 import _repobee.command.peer
@@ -136,6 +137,7 @@ class TestClone:
             new_file = new_dir / "file"
             new_file.write_text(str(new_dir), encoding="utf-8")
             expected_dir_hashes.append((new_dir, hash_directory(new_dir)))
+            repobee_testhelpers.funcs.initialize_repo(new_dir)
 
         command = " ".join(
             [

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -2,6 +2,7 @@
 import pathlib
 import tempfile
 import itertools
+import shutil
 
 from typing import List, Mapping, Tuple, Iterable
 
@@ -736,6 +737,35 @@ class TestClone:
         local_new_file = local_repo_path / new_file_name
         assert not local_new_file.is_file()
         assert "--update-local" in capsys.readouterr().err
+
+    def test_raises_on_name_clash_with_non_git_directory(
+        self, platform_url, tmp_path_factory, with_student_repos
+    ):
+        """Test that an error is raised if there is a name-clash between a
+        student repository, and a non-git directory.
+        """
+        # arrange
+        workdir = tmp_path_factory.mktemp("workdir")
+        self._clone_all_student_repos(platform_url, workdir)
+        non_git_dir = (
+            workdir
+            / str(STUDENT_TEAMS[0])
+            / plug.generate_repo_name(STUDENT_TEAMS[0], TEMPLATE_REPO_NAMES[0])
+        )
+        shutil.rmtree(non_git_dir / ".git")
+
+        # act/assert
+        with pytest.raises(exception.RepoBeeException) as exc_info:
+            funcs.run_repobee(
+                f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
+                f"--base-url {platform_url}",
+                workdir=workdir,
+            )
+
+        assert (
+            f"name clash with directory that is not a Git repository: "
+            f"'{non_git_dir}'" in str(exc_info)
+        )
 
     @staticmethod
     def _clone_all_student_repos(

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -738,11 +738,11 @@ class TestClone:
         assert not local_new_file.is_file()
         assert "--update-local" in capsys.readouterr().err
 
-    def test_raises_on_name_clash_with_non_git_directory(
+    def test_raises_on_path_clash_with_non_git_directory(
         self, platform_url, tmp_path_factory, with_student_repos
     ):
-        """Test that an error is raised if there is a name-clash between a
-        student repository, and a non-git directory.
+        """Test that an error is raised if there is a path clash between a
+        student repository and a non-git directory.
         """
         # arrange
         workdir = tmp_path_factory.mktemp("workdir")


### PR DESCRIPTION
Fix #752 

This PR makes RepoBee crash early if there is a path clash between a non-Git directory and student repo that is about to be cloned