### PR TITLE
[feat] Add non-interactive plugin uninstall

### DIFF
--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -200,6 +200,10 @@ class UninstallPluginCommand(plug.Plugin, plug.cli.Command):
         description="Uninstall a plugin.",
     )
 
+    plugin_name = plug.cli.option(
+        help="name of a plugin to uninstall (non-interactive)"
+    )
+
     def command(self) -> None:
         """Uninstall a plugin."""
         installed_plugins = {
@@ -208,19 +212,29 @@ class UninstallPluginCommand(plug.Plugin, plug.cli.Command):
             if not attrs.get("builtin")
         }
 
-        if not installed_plugins:
-            plug.echo("No plugins installed")
-            return
+        if self.plugin_name:
+            # non-interactive uninstall
+            if self.plugin_name not in installed_plugins:
+                raise plug.PlugError(
+                    f"no plugin '{self.plugin_name}' installed"
+                )
+            selected_plugin_name = self.plugin_name
+        else:
+            # interactive uninstall
+            if not installed_plugins:
+                plug.echo("No plugins installed")
+                return
 
-        plug.echo("Installed plugins:")
-        _list_installed_plugins(
-            installed_plugins, disthelpers.get_active_plugins()
-        )
+            plug.echo("Installed plugins:")
+            _list_installed_plugins(
+                installed_plugins, disthelpers.get_active_plugins()
+            )
 
-        selected_plugin_name = bullet.Bullet(
-            prompt="Select a plugin to uninstall:",
-            choices=list(installed_plugins.keys()),
-        ).launch()
+            selected_plugin_name = bullet.Bullet(
+                prompt="Select a plugin to uninstall:",
+                choices=list(installed_plugins.keys()),
+            ).launch()
+
         _uninstall_plugin(selected_plugin_name, installed_plugins)
 
 

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -197,7 +197,10 @@ class UninstallPluginCommand(plug.Plugin, plug.cli.Command):
     __settings__ = plug.cli.command_settings(
         action=plugin_category.uninstall,
         help="uninstall a plugin",
-        description="Uninstall a plugin.",
+        description="Uninstall a plugin. Running this command without options "
+        "starts an interactive uninstall wizard. Running with the "
+        "'--plugin-name' option non-interactively uninstall the specified "
+        "plugin.",
     )
 
     plugin_name = plug.cli.option(

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -216,6 +216,35 @@ class TestPluginUninstall:
 
         assert not get_pkg_version(f"repobee-{plugin_name}")
 
+    def test_non_interactive_uninstall_of_installed_plugin(self):
+        plugin_name = "junit4"
+        install_plugin(plugin_name, version="v1.0.0")
+
+        cmd = [
+            *pluginmanager.plugin_category.uninstall.as_name_tuple(),
+            "--plugin-name",
+            plugin_name,
+        ]
+        repobee.run(cmd)
+
+        assert not get_pkg_version(f"repobee-{plugin_name}")
+
+    def test_raises_on_non_interactive_uninstall_of_non_installed_plugin(self):
+        """An error should be raised when trying to uninstall a plugin that
+        isn't installed.
+        """
+        plugin_name = "junit4"
+        cmd = [
+            *pluginmanager.plugin_category.uninstall.as_name_tuple(),
+            "--plugin-name",
+            plugin_name,
+        ]
+
+        with pytest.raises(plug.PlugError) as exc_info:
+            repobee.run(cmd)
+
+        assert f"no plugin '{plugin_name}' installed" in str(exc_info.value)
+
 
 class TestPluginList:
     """Tests for the ``plugin list`` command."""


### PR DESCRIPTION
Part 2/3 of #782 

This PR adds a non-interactive mode to `plugin uninstall` with the `--plugin-name` argument. A plugin can be non-interactively installed like so:

```
$ repobee plugin uninstall --plugin-name junit4
```