### PR TITLE
[feat] Add support for local configuration files

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -129,8 +129,8 @@ Configure RepoBee for the target organization (the ``config`` category)
 In this section, we'll cover the ``config`` category of commands. These are used
 to configure RepoBee.
 
-Editing the configuration file (the ``wizard`` and ``show`` actions)
---------------------------------------------------------------------
+Editing the global configuration file (the ``wizard`` and ``show`` actions)
+---------------------------------------------------------------------------
 
 For RepoBee to work at all, it needs to be provided with an access token to
 whichever platform instance you intend to use. See the `GitHub access token
@@ -203,6 +203,14 @@ got everything set correctly.
 Note that the token is not shown. To show secrets in the configuration file,
 provide the ``--secrets`` option to ``config show``. If you ever want to
 re-configure some of the options, simply run ``config wizard`` again.
+
+Local config files
+------------------
+
+When executing a command, RepoBee will first look for a file called
+``repobee.ini`` in the current working directory. If such a file is found, it
+completely overrides the global config file. This is useful for managing
+different courses or groups within courses, with different settings.
 
 The students file
 -----------------

--- a/src/_repobee/cli/preparser.py
+++ b/src/_repobee/cli/preparser.py
@@ -29,12 +29,16 @@ PRE_PARSER_NO_PLUGS = "--no-plugins"
 PRE_PARSER_FLAGS = [PRE_PARSER_NO_PLUGS]
 
 
-def parse_args(sys_args: List[str]) -> argparse.Namespace:
+def parse_args(
+    sys_args: List[str], default_config_file: pathlib.Path
+) -> argparse.Namespace:
     """Parse all arguments that can somehow alter the end-user CLI, such
     as plugins.
 
     Args:
         sys_args: Command line arguments.
+        default_config_file: The default config file to use if none is
+            specified.
     Returns:
         The parsed arguments.
     """
@@ -46,7 +50,7 @@ def parse_args(sys_args: List[str]) -> argparse.Namespace:
         *PRE_PARSER_CONFIG_OPTS,
         help="Specify path to the config file to use.",
         type=pathlib.Path,
-        default=_repobee.constants.DEFAULT_CONFIG_FILE,
+        default=default_config_file,
     )
 
     mutex_grp = parser.add_mutually_exclusive_group()

--- a/src/_repobee/constants.py
+++ b/src/_repobee/constants.py
@@ -17,6 +17,7 @@ CONFIG_DIR = pathlib.Path(
         appname=_repobee._external_package_name, appauthor=_repobee.__author__
     )
 )
+LOCAL_CONFIG_NAME = "repobee.ini"
 LOG_DIR = pathlib.Path(
     appdirs.user_log_dir(
         appname=_repobee._external_package_name, appauthor=_repobee.__author__

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -10,6 +10,7 @@ from repobee_testhelpers import const
 import repobee_plug as plug
 
 import _repobee.exception
+import _repobee.main
 
 
 class TestConfigShow:
@@ -32,6 +33,21 @@ class TestConfigShow:
 
         outerr = capsys.readouterr()
         assert const.TOKEN in outerr.out
+
+    def test_prints_local_config(self, capsys, tmp_path):
+        """Local (in the working dir) repobee.ini files should take precedence
+        over the default config file.
+        """
+        config_content = "[repobee]\nuser = some-unlikely-user"
+        local_config = tmp_path / "repobee.ini"
+        local_config.write_text(config_content, encoding="utf8")
+
+        _repobee.main.main(
+            ["repobee", *plug.cli.CoreCommand.config.show.as_name_tuple()],
+            workdir=tmp_path,
+        )
+
+        assert config_content in capsys.readouterr().out
 
 
 class TestConfigVerify:


### PR DESCRIPTION
Fix #465 

This PRs adds support for "local" configuration files. If you place a config file called `repobee.ini` into the current working directory, it overrides the global config file.