### PR TITLE
[misc] Correct GitPython dependency

### DIFF
--- a/requirements/app.txt
+++ b/requirements/app.txt
@@ -4,7 +4,7 @@ bullet
 colored
 daiquiri
 dataclasses>='0.7';python_version<'3.7'
-git-python
+gitpython
 more-itertools>=8.4.0
 pluggy==0.13.1
 pygithub

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ required = [
     "colored",
     "daiquiri",
     "dataclasses>='0.7';python_version<'3.7'",
-    "git-python",
+    "gitpython",
     "more-itertools>=8.4.0",
     "pluggy>=0.13.1",
     "pygithub",


### PR DESCRIPTION
Changes a misspelling of a dependency, which just happened to be an actual package that depended on the desired dependency. The package is not malicious, so it isn't a security risk, but it should still be removed ASAP.