### PR TITLE
[feat] Add non-interactive plugin installation

### DIFF
--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -63,7 +63,10 @@ class InstallPluginCommand(plug.Plugin, plug.cli.Command):
     __settings__ = plug.cli.command_settings(
         action=plugin_category.install,
         help="install a plugin",
-        description="Install a plugin.",
+        description="Install a plugin. Running this command without options "
+        "starts an interactive installer, where you can select plugin and "
+        "version to install. Plugins can also be installed non-interactively "
+        "with the (mutually exclusive) '--plugin-spec' or '--local' options.",
     )
 
     non_interactive_install_options = plug.cli.mutually_exclusive_group(

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -64,10 +64,17 @@ class InstallPluginCommand(plug.Plugin, plug.cli.Command):
         description="Install a plugin.",
     )
 
-    local = plug.cli.option(
-        converter=pathlib.Path,
-        help="path to a local plugin to install, either a single file or a "
-        "plugin package",
+    non_interactive_install_options = plug.cli.mutually_exclusive_group(
+        local=plug.cli.option(
+            converter=pathlib.Path,
+            help="path to a local plugin to install, either a single file or "
+            "a plugin package",
+        ),
+        plugin_spec=plug.cli.option(
+            help="a plugin specifier on the form '<NAME>@<VERSION>' (e.g. "
+            "'junit4@v1.0.0' to do a non-interactive install of an official "
+            "plugin"
+        ),
     )
 
     def command(self) -> None:
@@ -84,8 +91,14 @@ class InstallPluginCommand(plug.Plugin, plug.cli.Command):
             _install_local_plugin(abspath, installed_plugins)
         else:
             plug.echo("Available plugins:")
-            _list_all_plugins(plugins, installed_plugins, active_plugins)
-            name, version = _select_plugin(plugins)
+
+            if self.plugin_spec:
+                # non-interactive install
+                name, version = self.plugin_spec.split("@")
+            else:
+                # interactive install
+                _list_all_plugins(plugins, installed_plugins, active_plugins)
+                name, version = _select_plugin(plugins)
 
             if name in installed_plugins:
                 _uninstall_plugin(name, installed_plugins)

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -117,7 +117,12 @@ class InstallPluginCommand(plug.Plugin, plug.cli.Command):
 
     @staticmethod
     def _split_plugin_spec(plugin_spec: str, plugins: dict) -> Tuple[str, str]:
-        name, version = plugin_spec.split(PLUGIN_SPEC_SEP)
+        parts = plugin_spec.split(PLUGIN_SPEC_SEP)
+        if len(parts) != 2:
+            raise plug.PlugError(f"malformed plugin spec '{plugin_spec}'")
+
+        name, version = parts
+
         if name not in plugins:
             raise plug.PlugError(f"no plugin with name '{name}'")
         elif version not in plugins[name]["versions"]:

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -24,6 +24,7 @@ import repobee
 import _repobee
 
 from _repobee import disthelpers, distinfo
+from _repobee.ext.dist import pluginmanager
 
 
 INSTALL_SCRIPT = (
@@ -131,6 +132,21 @@ class Hello(plug.Plugin, plug.cli.Command):
             repobee.run(shlex.split(f"plugin install --local {tmpfile.name}"))
 
         assert "no such file or directory" in str(exc_info.value)
+
+    def test_non_interactive_install(self):
+        plugin_name = "junit4"
+        plugin_version = "v1.0.0"
+        cmd = [
+            *pluginmanager.plugin_category.install.as_name_tuple(),
+            "--plugin-spec",
+            f"{plugin_name}@{plugin_version}",
+        ]
+
+        repobee.run(cmd)
+
+        assert get_pkg_version(
+            f"repobee-{plugin_name}"
+        ) == plugin_version.lstrip("v")
 
 
 class TestPluginUninstall:

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -139,7 +139,7 @@ class Hello(plug.Plugin, plug.cli.Command):
         cmd = [
             *pluginmanager.plugin_category.install.as_name_tuple(),
             "--plugin-spec",
-            f"{plugin_name}@{plugin_version}",
+            f"{plugin_name}{pluginmanager.PLUGIN_SPEC_SEP}{plugin_version}",
         ]
 
         repobee.run(cmd)
@@ -147,6 +147,43 @@ class Hello(plug.Plugin, plug.cli.Command):
         assert get_pkg_version(
             f"repobee-{plugin_name}"
         ) == plugin_version.lstrip("v")
+
+    def test_raises_on_non_interactive_install_of_non_existing_plugin(self):
+        """An error should be raised if one tries to install a plugin that
+        does not exist.
+        """
+        plugin_name = "somepluginthatdoesntexist"
+        plugin_version = "v1.0.0"
+        cmd = [
+            *pluginmanager.plugin_category.install.as_name_tuple(),
+            "--plugin-spec",
+            f"{plugin_name}{pluginmanager.PLUGIN_SPEC_SEP}{plugin_version}",
+        ]
+
+        with pytest.raises(plug.PlugError) as exc_info:
+            repobee.run(cmd)
+
+        assert f"no plugin with name '{plugin_name}'" in str(exc_info.value)
+
+    def test_raises_on_non_interactive_install_of_non_existing_version(self):
+        """An error should be raised if one tries to install a version that
+        does not exist, but the plugin does.
+        """
+        plugin_name = "junit4"
+        plugin_version = "v0.32.0"
+        cmd = [
+            *pluginmanager.plugin_category.install.as_name_tuple(),
+            "--plugin-spec",
+            f"{plugin_name}{pluginmanager.PLUGIN_SPEC_SEP}{plugin_version}",
+        ]
+
+        with pytest.raises(plug.PlugError) as exc_info:
+            repobee.run(cmd)
+
+        assert (
+            f"plugin '{plugin_name}' has no version '{plugin_version}'"
+            in str(exc_info.value)
+        )
 
 
 class TestPluginUninstall:

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -185,6 +185,24 @@ class Hello(plug.Plugin, plug.cli.Command):
             in str(exc_info.value)
         )
 
+    def test_raises_on_malformed_plugin_spec(self):
+        """An error should be raised if a plugin spec is malformed."""
+        malformed_spec = pluginmanager.PLUGIN_SPEC_SEP.join(
+            ["too", "many", "parts"]
+        )
+        cmd = [
+            *pluginmanager.plugin_category.install.as_name_tuple(),
+            "--plugin-spec",
+            malformed_spec,
+        ]
+
+        with pytest.raises(plug.PlugError) as exc_info:
+            repobee.run(cmd)
+
+        assert f"malformed plugin spec '{malformed_spec}'" in str(
+            exc_info.value
+        )
+
 
 class TestPluginUninstall:
     """Tests for the ``plugin uninstall`` command."""


### PR DESCRIPTION
This PR addresses part 1/3 of #782: non-interactive plugin installation. This is important for using RepoBee in scripts, for example when using the Docker distribution. With this, one can install for example `junit4` `v1.0.0` like so:

```
$ repobee plugin install --plugin-spec junit4@v1.0.0
```

The reason it's collapsed into a `--plugin-spec` instead of separate `--plugin-name` and `--plugin-version` is that it's enormously much easier to make `--plugin-spec` mutually exclusive to `--local` (and later `--remote`, when that's implemented), than it is to make `--plugin-name` AND `--plugin-version` mutually exclusive to `--local`, but dependent on each other.