### PR TITLE
[misc] Adapt double blind terminology from "salt" to "key"

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -146,13 +146,13 @@ def _dispatch_reviews_command(
             args.students,
             args.num_reviews,
             args.issue,
-            args.double_blind_salt,
+            args.double_blind_key,
             api,
         )
         return None
     elif action == reviews.end:
         command.end_reviews(
-            args.assignments, args.students, args.double_blind_salt, api
+            args.assignments, args.students, args.double_blind_key, api
         )
         return None
     elif action == reviews.check:
@@ -161,7 +161,7 @@ def _dispatch_reviews_command(
             args.students,
             args.title_regex,
             args.num_reviews,
-            args.double_blind_salt,
+            args.double_blind_key,
             api,
         )
         return None

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -382,10 +382,10 @@ def _add_config_parsers(
 def _add_peer_review_parsers(base_parsers, add_parser):
     double_blind_parser = argparse_ext.RepobeeParser(add_help=False)
     double_blind_parser.add_argument(
-        "--double-blind-salt",
-        help="salt (a string) to use for double-blind peer review assignment "
+        "--double-blind-key",
+        help="key (any string) to use for double-blind peer review"
         "(alpha feature)",
-        metavar="SALT",
+        metavar="KEY",
     )
     base_review_parsers = [*base_parsers, double_blind_parser]
 

--- a/src/_repobee/hash.py
+++ b/src/_repobee/hash.py
@@ -6,7 +6,7 @@ import hashlib
 
 def hash(obj: Any, max_hash_size: Optional[int] = None) -> str:
     """Return the hexdigest of a sha256 hash of the string representation of
-    the input object, salted with the giiven salt and truncated to the given
+    the input object, keyed with the giiven key and truncated to the given
     hash size.
 
     Args:
@@ -18,11 +18,9 @@ def hash(obj: Any, max_hash_size: Optional[int] = None) -> str:
     return hashlib.sha256(str(obj).encode("utf8")).hexdigest()[:max_hash_size]
 
 
-def salted_hash(
-    obj: Any, salt: Any, max_hash_size: Optional[int] = None
-) -> str:
+def keyed_hash(obj: Any, key: Any, max_hash_size: Optional[int] = None) -> str:
     """Return the hexdigest of a sha256 hash of the string representation of
-    the input object, salted with the giiven salt and truncated to the given
+    the input object, keyed with the giiven key and truncated to the given
     hash size.
 
     .. danger::
@@ -32,9 +30,9 @@ def salted_hash(
 
     Args:
         obj: Any object to calculate a hash for.
-        salt: A salt, typically a string.
+        key: A key, typically a string.
         max_hash_size: The maximum size of the returned hash.
     Returns:
         A hash as described.
     """
-    return hash(str(obj) + salt, max_hash_size=max_hash_size)
+    return hash(str(obj) + key, max_hash_size=max_hash_size)

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -77,7 +77,7 @@ VALID_PARSED_ARGS = dict(
     ],
     secrets=False,
     update_local=False,
-    double_blind_salt=None,
+    double_blind_key=None,
 )
 
 


### PR DESCRIPTION
Just replacing the word "salt" with "key", as the latter is probably more easily understood by users.