### PR TITLE
fix: Don't assign reviewers as assignees for Gitea

### DIFF
--- a/src/_repobee/command/peer.py
+++ b/src/_repobee/command/peer.py
@@ -17,6 +17,7 @@ from typing import Iterable, Optional
 import repobee_plug as plug
 
 import _repobee.command.teams
+import _repobee.ext.gitea
 from _repobee import formatters
 
 from _repobee.command import progresswrappers
@@ -117,7 +118,11 @@ def assign_peer_reviews(
                 issue.title,
                 issue.body,
                 reviewed_repo,
-                assignees=review_team.members,
+                # It's not possible to assign users with read-access in Gitea
+                # FIXME redesign so Gitea does not require special handling
+                assignees=review_team.members
+                if not isinstance(api, _repobee.ext.gitea.GiteaAPI)
+                else None,
             )
 
 

--- a/system_tests/gitea/conftest.py
+++ b/system_tests/gitea/conftest.py
@@ -1,5 +1,12 @@
+import re
+import shlex
+
 import pytest
 import giteamanager
+
+import repobee
+from _repobee.ext import gitea
+from repobee_testhelpers._internal import templates as template_helpers
 
 
 @pytest.fixture(autouse=True)
@@ -17,3 +24,43 @@ def teardown_gitea():
 def teardown_after():
     yield
     giteamanager.teardown()
+
+
+@pytest.fixture
+def with_student_repos():
+    command = re.sub(
+        r"\s+",
+        " ",
+        f"""
+repos setup --bu https://localhost:3000/api/v1
+    --token {giteamanager.TEACHER_TOKEN}
+    --user {giteamanager.TEACHER_USER}
+    --org-name {giteamanager.TARGET_ORG_NAME}
+    --template-org-name {giteamanager.TEMPLATE_ORG_NAME}
+    --students {' '.join([t.members[0] for t in giteamanager.STUDENT_TEAMS])}
+    --assignments {' '.join(template_helpers.TEMPLATE_REPO_NAMES)}
+    --tb
+""",
+    )
+
+    repobee.run(shlex.split(command), plugins=[gitea])
+
+
+@pytest.fixture
+def target_api():
+    return gitea.GiteaAPI(
+        giteamanager.API_URL,
+        giteamanager.TEACHER_USER,
+        giteamanager.TEACHER_TOKEN,
+        giteamanager.TARGET_ORG_NAME,
+    )
+
+
+@pytest.fixture
+def template_api():
+    return gitea.GiteaAPI(
+        giteamanager.API_URL,
+        giteamanager.TEACHER_USER,
+        giteamanager.TEACHER_TOKEN,
+        giteamanager.TEMPLATE_ORG_NAME,
+    )

--- a/system_tests/gitea/test_gitea.py
+++ b/system_tests/gitea/test_gitea.py
@@ -7,26 +7,6 @@ from _repobee.ext import gitea
 import giteamanager
 
 
-@pytest.fixture
-def target_api():
-    return gitea.GiteaAPI(
-        giteamanager.API_URL,
-        giteamanager.TEACHER_USER,
-        giteamanager.TEACHER_TOKEN,
-        giteamanager.TARGET_ORG_NAME,
-    )
-
-
-@pytest.fixture
-def template_api():
-    return gitea.GiteaAPI(
-        giteamanager.API_URL,
-        giteamanager.TEACHER_USER,
-        giteamanager.TEACHER_TOKEN,
-        giteamanager.TEMPLATE_ORG_NAME,
-    )
-
-
 class TestCreateTeam:
     """Tests for the create_team function."""
 

--- a/system_tests/gitea/test_reviews.py
+++ b/system_tests/gitea/test_reviews.py
@@ -1,0 +1,44 @@
+import re
+import shlex
+
+import repobee_plug as plug
+import repobee
+from repobee_testhelpers._internal import templates as template_helpers
+from _repobee.ext import gitea
+
+import giteamanager
+
+
+class TestAssign:
+    def test_asignees_are_not_assigned(self, target_api, with_student_repos):
+        # arrange
+        assignment_name = template_helpers.TEMPLATE_REPO_NAMES[0]
+
+        command = re.sub(
+            r"\s+",
+            " ",
+            f"""
+reviews assign --bu {giteamanager.API_URL}
+    --token {giteamanager.TEACHER_TOKEN}
+    --user {giteamanager.TEACHER_USER}
+    --org-name {giteamanager.TARGET_ORG_NAME}
+    --students {' '.join(map(str, giteamanager.STUDENT_TEAMS))}
+    --assignments {assignment_name}
+    --tb
+""",
+        )
+
+        # act
+        repobee.run(shlex.split(command), plugins=[gitea])
+
+        # assert
+        repos = [
+            target_api.get_repo(
+                plug.generate_repo_name(team, assignment_name), team.name
+            )
+            for team in giteamanager.STUDENT_TEAMS
+        ]
+        assert repos
+        for repo in repos:
+            issue = next(target_api.get_repo_issues(repo))
+            assert not issue.implementation["assignees"]


### PR DESCRIPTION
Related to #802 

Assigning reviewers to the review issue on Gitea isn't possible, as Gitea prohibits users with read-access only to be assignees. This PR makes it such that RepoBee does not try to assign reviewers as assignees if Gitea is used. It's a temporary solution, the review assignment is to be redesigned.