### PR TITLE
Add allow-local-templates to migrate documentation

### DIFF
--- a/docs/repos.rst
+++ b/docs/repos.rst
@@ -214,7 +214,7 @@ directory (i.e. local repos), all we have to do is this:
 
 .. code-block:: bash
 
-    $ repobee repos migrate --assignments task-1 task-2
+    $ repobee repos migrate --allow-local-templates --assignments task-1 task-2
 
 .. note::
 
@@ -222,6 +222,11 @@ directory (i.e. local repos), all we have to do is this:
     the repos to migrate. This is an implementation detail that makes it easier
     to handle the command, but may be changed in the future for better
     usability.
+    
+    The --allow-local-templates oprion is necessary to permit the use of a local
+    template on your computer, i.e., the assignment templates that you are migrating.
+    Repobee prohibits using local templates by default for safety, but this is
+    precisely what you want in this case.
 
 .. important::
 

--- a/docs/repos.rst
+++ b/docs/repos.rst
@@ -223,9 +223,9 @@ directory (i.e. local repos), all we have to do is this:
     to handle the command, but may be changed in the future for better
     usability.
     
-    The --allow-local-templates oprion is necessary to permit the use of a local
+    The ``--allow-local-templates`` option is necessary to permit the use of a local
     template on your computer, i.e., the assignment templates that you are migrating.
-    Repobee prohibits using local templates by default for safety, but this is
+    RepoBee prohibits using local templates by default to avoid user error, but this is
     precisely what you want in this case.
 
 .. important::


### PR DESCRIPTION
I'm a brand new RepoBee user, so this may in fact be my error and I'd love to learn from the experience.

When I tried to follow these directions to migrate a local template repository into an organization --- which I think is the expected use case --- I got an error from RepoBee indicating that this wasn't allowed without the --allow-local-templates option. I see that this was added recently in repobee#629, and so perhaps updating this documentation page was overlooked.