### PR TITLE
[feat] Include --double-blind-key in alpha arguments

### DIFF
--- a/src/_repobee/cli/argparse_ext.py
+++ b/src/_repobee/cli/argparse_ext.py
@@ -64,7 +64,7 @@ class RepobeeParser(argparse.ArgumentParser):
             "--base-url",
         }
         debug_args = {"--traceback", "--quiet"}
-        alpha_args = {"--hook-results-file"}
+        alpha_args = {"--hook-results-file", "--double-blind-key"}
 
         for arg in args:
             if arg in platform_args:

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -74,7 +74,9 @@ _LOCAL_TEMPLATES_PARSER.add_argument(
     action="store_true",
 )
 
-_DOUBLE_BLIND_PARSER = argparse_ext.RepobeeParser(add_help=False)
+_DOUBLE_BLIND_PARSER = argparse_ext.RepobeeParser(
+    is_core_command=True, add_help=False
+)
 _DOUBLE_BLIND_PARSER.add_argument(
     "--double-blind-key",
     help="key (any string) to use for double-blind peer review"


### PR DESCRIPTION
#811

Makes the `--double-blind-key` argument appear in the "Alpha arguments" section of the help listing.