### PR TITLE
[feat] Add support for double-blind in `reviews check`

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -161,6 +161,7 @@ def _dispatch_reviews_command(
             args.students,
             args.title_regex,
             args.num_reviews,
+            args.double_blind_salt,
             api,
         )
         return None


### PR DESCRIPTION
Fix #791 

Final piece of the puzzle to support double-blind reviews. Well, except actually distributing the reviews to the affected students.