### PR TITLE
[fix] Actually assign assignees to issues on Gitea

### DIFF
--- a/src/_repobee/ext/gitea.py
+++ b/src/_repobee/ext/gitea.py
@@ -317,7 +317,7 @@ class GiteaAPI(plug.PlatformAPI):
             requests.post,
             endpoint,
             error_msg=f"could not open issue in {owner}/{repo.name}",
-            data=dict(title=title, body=body),
+            data=dict(title=title, body=body, assignees=assignees or []),
         )
         return self._wrap_issue(response.json())
 


### PR DESCRIPTION
Makes `GiteaAPI.create_issue` actually assign assignees to issues. Previously, it simply ignored the assignees argument.