### PR TITLE
[fix] Merge configurable args for the same section to avoid duplication

### DIFF
--- a/src/_repobee/ext/defaults/merge_configurable_args.py
+++ b/src/_repobee/ext/defaults/merge_configurable_args.py
@@ -1,0 +1,34 @@
+"""Hookwrapper that merges results from get_configurable_args such that there
+are no duplicates in the otuput.
+"""
+import collections
+
+from repobee_plug.cli import args
+from repobee_plug.hook import hookimpl
+
+
+@hookimpl(hookwrapper=True)
+def get_configurable_args():
+    """Merge configurable args by section and ensure that there are no
+    duplicated argument names for a given section.
+    """
+    outcome = yield
+    args_by_section = collections.defaultdict(list)
+    for configurable_args in outcome.get_result():
+        argnames = args_by_section[configurable_args.config_section_name]
+        argnames.extend(
+            [
+                name
+                for name in configurable_args.argnames
+                if name not in argnames
+            ]
+        )
+
+    outcome.force_result(
+        [
+            args.ConfigurableArguments(
+                config_section_name=config_section_name, argnames=argnames
+            )
+            for config_section_name, argnames in args_by_section.items()
+        ]
+    )

--- a/src/_repobee/ext/defaults/merge_configurable_args.py
+++ b/src/_repobee/ext/defaults/merge_configurable_args.py
@@ -3,11 +3,11 @@ are no duplicates in the otuput.
 """
 import collections
 
+import repobee_plug as plug
 from repobee_plug.cli import args
-from repobee_plug.hook import hookimpl
 
 
-@hookimpl(hookwrapper=True)
+@plug.repobee_hook(hookwrapper=True)
 def get_configurable_args():
     """Merge configurable args by section and ensure that there are no
     duplicated argument names for a given section.

--- a/tests/new_integration_tests/test_plugins.py
+++ b/tests/new_integration_tests/test_plugins.py
@@ -228,6 +228,7 @@ def test_get_configurable_args_merges_sections():
     are both configurable, it results in duplicated configurable args. The
     config wizard should ignore these.
     """
+    # arrange
 
     class FirstCommand(plug.Plugin, plug.cli.Command):
         duplicated_option = plug.cli.option(configurable=True, required=True)
@@ -259,8 +260,10 @@ def test_get_configurable_args_merges_sections():
     plugin_module.SecondCommand = SecondCommand
     plugin_module.Collect = Collect
 
-    funcs.run_repobee("collect", plugins=[plugin_module])
+    # act
+    funcs.run_repobee(Collect.__name__.lower(), plugins=[plugin_module])
 
+    # assert
     assert not rest
     assert configurable_args.config_section_name == plugin_name
     assert configurable_args.argnames == ["duplicated_option"]

--- a/tests/new_integration_tests/test_plugins.py
+++ b/tests/new_integration_tests/test_plugins.py
@@ -241,13 +241,26 @@ def test_get_configurable_args_merges_sections():
         def command(self):
             pass
 
+    configurable_args = None
+    rest = None
+
+    class Collect(plug.Plugin, plug.cli.Command):
+        def command(self):
+            nonlocal configurable_args, rest
+            (
+                configurable_args,
+                *rest,
+            ) = plug.manager.hook.get_configurable_args()
+
     plugin_name = "someplugin"
     plugin_module = types.ModuleType(plugin_name)
+    plugin_module.__package__ = "somepackage"
     plugin_module.FirstCommand = FirstCommand
     plugin_module.SecondCommand = SecondCommand
-    _repobee.plugin.register_plugins([plugin_module])
+    plugin_module.Collect = Collect
 
-    configurable_args, *rest = plug.manager.hook.get_configurable_args()
+    funcs.run_repobee("collect", plugins=[plugin_module])
+
     assert not rest
     assert configurable_args.config_section_name == plugin_name
     assert configurable_args.argnames == ["duplicated_option"]


### PR DESCRIPTION
Fix #757 

Introduces a hookwrapper implementation of `get_configurable_args` that merges `ConfigurableArgs` instances that reference the same config section. Hookwrappers are really neat, [docs are here](https://pluggy.readthedocs.io/en/latest/#wrappers)