### PR TITLE
[fact] Use tmp_path as workdir in integration tests

### DIFF
--- a/src/repobee_testhelpers/fixtures.py
+++ b/src/repobee_testhelpers/fixtures.py
@@ -56,3 +56,11 @@ def with_student_repos(platform_url):
         f"--org-name {TARGET_ORG_NAME} "
         f"--template-org-name {TEMPLATE_ORG_NAME}"
     )
+
+
+@pytest.fixture
+def workdir(tmp_path_factory):
+    """Temporary working directory for running commands such as ``repos
+    clone``.
+    """
+    yield tmp_path_factory.mktemp("workdir")

--- a/src/repobee_testhelpers/fixtures.py
+++ b/src/repobee_testhelpers/fixtures.py
@@ -56,11 +56,3 @@ def with_student_repos(platform_url):
         f"--org-name {TARGET_ORG_NAME} "
         f"--template-org-name {TEMPLATE_ORG_NAME}"
     )
-
-
-@pytest.fixture
-def workdir(tmp_path_factory):
-    """Temporary working directory for running commands such as ``repos
-    clone``.
-    """
-    yield tmp_path_factory.mktemp("workdir")

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -76,7 +76,7 @@ class TestPluginInstall:
 
         assert get_pkg_version("repobee") == repobee_initial_version
 
-    def test_install_local_plugin_file(self, capsys, workdir):
+    def test_install_local_plugin_file(self, capsys, tmp_path):
         plugin_content = """
 import repobee_plug as plug
 class Hello(plug.Plugin, plug.cli.Command):
@@ -87,7 +87,7 @@ class Hello(plug.Plugin, plug.cli.Command):
             msg='Best message'
         )
 """
-        hello_py = workdir / "hello.py"
+        hello_py = tmp_path / "hello.py"
         hello_py.write_text(plugin_content, encoding="utf8")
 
         repobee.run(shlex.split(f"plugin install --local {hello_py}"))
@@ -96,10 +96,10 @@ class Hello(plug.Plugin, plug.cli.Command):
         assert install_info["version"] == "local"
         assert install_info["path"] == str(hello_py)
 
-    def test_install_local_plugin_package(self, workdir):
+    def test_install_local_plugin_package(self, tmp_path):
         plugin_version = "1.0.0"
 
-        junit4_local = workdir / "repobee-junit4"
+        junit4_local = tmp_path / "repobee-junit4"
         repo = git.Repo.clone_from(
             "https://github.com/repobee/repobee-junit4", to_path=junit4_local
         )
@@ -112,8 +112,8 @@ class Hello(plug.Plugin, plug.cli.Command):
         assert install_info["path"] == str(junit4_local)
         assert get_pkg_version("repobee-junit4") == plugin_version
 
-    def test_raises_when_local_package_lacks_repobee_prefix(self, workdir):
-        junit4_local = workdir / "junit4"
+    def test_raises_when_local_package_lacks_repobee_prefix(self, tmp_path):
+        junit4_local = tmp_path / "junit4"
         git.Repo.clone_from(
             "https://github.com/repobee/repobee-junit4", to_path=junit4_local
         )

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -76,7 +76,7 @@ class TestPluginInstall:
 
         assert get_pkg_version("repobee") == repobee_initial_version
 
-    def test_install_local_plugin_file(self, capsys):
+    def test_install_local_plugin_file(self, capsys, workdir):
         plugin_content = """
 import repobee_plug as plug
 class Hello(plug.Plugin, plug.cli.Command):
@@ -87,51 +87,41 @@ class Hello(plug.Plugin, plug.cli.Command):
             msg='Best message'
         )
 """
-        with tempfile.TemporaryDirectory() as tmpdir:
-            workdir = pathlib.Path(tmpdir)
-            hello_py = workdir / "hello.py"
-            hello_py.write_text(plugin_content, encoding="utf8")
+        hello_py = workdir / "hello.py"
+        hello_py.write_text(plugin_content, encoding="utf8")
 
-            repobee.run(shlex.split(f"plugin install --local {hello_py}"))
+        repobee.run(shlex.split(f"plugin install --local {hello_py}"))
 
-            install_info = disthelpers.get_installed_plugins()[str(hello_py)]
-            assert install_info["version"] == "local"
-            assert install_info["path"] == str(hello_py)
+        install_info = disthelpers.get_installed_plugins()[str(hello_py)]
+        assert install_info["version"] == "local"
+        assert install_info["path"] == str(hello_py)
 
-    def test_install_local_plugin_package(self):
+    def test_install_local_plugin_package(self, workdir):
         plugin_version = "1.0.0"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            workdir = pathlib.Path(tmpdir)
-            junit4_local = workdir / "repobee-junit4"
-            repo = git.Repo.clone_from(
-                "https://github.com/repobee/repobee-junit4",
-                to_path=junit4_local,
-            )
-            repo.git.checkout(f"v{plugin_version}")
+        junit4_local = workdir / "repobee-junit4"
+        repo = git.Repo.clone_from(
+            "https://github.com/repobee/repobee-junit4", to_path=junit4_local
+        )
+        repo.git.checkout(f"v{plugin_version}")
 
+        repobee.run(shlex.split(f"plugin install --local {junit4_local}"))
+
+        install_info = disthelpers.get_installed_plugins()["junit4"]
+        assert install_info["version"] == "local"
+        assert install_info["path"] == str(junit4_local)
+        assert get_pkg_version("repobee-junit4") == plugin_version
+
+    def test_raises_when_local_package_lacks_repobee_prefix(self, workdir):
+        junit4_local = workdir / "junit4"
+        git.Repo.clone_from(
+            "https://github.com/repobee/repobee-junit4", to_path=junit4_local
+        )
+
+        with pytest.raises(plug.PlugError) as exc_info:
             repobee.run(shlex.split(f"plugin install --local {junit4_local}"))
 
-            install_info = disthelpers.get_installed_plugins()["junit4"]
-            assert install_info["version"] == "local"
-            assert install_info["path"] == str(junit4_local)
-            assert get_pkg_version("repobee-junit4") == plugin_version
-
-    def test_raises_when_local_package_lacks_repobee_prefix(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            workdir = pathlib.Path(tmpdir)
-            junit4_local = workdir / "junit4"
-            git.Repo.clone_from(
-                "https://github.com/repobee/repobee-junit4",
-                to_path=junit4_local,
-            )
-
-            with pytest.raises(plug.PlugError) as exc_info:
-                repobee.run(
-                    shlex.split(f"plugin install --local {junit4_local}")
-                )
-
-            assert "'repobee-'" in str(exc_info.value)
+        assert "'repobee-'" in str(exc_info.value)
 
     def test_raises_when_local_points_to_non_existing_path(self):
         with tempfile.NamedTemporaryFile() as tmpfile:

--- a/tests/new_integration_tests/test_plugins.py
+++ b/tests/new_integration_tests/test_plugins.py
@@ -48,14 +48,14 @@ def test_create_repo_with_plugin(platform_url):
     assert matching_repo.private == private
 
 
-def test_plugin_command_without_category(capsys, workdir):
+def test_plugin_command_without_category(capsys, tmp_path):
     """A plugin command without category should be added as a 'category
     command'.
 
     Note that this test is run with repobee.main, as it previously broke there
     but not with repobee.run due to the implementation of tab completion.
     """
-    hello_py = workdir / "hello.py"
+    hello_py = tmp_path / "hello.py"
     hello_py.write_text(
         """
 import repobee_plug as plug
@@ -202,9 +202,9 @@ def test_repo_discovery_parser_requires_student_parser():
     )
 
 
-def test_plugin_crash_error_message(capsys, workdir):
+def test_plugin_crash_error_message(capsys, tmp_path):
     """"""
-    crash_py = workdir / "crash.py"
+    crash_py = tmp_path / "crash.py"
     crash_py.write_text(
         """
 import repobee_plug as plug

--- a/tests/new_integration_tests/test_plugins.py
+++ b/tests/new_integration_tests/test_plugins.py
@@ -1,7 +1,4 @@
 """Integration tests for plugin functionality."""
-import tempfile
-import pathlib
-
 import pytest
 
 import _repobee
@@ -51,27 +48,25 @@ def test_create_repo_with_plugin(platform_url):
     assert matching_repo.private == private
 
 
-def test_plugin_command_without_category(capsys):
+def test_plugin_command_without_category(capsys, workdir):
     """A plugin command without category should be added as a 'category
     command'.
 
     Note that this test is run with repobee.main, as it previously broke there
     but not with repobee.run due to the implementation of tab completion.
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        workdir = pathlib.Path(tmpdir)
-        hello_py = workdir / "hello.py"
-        hello_py.write_text(
-            """
+    hello_py = workdir / "hello.py"
+    hello_py.write_text(
+        """
 import repobee_plug as plug
 class HelloWorld(plug.Plugin, plug.cli.Command):
     def command(self):
         plug.echo("Hello, world!")
 """,
-            encoding="utf8",
-        )
+        encoding="utf8",
+    )
 
-        _repobee.main.main(["repobee", "-p", str(hello_py), "helloworld"])
+    _repobee.main.main(["repobee", "-p", str(hello_py), "helloworld"])
 
     assert "Hello, world!" in capsys.readouterr().out
 
@@ -207,9 +202,8 @@ def test_repo_discovery_parser_requires_student_parser():
     )
 
 
-def test_plugin_crash_error_message(capsys, tmp_path_factory):
+def test_plugin_crash_error_message(capsys, workdir):
     """"""
-    workdir = tmp_path_factory.mktemp("workdir")
     crash_py = workdir / "crash.py"
     crash_py.write_text(
         """

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -144,7 +144,7 @@ class TestSetup:
             STUDENT_TEAMS, TEMPLATE_REPO_NAMES, funcs.get_repos(platform_url)
         )
 
-    def test_setup_with_local_repos(self, platform_url, workdir):
+    def test_setup_with_local_repos(self, platform_url, tmp_path):
         """Test running the setup command with the names of local
         repositories. That is to say, repos that are not in the
         template organization.
@@ -152,8 +152,8 @@ class TestSetup:
         # arrange
         template_repo_hashes = {}
 
-        task_34 = workdir / "task-34"
-        task_55 = workdir / "task-55"
+        task_34 = tmp_path / "task-34"
+        task_55 = tmp_path / "task-55"
         template_repo_hashes[task_34.name] = create_local_repo(
             task_34, [("somefile.txt", "This is task 34!")]
         )
@@ -166,7 +166,7 @@ class TestSetup:
             f"repos setup -a {task_55.name} {task_34.name} "
             f"--base-url {platform_url} "
             "--allow-local-templates",
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         # assert
@@ -182,13 +182,13 @@ class TestSetup:
         )
 
     def test_does_not_push_to_existing_repos(
-        self, platform_url, with_student_repos, capsys, workdir
+        self, platform_url, with_student_repos, capsys, tmp_path
     ):
         """This command should not push to existing repos, that's for the
         ``update`` command to do.
         """
         # arrange
-        task = workdir / TEMPLATE_REPO_NAMES[0]
+        task = tmp_path / TEMPLATE_REPO_NAMES[0]
         create_local_repo(task, [("best/file/ever.txt", "content")])
 
         # act
@@ -199,7 +199,7 @@ class TestSetup:
             f"repos setup -a {TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url} "
             "--allow-local-templates",
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         # nothing should have changed, and there should be no errors
@@ -209,29 +209,29 @@ class TestSetup:
         assert "[ERROR]" not in capsys.readouterr().out
 
     def test_setup_with_local_repos_fails_without_local_templates_arg(
-        self, platform_url, workdir
+        self, platform_url, tmp_path
     ):
-        task_34 = workdir / "task-34"
+        task_34 = tmp_path / "task-34"
         create_local_repo(task_34, [("somefile.txt", "Yay!")])
 
         with pytest.raises(exception.ParseError) as exc_info:
             funcs.run_repobee(
                 f"repos setup -a {task_34.name} "
                 f"--base-url {platform_url} ",
-                workdir=workdir,
+                workdir=tmp_path,
             )
 
         assert "`--allow-local-templates`" in str(exc_info.value)
 
     def test_use_local_template_with_strangely_named_default_branch(
-        self, platform_url, workdir
+        self, platform_url, tmp_path
     ):
         """Test setting up student repos with a template repo that has a
         non-standard default branch name. The student repos should get
         the same default branch.
         """
         strange_branch_name = "definitelynotmaster"
-        task_99 = workdir / "task-99"
+        task_99 = tmp_path / "task-99"
         create_local_repo(
             task_99,
             [("README.md", "Read me plz.")],
@@ -242,7 +242,7 @@ class TestSetup:
             f"repos setup -a {task_99.name} "
             f"--base-url {platform_url} "
             "--allow-local-templates",
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         repo = git.Repo(funcs.get_repos(platform_url)[0].path)
@@ -305,36 +305,36 @@ class TestSetup:
 class TestClone:
     """Tests for the ``repos clone`` command."""
 
-    def test_clone_all_repos(self, platform_url, with_student_repos, workdir):
+    def test_clone_all_repos(self, platform_url, with_student_repos, tmp_path):
         funcs.run_repobee(
             f"repos clone -a {TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url}",
-            workdir=workdir,
+            workdir=tmp_path,
         )
         assert_cloned_student_repos_match_templates(
-            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, workdir
+            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, tmp_path
         )
 
     def test_clone_local_gitconfig(
-        self, platform_url, with_student_repos, workdir
+        self, platform_url, with_student_repos, tmp_path
     ):
         funcs.run_repobee(
             f"repos clone --assignments {TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url}",
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         # do a spot check on a single repo
         team = STUDENT_TEAMS[0]
         assignment_name = TEMPLATE_REPO_NAMES[0]
         repo = git.Repo(
-            workdir
+            tmp_path
             / str(team)
             / plug.generate_repo_name(team, assignment_name)
         )
         assert "pull.ff=only" in repo.git.config("--local", "--list")
 
-    def test_use_non_standard_repo_names(self, platform_url, workdir):
+    def test_use_non_standard_repo_names(self, platform_url, tmp_path):
         """Test cloning repos with non-standard repo names using an
         implementation of the ``generate_repo_name`` hook.
         """
@@ -362,13 +362,13 @@ class TestClone:
         funcs.run_repobee(
             f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url}",
-            workdir=workdir,
+            workdir=tmp_path,
             plugins=[StrangeNamingConvention],
         )
 
         # assert
         local_repos = itertools.chain.from_iterable(
-            student_dir.iterdir() for student_dir in workdir.iterdir()
+            student_dir.iterdir() for student_dir in tmp_path.iterdir()
         )
         actual_repo_names = [
             repo_path.name for repo_path in local_repos if repo_path.is_dir()
@@ -376,14 +376,14 @@ class TestClone:
         assert sorted(actual_repo_names) == sorted(expected_repo_names)
 
     def test_clone_discover_repos(
-        self, platform_url, with_student_repos, workdir
+        self, platform_url, with_student_repos, tmp_path
     ):
         funcs.run_repobee(
             f"repos clone --discover-repos " f"--base-url {platform_url} ",
-            workdir=workdir,
+            workdir=tmp_path,
         )
         assert_cloned_student_repos_match_templates(
-            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, workdir
+            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, tmp_path
         )
 
     def test_post_clone_hook_invoked_on_all_student_repos(
@@ -414,14 +414,14 @@ class TestClone:
 
         assert not expected_repo_names
 
-    def test_javac_plugin_happy_path(self, platform_url, workdir):
-        java_task = self._setup_task_with_java_code(platform_url, workdir)
+    def test_javac_plugin_happy_path(self, platform_url, tmp_path):
+        java_task = self._setup_task_with_java_code(platform_url, tmp_path)
         repo_names = plug.generate_repo_names(STUDENT_TEAMS, [java_task.name])
 
         plug_results = funcs.run_repobee(
             f"repos clone -a {java_task.name} --base-url {platform_url} ",
             plugins=[_repobee.ext.javac],
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         assert plug_results
@@ -431,8 +431,8 @@ class TestClone:
             assert javac_result.name == "javac"
             assert javac_result.status == plug.Status.SUCCESS
 
-    def test_pylint_plugin_happy_path(self, platform_url, workdir):
-        python_task = self._setup_task_with_python_code(platform_url, workdir)
+    def test_pylint_plugin_happy_path(self, platform_url, tmp_path):
+        python_task = self._setup_task_with_python_code(platform_url, tmp_path)
         repo_names = plug.generate_repo_names(
             STUDENT_TEAMS, [python_task.name]
         )
@@ -440,7 +440,7 @@ class TestClone:
         plug_results = funcs.run_repobee(
             f"repos clone -a {python_task.name} --base-url {platform_url}",
             plugins=[_repobee.ext.pylint],
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         assert plug_results
@@ -452,11 +452,11 @@ class TestClone:
             assert "src/main.py -- OK" in pylint_result.msg
 
     def test_pylint_plugin_with_python_syntax_error(
-        self, platform_url, workdir
+        self, platform_url, tmp_path
     ):
         """Test that the pylint plugin correctly reports errors."""
         python_task = self._setup_task_with_faulty_python_code(
-            platform_url, workdir
+            platform_url, tmp_path
         )
         repo_names = plug.generate_repo_names(
             STUDENT_TEAMS, [python_task.name]
@@ -465,7 +465,7 @@ class TestClone:
         plug_results = funcs.run_repobee(
             f"repos clone -a {python_task.name} --base-url {platform_url}",
             plugins=[_repobee.ext.pylint],
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         assert plug_results
@@ -476,8 +476,8 @@ class TestClone:
             assert pylint_result.status == plug.Status.ERROR
             assert "src/main.py -- ERROR" in pylint_result.msg
 
-    def _setup_task_with_faulty_python_code(self, platform_url, workdir):
-        python_task = workdir / "python-task"
+    def _setup_task_with_faulty_python_code(self, platform_url, tmp_path):
+        python_task = tmp_path / "python-task"
         python_code = (
             "print('Hello, world!'"  # note missing closing parenthesis
         )
@@ -486,47 +486,47 @@ class TestClone:
             f"repos setup -a {python_task.name} "
             f"--base-url {platform_url} "
             "--allow-local-templates",
-            workdir=workdir,
+            workdir=tmp_path,
         )
         return python_task
 
-    def _setup_task_with_python_code(self, platform_url, workdir):
-        python_task = workdir / "python-task"
+    def _setup_task_with_python_code(self, platform_url, tmp_path):
+        python_task = tmp_path / "python-task"
         python_code = "print('Hello, world!')"
         create_local_repo(python_task, [("src/main.py", python_code)])
         funcs.run_repobee(
             f"repos setup -a {python_task.name} "
             f"--base-url {platform_url} "
             "--allow-local-templates",
-            workdir=workdir,
+            workdir=tmp_path,
         )
         return python_task
 
     def _setup_task_with_java_code(
-        self, platform_url, workdir
+        self, platform_url, tmp_path
     ) -> pathlib.Path:
-        java_task = workdir / "java-task"
+        java_task = tmp_path / "java-task"
         create_local_repo(java_task, [("src/Main.java", _JAVA_MAIN_CLASS)])
         funcs.run_repobee(
             f"repos setup -a {java_task.name} "
             f"--base-url {platform_url} "
             "--allow-local-templates",
-            workdir=workdir,
+            workdir=tmp_path,
         )
         return java_task
 
     def test_clone_all_repos_quietly(
-        self, platform_url, with_student_repos, capsys, workdir
+        self, platform_url, with_student_repos, capsys, tmp_path
     ):
         """Try cloning repos with `-q` for the most quiet of experiences."""
         funcs.run_repobee(
             f"repos clone -a {TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url} "
             "-q",
-            workdir=workdir,
+            workdir=tmp_path,
         )
         assert_cloned_student_repos_match_templates(
-            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, workdir
+            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, tmp_path
         )
 
         out_err = capsys.readouterr()
@@ -563,7 +563,7 @@ class TestClone:
         assert "[ERROR]" in out_err.err.strip()
 
     def test_clone_twice_with_warnings_silenced(
-        self, with_student_repos, platform_url, capsys, workdir
+        self, with_student_repos, platform_url, capsys, tmp_path
     ):
         """Cloning the same repos twice with `-qq` should prevent warnings
         about repos already existing from showing up.
@@ -573,18 +573,18 @@ class TestClone:
                 f"repos clone -a {TEMPLATE_REPOS_ARG} "
                 f"--base-url {platform_url} "
                 "-qq",
-                workdir=workdir,
+                workdir=tmp_path,
             )
 
         assert_cloned_student_repos_match_templates(
-            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, workdir
+            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, tmp_path
         )
         out_err = capsys.readouterr()
         assert not out_err.out.strip()
         assert not out_err.err.strip()
 
     def test_empty_student_repos_dont_cause_errors(
-        self, with_student_repos, platform_url, capsys, workdir
+        self, with_student_repos, platform_url, capsys, tmp_path
     ):
         """No error messages should be displayed when empty repos are
         cloned, and the empty repos should be on disk.
@@ -595,14 +595,14 @@ class TestClone:
         # act
         funcs.run_repobee(
             f"repos clone -a {task_name} --base-url {platform_url} ",
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         # assert
         assert not capsys.readouterr().err
         for student_team in STUDENT_TEAMS:
             repo = (
-                workdir
+                tmp_path
                 / student_team.name
                 / plug.generate_repo_name(student_team.name, task_name)
             )
@@ -623,7 +623,7 @@ class TestClone:
 
         return task_name
 
-    def test_update_local(self, platform_url, with_student_repos, workdir):
+    def test_update_local(self, platform_url, with_student_repos, tmp_path):
         """Test cloning an updated repository that already exists locally, when
         there are no incompatible changes between the remote copy and the local
         copy and --update-local is specified.
@@ -631,7 +631,7 @@ class TestClone:
         # arrange
         new_file_name = "suspicious_file.txt"
         target_repo = funcs.get_repos(platform_url)[-1]
-        self._clone_all_student_repos(platform_url, workdir)
+        self._clone_all_student_repos(platform_url, tmp_path)
 
         with funcs.update_repository(target_repo.url) as repo_path:
             (repo_path / new_file_name).write_text(new_file_name)
@@ -641,31 +641,31 @@ class TestClone:
             f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
             f"--update-local "
             f"--base-url {platform_url}",
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         # assert
-        local_repo_path = list(workdir.rglob(target_repo.name))[0]
-        assert local_repo_path.parent.parent == workdir
+        local_repo_path = list(tmp_path.rglob(target_repo.name))[0]
+        assert local_repo_path.parent.parent == tmp_path
         local_new_file = local_repo_path / new_file_name
         assert local_new_file.is_file()
         assert local_new_file.read_text() == new_file_name
 
     def test_update_local_stashes_local_changes(
-        self, platform_url, with_student_repos, workdir
+        self, platform_url, with_student_repos, tmp_path
     ):
         """Test that updating local repositories with unstaged changes causes
         the changes to be stashed, and the update to proceed.
         """
         new_file_name = "suspicious_file.txt"
         target_repo = funcs.get_repos(platform_url)[-1]
-        self._clone_all_student_repos(platform_url, workdir)
+        self._clone_all_student_repos(platform_url, tmp_path)
 
         # update remote repo
         with funcs.update_repository(target_repo.url) as repo_path:
             (repo_path / new_file_name).write_text(new_file_name)
         # update local repo
-        local_repo_path = list(workdir.rglob(target_repo.name))[0]
+        local_repo_path = list(tmp_path.rglob(target_repo.name))[0]
         next(
             file for file in local_repo_path.iterdir() if file.is_file()
         ).write_text("this is an update!")
@@ -675,18 +675,18 @@ class TestClone:
             f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
             f"--update-local "
             f"--base-url {platform_url}",
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         # assert
-        assert local_repo_path.parent.parent == workdir
+        assert local_repo_path.parent.parent == tmp_path
         local_new_file = local_repo_path / new_file_name
         assert local_new_file.is_file()
         assert local_new_file.read_text() == new_file_name
         assert git.Repo(local_repo_path).git.stash("list")
 
     def test_does_not_update_local_by_default(
-        self, platform_url, with_student_repos, workdir, capsys
+        self, platform_url, with_student_repos, tmp_path, capsys
     ):
         """Test that cloning an update repository that exists locally does not
         cause it to be updated by default.
@@ -694,7 +694,7 @@ class TestClone:
         # arrange
         new_file_name = "suspicious_file.txt"
         target_repo = funcs.get_repos(platform_url)[-1]
-        self._clone_all_student_repos(platform_url, workdir)
+        self._clone_all_student_repos(platform_url, tmp_path)
 
         with funcs.update_repository(target_repo.url) as repo_path:
             (repo_path / new_file_name).write_text(new_file_name)
@@ -703,25 +703,25 @@ class TestClone:
         funcs.run_repobee(
             f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url}",
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         # assert
-        local_repo_path = list(workdir.rglob(target_repo.name))[0]
+        local_repo_path = list(tmp_path.rglob(target_repo.name))[0]
         local_new_file = local_repo_path / new_file_name
         assert not local_new_file.is_file()
         assert "--update-local" in capsys.readouterr().err
 
     def test_raises_on_path_clash_with_non_git_directory(
-        self, platform_url, workdir, with_student_repos
+        self, platform_url, tmp_path, with_student_repos
     ):
         """Test that an error is raised if there is a path clash between a
         student repository and a non-git directory.
         """
         # arrange
-        self._clone_all_student_repos(platform_url, workdir)
+        self._clone_all_student_repos(platform_url, tmp_path)
         non_git_dir = (
-            workdir
+            tmp_path
             / str(STUDENT_TEAMS[0])
             / plug.generate_repo_name(STUDENT_TEAMS[0], TEMPLATE_REPO_NAMES[0])
         )
@@ -732,7 +732,7 @@ class TestClone:
             funcs.run_repobee(
                 f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
                 f"--base-url {platform_url}",
-                workdir=workdir,
+                workdir=tmp_path,
             )
 
         assert (
@@ -742,14 +742,14 @@ class TestClone:
 
     @staticmethod
     def _clone_all_student_repos(
-        platform_url: str, workdir: pathlib.Path
+        platform_url: str, tmp_path: pathlib.Path
     ) -> None:
         funcs.run_repobee(
             f"repos clone -a {const.TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url} ",
-            workdir=workdir,
+            workdir=tmp_path,
         )
-        assert list(workdir.iterdir())
+        assert list(tmp_path.iterdir())
 
 
 class TestUpdate:
@@ -771,7 +771,7 @@ class TestUpdate:
         assert not funcs.get_repos(platform_url)
 
     def test_opens_issue_when_push_fails(
-        self, platform_url, with_student_repos, workdir
+        self, platform_url, with_student_repos, tmp_path
     ):
         """Test running update when a student repo has been modified such that
         the push is rejected. The specified issues should then be opened in
@@ -780,11 +780,11 @@ class TestUpdate:
         # arrange
         title = "You done goofed"
         body = "You need to fix these things manually."
-        issue_path = workdir / "issue.md"
+        issue_path = tmp_path / "issue.md"
         issue_path.write_text(f"{title}\n{body}", encoding="utf8")
 
         # modify a student repo
-        repo_path = workdir / "repo"
+        repo_path = tmp_path / "repo"
         selected_repo = funcs.get_repos(platform_url)[0]
         repo = git.Repo.clone_from(selected_repo.path, to_path=repo_path)
         repo.git.commit("--amend", "-m", "Best commit")
@@ -811,9 +811,9 @@ class TestUpdate:
 class TestMigrate:
     """Tests for the ``repos migrate`` command."""
 
-    def test_use_strange_default_branch_name(self, platform_url, workdir):
+    def test_use_strange_default_branch_name(self, platform_url, tmp_path):
         strange_branch_name = "definitelynotmaster"
-        task_99 = workdir / "task-99"
+        task_99 = tmp_path / "task-99"
         create_local_repo(
             task_99,
             [("README.md", "Read me plz.")],
@@ -824,7 +824,7 @@ class TestMigrate:
             f"repos migrate -a {task_99.name} "
             f"--base-url {platform_url} "
             "--allow-local-templates",
-            workdir=workdir,
+            workdir=tmp_path,
         )
 
         platform_repos = funcs.get_repos(platform_url)


### PR DESCRIPTION
There was a lot of repetition in creating a workdir for e.g. cloning repos, so this PR introduces a fixture in repobee_testhelpers called `workdir` that just does that.