### PR TITLE
[feat] Implement GiteaAPI.close_issue

### DIFF
--- a/src/_repobee/ext/gitea.py
+++ b/src/_repobee/ext/gitea.py
@@ -311,6 +311,17 @@ class GiteaAPI(plug.PlatformAPI):
         )
         return self._wrap_issue(response.json())
 
+    def close_issue(self, issue: plug.Issue) -> None:
+        """See :py:meth:`repobee_plug.PlatformAPI.close_issue`."""
+        repo_full_name = issue.implementation["repository"]["full_name"]
+        endpoint = f"/repos/{repo_full_name}/issues/{issue.number}"
+        self._request(
+            requests.patch,
+            endpoint,
+            error_msg=f"could not close issue {repo_full_name}#{issue.number}",
+            data=dict(state=plug.IssueState.CLOSED.value),
+        )
+
     def get_repo_issues(self, repo: plug.Repo) -> Iterable[plug.Issue]:
         """See :py:meth:`repobee_plug.PlatformAPI.get_repo_issues`."""
         owner = repo.implementation["owner"]["login"]
@@ -318,6 +329,7 @@ class GiteaAPI(plug.PlatformAPI):
         response = self._request(
             requests.get,
             endpoint,
+            params=dict(state=plug.IssueState.ALL.value),
             error_msg="could not fetch issues from {owner}/{repo.name}",
         )
         return (self._wrap_issue(issue_data) for issue_data in response.json())

--- a/src/_repobee/ext/gitea.py
+++ b/src/_repobee/ext/gitea.py
@@ -313,6 +313,7 @@ class GiteaAPI(plug.PlatformAPI):
 
     def close_issue(self, issue: plug.Issue) -> None:
         """See :py:meth:`repobee_plug.PlatformAPI.close_issue`."""
+        assert issue.implementation
         repo_full_name = issue.implementation["repository"]["full_name"]
         endpoint = f"/repos/{repo_full_name}/issues/{issue.number}"
         self._request(

--- a/system_tests/gitea/test_gitea.py
+++ b/system_tests/gitea/test_gitea.py
@@ -240,6 +240,26 @@ class TestCreateIssue:
         assert created_issue == fetched_issue
 
 
+class TestCloseIssue:
+    """tests for the close_issue function."""
+
+    def test_close_open_issue(self, target_api):
+        # arrange
+        repo = target_api.create_repo("some-repo", "some description", True)
+        issue = target_api.create_issue(
+            title="issue title", body="issue body", repo=repo
+        )
+
+        # act
+        target_api.close_issue(issue)
+
+        # assert
+        assert (
+            next(target_api.get_repo_issues(repo)).state
+            == plug.IssueState.CLOSED
+        )
+
+
 class TestGetRepoIssues:
     """Tests for the get_repo_issues function."""
 


### PR DESCRIPTION
#732 

This PR adds `close_issue` to the `GiteaAPI`. Also fixes a bug in `get_repo_issues` that caused closed issues not to be fetched, which was needed to test the new function.