### PR TITLE
[fix] Actually assign repository to specified team in GiteaAPI.create_repo

### DIFF
--- a/src/_repobee/ext/gitea.py
+++ b/src/_repobee/ext/gitea.py
@@ -207,13 +207,18 @@ class GiteaAPI(plug.PlatformAPI):
             )
 
         resp_data = response.json()
-        return plug.Repo(
+        repo = plug.Repo(
             name=name,
             description=description,
             private=private,
             url=resp_data["clone_url"],
             implementation=resp_data,
         )
+
+        if team:
+            self.assign_repo(team, repo, plug.TeamPermission.PUSH)
+
+        return repo
 
     def get_repo(self, repo_name: str, team_name: Optional[str]) -> plug.Repo:
         """See :py:meth:`repobee_plug.PlatformAPI.get_repo`."""

--- a/system_tests/gitea/test_gitea.py
+++ b/system_tests/gitea/test_gitea.py
@@ -128,6 +128,18 @@ class TestCreateRepo:
 
         assert exc_info.value.status == 409
 
+    def test_create_repo_with_team(self, target_api):
+        repo_name = "best-repo"
+        description = "The epicest repo!"
+        private = True
+        team = target_api.create_team("some-team")
+
+        created_repo = target_api.create_repo(
+            name=repo_name, description=description, private=private, team=team
+        )
+
+        assert next(target_api.get_team_repos(team)) == created_repo
+
 
 class TestGetRepo:
     """Tests for the get_repo function."""


### PR DESCRIPTION
Fixes a bug in that the `team` argument to `GiteaAPI.create_team` was silently ignored