### PR TITLE
[feat] Add functionality to distribute double-blind reviews

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -10,7 +10,7 @@ CLI into commands for RepoBee's core.
 """
 import argparse
 import pathlib
-import json
+import sys
 from typing import Optional, List, Mapping, NoReturn
 
 import repobee_plug as plug
@@ -105,7 +105,13 @@ def _dispatch_issues_command(
             )
         else:
             command.open_issues_from_hook_results(
-                json.loads(args.hook_results_file.read_text()), args.repos, api
+                plug.json_to_result_mapping(
+                    args.hook_results_file.read_text(
+                        encoding=sys.getdefaultencoding()
+                    )
+                ),
+                args.repos,
+                api,
             )
         return None
     elif action == issues.close:

--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -10,6 +10,7 @@ CLI into commands for RepoBee's core.
 """
 import argparse
 import pathlib
+import json
 from typing import Optional, List, Mapping, NoReturn
 
 import repobee_plug as plug
@@ -98,7 +99,14 @@ def _dispatch_issues_command(
     issues = plug.cli.CoreCommand.issues
     action = args.action
     if action == issues.open:
-        command.open_issue(args.issue, args.assignments, args.students, api)
+        if args.issue:
+            command.open_issue(
+                args.issue, args.assignments, args.students, api
+            )
+        else:
+            command.open_issues_from_hook_results(
+                json.loads(args.hook_results_file.read_text()), args.repos, api
+            )
         return None
     elif action == issues.close:
         command.close_issue(args.title_regex, args.repos, api)

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -489,13 +489,19 @@ def _add_issue_parsers(base_parsers, add_parser):
         parents=base_parsers,
         formatter_class=argparse_ext.OrderedFormatter,
     )
-    open_parser.add_argument(
+
+    issue_mutex = open_parser.add_mutually_exclusive_group(required=True)
+    issue_mutex.add_argument(
         "-i",
         "--issue",
         help="path to an issue file (NOTE: first line is assumed to be the "
         "title)",
         type=str,
-        required=True,
+    )
+    issue_mutex.add_argument(
+        "--hook-results-file",
+        help="path to a hook result JSON file with issues to open",
+        type=pathlib.Path,
     )
 
     close_parser = add_parser(

--- a/src/_repobee/command/__init__.py
+++ b/src/_repobee/command/__init__.py
@@ -1,4 +1,9 @@
-from _repobee.command.issues import open_issue, close_issue, list_issues
+from _repobee.command.issues import (
+    open_issue,
+    open_issues_from_hook_results,
+    close_issue,
+    list_issues,
+)
 from _repobee.command.peer import (
     assign_peer_reviews,
     end_reviews,
@@ -17,6 +22,7 @@ from . import progresswrappers
 
 __all__ = [
     "open_issue",
+    "open_issues_from_hook_results",
     "close_issue",
     "list_issues",
     "assign_peer_reviews",

--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -212,7 +212,7 @@ def _limit_line_length(s: str, max_line_length: int = 100) -> str:
 
 
 def open_issues_from_hook_results(
-    hook_results: dict,
+    hook_results: Mapping[str, List[plug.Result]],
     repos: Iterable[plug.StudentRepo],
     api: plug.PlatformAPI,
 ) -> None:
@@ -226,7 +226,7 @@ def open_issues_from_hook_results(
         api: plug.PlatformAPI,
     """
     url_to_repo = {repo.url: repo for repo in repos}
-    for repo_url, repo_data in hook_results["repos"]["repos"]["data"].items():
+    for repo_url, repo_data in hook_results["repos"][0].data.items():
         if repo_url in url_to_repo and repo_data["issues"]:
             repo = url_to_repo[repo_url]
             platform_repo = api.get_repo(repo.name, repo.team.name)

--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -105,7 +105,7 @@ def list_issues(
         repos_data[repo.url]["issues"] = {
             issue.number: issue.to_dict() for issue in issues
         }
-    hook_result_mapping["_repos"] = [
+    hook_result_mapping["repos"] = [
         plug.Result("repos", plug.Status.SUCCESS, "repo_data", data=repos_data)
     ]
 
@@ -226,7 +226,7 @@ def open_issues_from_hook_results(
         api: plug.PlatformAPI,
     """
     url_to_repo = {repo.url: repo for repo in repos}
-    for repo_url, repo_data in hook_results["_repos"]["repos"]["data"].items():
+    for repo_url, repo_data in hook_results["repos"]["repos"]["data"].items():
         if repo_url in url_to_repo and repo_data["issues"]:
             repo = url_to_repo[repo_url]
             platform_repo = api.get_repo(repo.name, repo.team.name)

--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -105,7 +105,9 @@ def list_issues(
         repos_data[repo.url]["issues"] = {
             issue.number: issue.to_dict() for issue in issues
         }
-    hook_result_mapping["_repos"] = repos_data
+    hook_result_mapping["_repos"] = [
+        plug.Result("repos", plug.Status.SUCCESS, "repo_data", data=repos_data)
+    ]
 
     return hook_result_mapping
 
@@ -224,7 +226,7 @@ def open_issues_from_hook_results(
         api: plug.PlatformAPI,
     """
     url_to_repo = {repo.url: repo for repo in repos}
-    for repo_url, repo_data in hook_results["_repos"].items():
+    for repo_url, repo_data in hook_results["_repos"]["repos"]["data"].items():
         if repo_url in url_to_repo and repo_data["issues"]:
             repo = url_to_repo[repo_url]
             platform_repo = api.get_repo(repo.name, repo.team.name)

--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -105,7 +105,7 @@ def list_issues(
         repos_data[repo.url]["issues"] = {
             issue.number: issue.to_dict() for issue in issues
         }
-    hook_result_mapping["repos"] = [
+    hook_result_mapping["_repos"] = [
         plug.Result("repos", plug.Status.SUCCESS, "repo_data", data=repos_data)
     ]
 
@@ -226,7 +226,7 @@ def open_issues_from_hook_results(
         api: plug.PlatformAPI,
     """
     url_to_repo = {repo.url: repo for repo in repos}
-    for repo_url, repo_data in hook_results["repos"]["repos"]["data"].items():
+    for repo_url, repo_data in hook_results["_repos"]["repos"]["data"].items():
         if repo_url in url_to_repo and repo_data["issues"]:
             repo = url_to_repo[repo_url]
             platform_repo = api.get_repo(repo.name, repo.team.name)

--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -11,6 +11,7 @@ self-contained program.
 """
 import os
 import re
+import dataclasses
 from typing import Iterable, Optional, List, Tuple, Any, Mapping
 
 from colored import bg, fg, style  # type: ignore
@@ -86,6 +87,7 @@ def list_issues(
         ]
         for repo, issues in pers_issues_per_repo
     }
+
     # meta hook result
     hook_result_mapping["list-issues"] = [
         plug.Result(
@@ -94,6 +96,17 @@ def list_issues(
             msg="Meta info about the list-issues hook results",
             data={"state": state.value},
         )
+    ]
+
+    # new experimental format for repo data used by `issues list` with
+    # --hook-results-file
+    repos_data = {repo.url: dataclasses.asdict(repo) for repo in repos}
+    for repo, issues in pers_issues_per_repo:
+        repos_data[repo.url]["issues"] = {
+            issue.number: issue.to_dict() for issue in issues
+        }
+    hook_result_mapping["repos"] = [
+        plug.Result("repos", plug.Status.SUCCESS, "repo_data", data=repos_data)
     ]
 
     return hook_result_mapping
@@ -196,6 +209,36 @@ def _limit_line_length(s: str, max_line_length: int = 100) -> str:
             cur = idx + 1
         out += line[cur : cur + max_line_length] + os.linesep
     return out
+
+
+def open_issues_from_hook_results(
+    hook_results: dict,
+    repos: Iterable[plug.StudentRepo],
+    api: plug.PlatformAPI,
+) -> None:
+    """Open all issues from the hook results in the given repos. Issues given
+    in the hook results that do not belong to the repos are ignored, and repos
+    provided without corresponding issues in the hook results have no effect.
+
+    Args:
+        hook_results: A hook results dictionary.
+        repos: Student repos to open issues in.
+        api: plug.PlatformAPI,
+    """
+    url_to_repo = {repo.url: repo for repo in repos}
+    for repo_url, repo_data in hook_results["repos"]["repos"]["data"].items():
+        if repo_url in url_to_repo and repo_data["issues"]:
+            repo = url_to_repo[repo_url]
+            platform_repo = api.get_repo(repo.name, repo.team.name)
+
+            for issue_data in repo_data["issues"].values():
+                issue = api.create_issue(
+                    issue_data["title"], issue_data["body"], platform_repo
+                )
+                msg = (
+                    f"Opened issue {repo.name}/#{issue.number}-'{issue.title}'"
+                )
+                plug.echo(msg)
 
 
 def open_issue(

--- a/src/_repobee/command/issues.py
+++ b/src/_repobee/command/issues.py
@@ -105,9 +105,7 @@ def list_issues(
         repos_data[repo.url]["issues"] = {
             issue.number: issue.to_dict() for issue in issues
         }
-    hook_result_mapping["_repos"] = [
-        plug.Result("repos", plug.Status.SUCCESS, "repo_data", data=repos_data)
-    ]
+    hook_result_mapping["_repos"] = repos_data
 
     return hook_result_mapping
 
@@ -226,7 +224,7 @@ def open_issues_from_hook_results(
         api: plug.PlatformAPI,
     """
     url_to_repo = {repo.url: repo for repo in repos}
-    for repo_url, repo_data in hook_results["_repos"]["repos"]["data"].items():
+    for repo_url, repo_data in hook_results["_repos"].items():
         if repo_url in url_to_repo and repo_data["issues"]:
             repo = url_to_repo[repo_url]
             platform_repo = api.get_repo(repo.name, repo.team.name)

--- a/src/repobee_plug/serialize.py
+++ b/src/repobee_plug/serialize.py
@@ -19,7 +19,6 @@ def result_mapping_to_json(result_mapping: Mapping[str, List[Result]]) -> str:
             for h in hook_results
         }
         for repo_name, hook_results in result_mapping.items()
-        if not repo_name.startswith("_")
     }
     return json.dumps(hook_results_as_dicts, indent=4, ensure_ascii=False)
 

--- a/src/repobee_plug/serialize.py
+++ b/src/repobee_plug/serialize.py
@@ -14,18 +14,17 @@ def result_mapping_to_json(result_mapping: Mapping[str, List[Result]]) -> str:
     List[Result]`` to JSON.
     """
     hook_results_as_dicts = {
-        key: {
+        repo_name: {
             h.name: {"status": h.status.value, "msg": h.msg, "data": h.data}
             for h in hook_results
         }
-        if not key.startswith("_")
-        else hook_results
-        for key, hook_results in result_mapping.items()
+        for repo_name, hook_results in result_mapping.items()
+        if not repo_name.startswith("_")
     }
     return json.dumps(hook_results_as_dicts, indent=4, ensure_ascii=False)
 
 
-def json_to_result_mapping(json_string: str) -> Mapping[str, List[Result]]:
+def json_to_result_mapping(json_string: str,) -> Mapping[str, List[Result]]:
     """Deserialize a JSON string to a mapping ``repo_name: str -> hook_results:
     List[Result]``
     """

--- a/src/repobee_plug/serialize.py
+++ b/src/repobee_plug/serialize.py
@@ -19,6 +19,7 @@ def result_mapping_to_json(result_mapping: Mapping[str, List[Result]]) -> str:
             for h in hook_results
         }
         for repo_name, hook_results in result_mapping.items()
+        if not repo_name.startswith("_")
     }
     return json.dumps(hook_results_as_dicts, indent=4, ensure_ascii=False)
 

--- a/src/repobee_plug/serialize.py
+++ b/src/repobee_plug/serialize.py
@@ -14,17 +14,18 @@ def result_mapping_to_json(result_mapping: Mapping[str, List[Result]]) -> str:
     List[Result]`` to JSON.
     """
     hook_results_as_dicts = {
-        repo_name: {
+        key: {
             h.name: {"status": h.status.value, "msg": h.msg, "data": h.data}
             for h in hook_results
         }
-        for repo_name, hook_results in result_mapping.items()
-        if not repo_name.startswith("_")
+        if not key.startswith("_")
+        else hook_results
+        for key, hook_results in result_mapping.items()
     }
     return json.dumps(hook_results_as_dicts, indent=4, ensure_ascii=False)
 
 
-def json_to_result_mapping(json_string: str,) -> Mapping[str, List[Result]]:
+def json_to_result_mapping(json_string: str) -> Mapping[str, List[Result]]:
     """Deserialize a JSON string to a mapping ``repo_name: str -> hook_results:
     List[Result]``
     """


### PR DESCRIPTION
Fix #811 

Makes it possible to distribute double-blind reviews through two extensions.

1. Add more data to the output from `issues list`, experimental format.
2. Make it possible to open issues from a hook results file using the new experimental format with `issues open --hook-reusults-file hf.json`.

It's a bit janky, but it should work as a first prototype.