### PR TITLE
[feat] Make `config verify` check that `--students-file` exists

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -71,8 +71,33 @@ for `zsh they typically go in ~/.zshenv
     With bash, the ``.profile`` file can be overridden by the
     ``~/.bash_profile`` file.
 
-Error message `bad interpreter: No such file or directory"`
-===========================================================
+Common error messages
+=====================
+
+Some error messages in RepoBee are quite common and can be a bit hard to
+troubleshoot for beginners. This section contains the most common error
+messages and solutions to them.
+
+[ERROR] FileError: '<some filepath>' is not a file
+--------------------------------------------------
+
+This happens when a filepath is given to RepoBee, but there's no file to be
+found. If you get this but you are certain that the file in question actually
+exists, it's often due to incorrectly escaped whitespace.
+
+* On the command line, whitespace must be escaped with ``\``, or enclosed
+  within quotation marks
+
+    - Example 1: ``--students-file /path/with\ whitespace/students.txt``
+    - Example 2: ``--students-file "/path/with whitespace/students.txt"``
+
+* In the config file, whitespace should **not** be escaped at all
+
+    - Example: ``students_file = /path/with whitespace/students.txt``
+
+
+[ERROR] bad interpreter: No such file or directory
+--------------------------------------------------
 
 This is typically caused by the system wide Python executable being upgraded or
 otherwise changed after installing RepoBee. To fix this, remove the

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -41,12 +41,13 @@ class TestConfigVerify:
         with tempfile.NamedTemporaryFile() as tmpfile:
             pass
 
+        non_existing_file = pathlib.Path(tmpfile.name).resolve(strict=False)
+
         with pytest.raises(_repobee.exception.RepoBeeException) as exc_info:
             funcs.run_repobee(
                 f"{plug.cli.CoreCommand.config.verify} "
                 f"--base-url {platform_url} "
-                f"--students-file {tmpfile.name}"
+                f"--students-file {non_existing_file}"
             )
 
-        expected_path = pathlib.Path(tmpfile.name).resolve(strict=False)
-        assert f"'{expected_path}' is not a file" in str(exc_info.value)
+        assert f"'{non_existing_file}' is not a file" in str(exc_info.value)

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -1,5 +1,6 @@
 """Tests for the config category of commands."""
 import tempfile
+import pathlib
 
 import pytest
 
@@ -47,4 +48,5 @@ class TestConfigVerify:
                 f"--students-file {tmpfile.name}"
             )
 
-        assert f"'{tmpfile.name}' is not a file" in str(exc_info.value)
+        expected_path = pathlib.Path(tmpfile.name).resolve(strict=False)
+        assert f"'{expected_path}' is not a file" in str(exc_info.value)

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -1,6 +1,14 @@
 """Tests for the config category of commands."""
+import tempfile
+
+import pytest
+
 from repobee_testhelpers import funcs
 from repobee_testhelpers import const
+
+import repobee_plug as plug
+
+import _repobee.exception
 
 
 class TestConfigShow:
@@ -23,3 +31,20 @@ class TestConfigShow:
 
         outerr = capsys.readouterr()
         assert const.TOKEN in outerr.out
+
+
+class TestConfigVerify:
+    """Tests for the ``config verify`` command."""
+
+    def test_raises_if_students_file_does_not_exist(self, platform_url):
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            pass
+
+        with pytest.raises(_repobee.exception.RepoBeeException) as exc_info:
+            funcs.run_repobee(
+                f"{plug.cli.CoreCommand.config.verify} "
+                f"--base-url {platform_url} "
+                f"--students-file {tmpfile.name}"
+            )
+
+        assert f"'{tmpfile.name}' is not a file" in str(exc_info.value)


### PR DESCRIPTION
Fix #763 

This PR simply makes `config verify` check that the students file exist (indirectly by failing to parse it, really), and a new entry in the FAQ on how to deal with the general "'blabla' is not a file" error message.