### PR TITLE
[fix] Only create anonymous repo copies for reviewed repos

### DIFF
--- a/src/_repobee/command/peer.py
+++ b/src/_repobee/command/peer.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 import pathlib
 import shutil
-from typing import Iterable, Optional, Dict, List, Tuple
+from typing import Iterable, Optional, Dict, List, Tuple, Set
 
 import git  # type: ignore
 import repobee_plug as plug
@@ -87,14 +87,7 @@ def assign_peer_reviews(
         plug.log.info(f"Creating anonymous repos with key: {double_blind_key}")
         fetched_repo_dict = _create_anonymized_repos(
             [
-                (
-                    team,
-                    [
-                        repo
-                        for repo in repos
-                        if repo.name in expected_repo_names
-                    ],
-                )
+                (team, _only_expected_repos(repos, expected_repo_names))
                 for team, repos in team_repo_tuples
             ],
             double_blind_key,
@@ -160,6 +153,12 @@ def assign_peer_reviews(
                 if not isinstance(api, _repobee.ext.gitea.GiteaAPI)
                 else None,
             )
+
+
+def _only_expected_repos(
+    repos: List[plug.Repo], expected_repo_names: Set[str]
+) -> List[plug.Repo]:
+    return [repo for repo in repos if repo.name in expected_repo_names]
 
 
 def _create_anonymized_repos(

--- a/src/_repobee/command/peer.py
+++ b/src/_repobee/command/peer.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 import pathlib
 import shutil
-from typing import Iterable, Optional, Dict, List, Tuple, Set
+from typing import Iterable, Optional, Dict, List, Tuple
 
 import git  # type: ignore
 import repobee_plug as plug
@@ -156,7 +156,7 @@ def assign_peer_reviews(
 
 
 def _only_expected_repos(
-    repos: List[plug.Repo], expected_repo_names: Set[str]
+    repos: List[plug.Repo], expected_repo_names: Iterable[str]
 ) -> List[plug.Repo]:
     return [repo for repo in repos if repo.name in expected_repo_names]
 

--- a/src/_repobee/command/peer.py
+++ b/src/_repobee/command/peer.py
@@ -15,7 +15,7 @@ import re
 import tempfile
 import pathlib
 import shutil
-from typing import Iterable, Optional, Dict, List, Tuple
+from typing import Iterable, Optional, Dict, List, Tuple, Set
 
 import git  # type: ignore
 import repobee_plug as plug
@@ -67,7 +67,9 @@ def assign_peer_reviews(
             interface with the platform (e.g. GitHub or GitLab) instance.
     """
     issue = issue or DEFAULT_REVIEW_ISSUE
-    expected_repo_names = plug.generate_repo_names(teams, assignment_names)
+    expected_repo_names = set(
+        plug.generate_repo_names(teams, assignment_names)
+    )
     fetched_teams = progresswrappers.get_teams(
         teams, api, desc="Fetching teams and repos"
     )
@@ -79,7 +81,7 @@ def assign_peer_reviews(
     )
     fetched_repo_dict = {r.name: r for r in fetched_repos}
 
-    missing = set(expected_repo_names) - set(fetched_repo_dict.keys())
+    missing = expected_repo_names - fetched_repo_dict.keys()
     if missing:
         raise plug.NotFoundError(f"Can't find repos: {', '.join(missing)}")
 
@@ -156,7 +158,7 @@ def assign_peer_reviews(
 
 
 def _only_expected_repos(
-    repos: List[plug.Repo], expected_repo_names: Iterable[str]
+    repos: List[plug.Repo], expected_repo_names: Set[str]
 ) -> List[plug.Repo]:
     return [repo for repo in repos if repo.name in expected_repo_names]
 

--- a/src/_repobee/command/peer.py
+++ b/src/_repobee/command/peer.py
@@ -86,7 +86,19 @@ def assign_peer_reviews(
     if double_blind_key:
         plug.log.info(f"Creating anonymous repos with key: {double_blind_key}")
         fetched_repo_dict = _create_anonymized_repos(
-            team_repo_tuples, double_blind_key, api
+            [
+                (
+                    team,
+                    [
+                        repo
+                        for repo in repos
+                        if repo.name in expected_repo_names
+                    ],
+                )
+                for team, repos in team_repo_tuples
+            ],
+            double_blind_key,
+            api,
         )
 
     for assignment_name in assignment_names:

--- a/tests/new_integration_tests/test_reviews.py
+++ b/tests/new_integration_tests/test_reviews.py
@@ -21,7 +21,7 @@ class TestAssign:
 
         funcs.run_repobee(
             f"reviews assign -n 1 --base-url {platform_url} "
-            f"--assignments {const.TEMPLATE_REPOS_ARG}",
+            f"--assignments {const.TEMPLATE_REPOS_ARG}"
         )
 
         review_teams = [
@@ -32,6 +32,24 @@ class TestAssign:
 
         assert {t.name for t in review_teams} == expected_review_team_names
         assert all(map(lambda t: len(t.members) == 1, review_teams))
+
+    def test_double_blind_creates_correct_amount_of_anonymous_copies(
+        self, platform_url, with_student_repos
+    ):
+        assignment_name = const.TEMPLATE_REPO_NAMES[0]
+        api = funcs.get_api(platform_url)
+        num_repos_before = len(list(api.get_repos()))
+
+        funcs.run_repobee(
+            f"reviews assign --num-reviews 1 "
+            f"--base-url {platform_url} "
+            f"--double-blind-key 1234 "
+            f"--assignments {assignment_name}"
+        )
+
+        api._restore_state()
+        num_repos_after = len(list(api.get_repos()))
+        assert num_repos_after == num_repos_before + len(const.STUDENT_TEAMS)
 
 
 class TestEnd:
@@ -45,7 +63,7 @@ class TestEnd:
         }
         funcs.run_repobee(
             f"reviews assign -n 1 --base-url {platform_url} "
-            f"--assignments {const.TEMPLATE_REPOS_ARG}",
+            f"--assignments {const.TEMPLATE_REPOS_ARG}"
         )
 
         funcs.run_repobee(
@@ -71,7 +89,7 @@ class TestCheck:
         template_repo_name = const.TEMPLATE_REPO_NAMES[0]
         funcs.run_repobee(
             f"reviews assign -n 1 --base-url {platform_url} "
-            f"--assignments {template_repo_name}",
+            f"--assignments {template_repo_name}"
         )
 
         funcs.run_repobee(


### PR DESCRIPTION
Fix #815 

Double-blind peer review would previously create anonymous repo copies for all student repos. That's not great :D.