### PR TITLE
[feat] Make `issues list` on anonymous repos show original repo names

### DIFF
--- a/system_tests/gitea/test_reviews.py
+++ b/system_tests/gitea/test_reviews.py
@@ -64,9 +64,7 @@ reviews assign --bu {giteamanager.API_URL}
         # assert
         for student_team in giteamanager.STUDENT_TEAMS:
             review_team_name = keyed_hash(
-                plug.generate_review_team_name(student_team, assignment_name),
-                key=double_blind_key,
-                max_hash_size=20,
+                student_team.name, key=double_blind_key, max_hash_size=20
             )
             original_repo_name = plug.generate_repo_name(
                 student_team, assignment_name
@@ -126,9 +124,7 @@ class TestEnd:
         # assert
         review_team_names = [
             keyed_hash(
-                plug.generate_review_team_name(student_team, assignment_name),
-                key=double_blind_key,
-                max_hash_size=20,
+                student_team.name, key=double_blind_key, max_hash_size=20
             )
             for student_team in giteamanager.STUDENT_TEAMS
         ]
@@ -191,9 +187,7 @@ class TestEnd:
         )
         orig_repo = target_api.get_repo(orig_repo_name, orig_team_name)
         review_team_name = keyed_hash(
-            plug.generate_review_team_name(orig_team_name, assignment_name),
-            key=double_blind_key,
-            max_hash_size=20,
+            orig_team_name, key=double_blind_key, max_hash_size=20
         )
         review_team = next(target_api.get_teams([review_team_name]))
         target_api.assign_repo(

--- a/tests/new_integration_tests/test_issues.py
+++ b/tests/new_integration_tests/test_issues.py
@@ -136,14 +136,12 @@ class TestList:
             f"--base-url {platform_url}"
         )
 
-        api = funcs.get_api(platform_url)
         stdout = capsys.readouterr().out
-        for team in const.STUDENT_TEAMS:
-            review_team = _get_anonymous_review_team(
-                team, assignment, key, api
-            )
-            anon_repo = next(api.get_team_repos(review_team))
-            assert re.search(fr"{anon_repo.name}.*{review_title}", stdout)
+        expected_repo_names = plug.generate_repo_names(
+            const.STUDENT_TEAMS, [assignment]
+        )
+        for repo_name in expected_repo_names:
+            assert re.search(fr"{repo_name}.*{review_title}", stdout)
 
 
 def _get_anonymous_review_team(
@@ -152,9 +150,8 @@ def _get_anonymous_review_team(
     key: str,
     api: plug.PlatformAPI,
 ) -> plug.Team:
-    review_team_name = plug.generate_review_team_name(student_team, assignment)
     review_team, *_ = list(
-        api.get_teams([_repobee.hash.keyed_hash(review_team_name, key, 20)])
+        api.get_teams([_repobee.hash.keyed_hash(student_team.name, key, 20)])
     )
     return review_team
 


### PR DESCRIPTION
#811 

`issues list` with `--double-blind-keys` now shows the original repo names instead of the names of the anonymous copies. This is semi-confusing, but we'll add a message in the future to highlight that these are de-anonymized names.