### PR TITLE
[break] Allow post_setup to process both newly created and existing repos

### DIFF
--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -82,13 +82,13 @@ def setup_student_repos(
 
         platform_teams = _create_platform_teams(teams, api)
 
-        to_push, pre_existing = _create_state_separated_push_tuples(
+        to_push, preexisting = _create_state_separated_push_tuples(
             platform_teams, template_repos, api
         )
         successful_pts, _ = git.push(push_tuples=to_push)
 
         post_setup_results = _execute_post_setup_hook(
-            successful_pts, pre_existing, api
+            successful_pts, preexisting, api
         )
 
     return _combine_dicts(pre_setup_results, post_setup_results)
@@ -124,7 +124,7 @@ def _create_platform_teams(
 
 
 def _execute_post_setup_hook(
-    pushed: List[git.Push], preexisting: List[git.Push], api: plug.PlatformAPI,
+    pushed: List[git.Push], preexisting: List[git.Push], api: plug.PlatformAPI
 ) -> Mapping[Any, Any]:
     """Execute the post_setup hook on the given push tuples. Note that the push
     tuples are expected to have the "team" and "repo" keys set in the metadata.
@@ -188,14 +188,14 @@ def _create_state_separated_push_tuples(
     )
 
     newly_created = []
-    pre_existing = []
+    preexisting = []
     for created, pt in push_tuple_iter_progress:
         if created:
             newly_created.append(pt)
         else:
-            pre_existing.append(pt)
+            preexisting.append(pt)
 
-    return newly_created, pre_existing
+    return newly_created, preexisting
 
 
 def _create_push_tuples(

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -85,17 +85,15 @@ def pre_setup(repo: TemplateRepo, api: PlatformAPI) -> Optional[Result]:
 
 
 @hookspec
-def post_setup(repo: StudentRepo, api: PlatformAPI) -> Optional[Result]:
+def post_setup(
+    repo: StudentRepo, api: PlatformAPI, newly_created: bool
+) -> Optional[Result]:
     """Operate on a student repo after the setup command has executed.
-
-    .. important::
-
-        This hook is only called on freshly created student repos that did
-        not already exist when the setup command was invoked.
 
     Args:
         repo: A student repository.
         api: An instance of the platform API.
+        newly_created: False if the student repo already existed.
     Returns:
         Optionally returns a Result for reporting the outcome of the hook.
         May also return None, in which case no reporting will be performed


### PR DESCRIPTION
Related to discussion in #769 

This PR appends allows the `post_setup` hook to process both newly created and existing student repos, whereas previously it would only be passed newly created ones. A new parameter `newly_created` is appended to the hook function's parameter list to indicated whether or not the passed in repository already existed or was newly created. Existing hook functions will therefore keep working, unless they rely on only being passed newly created repositories.

**This update is still breaking**, as any hook implementation that relied upon the passed repository being newly created will no longer be able to do so.