### PR TITLE
[fix] Fix GitHubAPI.insert_auth using the wrong URL

### DIFF
--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -398,7 +398,12 @@ class GitHubAPI(plug.PlatformAPI):
         """See :py:meth:`repobee_plug.PlatformAPI.insert_auth`."""
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(url)
 
-        html_base_url = urllib.parse.urlunsplit([scheme, netloc, *([""] * 3)])
+        base_scheme, base_netloc, *_ = urllib.parse.urlsplit(
+            self._org.html_url
+        )
+        html_base_url = urllib.parse.urlunsplit(
+            [base_scheme, base_netloc, *([""] * 3)]
+        )
         if html_base_url not in url:
             raise plug.InvalidURL(f"url not found on platform: '{url}'")
 

--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -396,9 +396,7 @@ class GitHubAPI(plug.PlatformAPI):
 
     def insert_auth(self, url: str) -> str:
         """See :py:meth:`repobee_plug.PlatformAPI.insert_auth`."""
-        scheme, netloc, path, query, fragment = urllib.parse.urlsplit(
-            self._org.html_url
-        )
+        scheme, netloc, path, query, fragment = urllib.parse.urlsplit(url)
 
         html_base_url = urllib.parse.urlunsplit([scheme, netloc, *([""] * 3)])
         if html_base_url not in url:

--- a/tests/unit_tests/repobee/plugin_tests/test_github.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_github.py
@@ -377,6 +377,12 @@ class TestInsertAuth:
 
         assert "url not found on platform" in str(exc_info.value)
 
+    def test_retains_endpoint(self, api):
+        endpoint = "some/repo"
+        url = f"{BASE_URL}/some/repo"
+        authed_url = api.insert_auth(url)
+        assert endpoint in authed_url
+
 
 class TestGetRepoUrls:
     """Tests for get_repo_urls."""


### PR DESCRIPTION
Fixes a bug that causes GitHubAPI.insert_auth to use the URL to the organization instead of the provided URL. Silly.