### PR TITLE
[feat] Add non-interactive mode to `plugin activate`

### DIFF
--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -292,9 +292,9 @@ class ActivatePluginCommand(plug.Plugin, plug.cli.Command):
 
         if self.plugin_name:
             # non-interactive activate
-            if self.plugin_name not in installed_plugins:
+            if self.plugin_name not in names:
                 raise plug.PlugError(
-                    f"no plugin with name '{self.plugin_name}' installed"
+                    f"no plugin named '{self.plugin_name}' installed"
                 )
             selection = (
                 active + [self.plugin_name]

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -273,12 +273,16 @@ class ActivatePluginCommand(plug.Plugin, plug.cli.Command):
 
     __settings__ = plug.cli.command_settings(
         action=plugin_category.activate,
-        help="activate a plugin",
-        description="Activate a plugin.",
+        help="activate and deactivate plugins",
+        description="Activate and deactivate plugins. Running the command "
+        "without options starts an interactive wizard for toggling the "
+        "active-status of all installed plugins. Specifying the "
+        "'--plugin-name' option non-interactively toggles the active-status "
+        "for a single plugin.",
     )
 
     plugin_name = plug.cli.option(
-        help="a plugin to toggle activation status for"
+        help="a plugin to toggle activation status for (non-interactive)"
     )
 
     def command(self) -> None:

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -316,6 +316,19 @@ class ActivatePluginCommand(plug.Plugin, plug.cli.Command):
 
         disthelpers.write_active_plugins(selection)
 
+        self._echo_state_change(active_before=active, active_after=selection)
+
+    @staticmethod
+    def _echo_state_change(
+        active_before: List[str], active_after: List[str]
+    ) -> None:
+        activations = set(active_after) - set(active_before)
+        deactivations = set(active_before) - set(active_after)
+        if activations:
+            plug.echo(f"Activating: {' '.join(activations)}")
+        if deactivations:
+            plug.echo(f"Deactivating: {' '.join(deactivations)}")
+
 
 def _wrap_cell(text: str, width: int = 40) -> str:
     return "\n".join(textwrap.wrap(text, width=width))

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -303,6 +303,20 @@ class TestPluginActivate:
             install_dir / "installed_plugins.json"
         )
 
+    def test_non_interactive_activate_of_builtin_plugin(self, install_dir):
+        plugin_name = "ghclassroom"
+
+        cmd = [
+            *pluginmanager.plugin_category.activate.as_name_tuple(),
+            "--plugin-name",
+            plugin_name,
+        ]
+        repobee.run(cmd)
+
+        assert plugin_name in disthelpers.get_active_plugins(
+            install_dir / "installed_plugins.json"
+        )
+
     def test_raises_on_non_interactive_activate_of_non_installed_plugin(self):
         plugin_name = "junit4"
         cmd = [

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -303,6 +303,24 @@ class TestPluginActivate:
             install_dir / "installed_plugins.json"
         )
 
+    def test_non_interactive_deactivate_of_builtin_plugin(self, install_dir):
+        # arrange
+        plugin_name = "ghclassroom"
+        cmd = [
+            *pluginmanager.plugin_category.activate.as_name_tuple(),
+            "--plugin-name",
+            plugin_name,
+        ]
+        repobee.run(cmd)
+
+        # act
+        repobee.run(cmd)
+
+        # assert
+        assert plugin_name not in disthelpers.get_active_plugins(
+            install_dir / "installed_plugins.json"
+        )
+
     def test_non_interactive_activate_of_builtin_plugin(self, install_dir):
         plugin_name = "ghclassroom"
 

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -285,6 +285,40 @@ class TestPluginList:
         assert "https://github.com" in out_err.out
 
 
+class TestPluginActivate:
+    """Tests for the ``plugin activate`` command."""
+
+    def test_non_interactive_activate_of_installed_plugin(self, install_dir):
+        plugin_name = "junit4"
+        install_plugin(plugin_name, "v1.0.0")
+
+        cmd = [
+            *pluginmanager.plugin_category.activate.as_name_tuple(),
+            "--plugin-name",
+            plugin_name,
+        ]
+        repobee.run(cmd)
+
+        assert plugin_name in disthelpers.get_active_plugins(
+            install_dir / "installed_plugins.json"
+        )
+
+    def test_raises_on_non_interactive_activate_of_non_installed_plugin(self):
+        plugin_name = "junit4"
+        cmd = [
+            *pluginmanager.plugin_category.activate.as_name_tuple(),
+            "--plugin-name",
+            plugin_name,
+        ]
+
+        with pytest.raises(plug.PlugError) as exc_info:
+            repobee.run(cmd)
+
+        assert f"no plugin named '{plugin_name}' installed" in str(
+            exc_info.value
+        )
+
+
 class TestManageUpgrade:
     """Tests for the ``manage upgrade`` command."""
 


### PR DESCRIPTION
Part 3/3 of #782. Adds a non-interactive mode to `plugin activate`, where running the following toggles the active-status of a single plugin.

```bash
$ repobee plugin activate --plugin-name junit4
```