### PR TITLE
fix: Fix paging error in fetching GitLab group

### DIFF
--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -327,19 +327,10 @@ class GitLabAPI(plug.PlatformAPI):
 
     @staticmethod
     def _get_group(group_name, gl):
-        plug.log.debug(f"Searching for groups with name {group_name}")
-        matches = [
-            g
-            for g in gl.groups.list(search=group_name, all=True)
-            if g.path == group_name
-        ]
+        plug.log.debug(f"Fetching group {group_name}")
 
-        if not matches:
-            raise plug.NotFoundError(group_name, status=404)
-
-        plug.log.debug(f"Found groups: {[group.path for group in matches]}")
-
-        return matches[0]
+        with _try_api_request():
+            return gl.groups.get(group_name)
 
     def _get_users(self, usernames):
         users = []

--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -93,12 +93,6 @@ class GitLabAPI(plug.PlatformAPI):
     _User = collections.namedtuple("_User", ("id", "login"))
 
     def __init__(self, base_url, token, org_name):
-        # ssl turns off only for
-
-        plug.log.debug(
-            f"Initializing GitLab API: url={base_url}, target group={org_name}"
-        )
-
         self._user = "oauth2"
         self._gitlab = gitlab.Gitlab(
             base_url, private_token=token, ssl_verify=self._ssl_verify()

--- a/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
@@ -510,9 +510,7 @@ class TestVerifySettings:
                 token=TOKEN,
             )
 
-        assert "Could not find group with slug {}".format(
-            non_existing_group
-        ) in str(exc_info.value)
+        assert non_existing_group in str(exc_info.value)
 
     def test_raises_if_master_group_cant_be_found(self):
         non_existing_group = "some-garbage-group"
@@ -525,9 +523,7 @@ class TestVerifySettings:
                 template_org_name=non_existing_group,
             )
 
-        assert "Could not find group with slug {}".format(
-            non_existing_group
-        ) in str(exc_info.value)
+        assert non_existing_group in str(exc_info.value)
 
     def test_raises_when_user_is_not_member(self, mocker):
         gl = GitLabMock(BASE_URL, TOKEN, False)

--- a/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
@@ -281,11 +281,16 @@ class GitLabMock:
         return list(groups)[: (PAGE_SIZE if not all else None)]
 
     def _get_group(self, id):
-        if id not in self._groups:
-            raise gitlab.exceptions.GitlabGetError(
-                response_code=404, error_message="Group Not Found"
-            )
-        return self._groups[id]
+        if id in self._groups:
+            return self._groups[id]
+
+        for gid, group in self._groups.items():
+            if group.path == id:
+                return group
+
+        raise gitlab.exceptions.GitlabGetError(
+            response_code=404, error_message="Group Not Found"
+        )
 
     def _list_users(self, username=None):
         if username:


### PR DESCRIPTION
Fix #774 

This PR fixes a paging issue when fetching groups of specific names in GitLab. Previously the search API was used, only fetching the first page. With this patch, the group name is used to fetch the group directly, instead.