### PR TITLE
[feat] Add handle_config hook

### DIFF
--- a/src/_repobee/config.py
+++ b/src/_repobee/config.py
@@ -64,13 +64,13 @@ def execute_config_hooks(config_file: Union[str, pathlib.Path]) -> None:
         config_file: path to the config file.
     """
     config_file = pathlib.Path(config_file)
+    plug.manager.hook.handle_config(config=plug.Config(config_file))
     if not config_file.is_file():
         return
     config_parser = _read_config(config_file)
     plug.manager.hook.config_hook(
         config_parser=config_parser
     )  # TODO remove by 3.8.0
-    plug.manager.hook.handle_config(config=plug.Config(config_file))
 
 
 def check_config_integrity(config_file: Union[str, pathlib.Path]) -> None:

--- a/src/_repobee/config.py
+++ b/src/_repobee/config.py
@@ -67,7 +67,10 @@ def execute_config_hooks(config_file: Union[str, pathlib.Path]) -> None:
     if not config_file.is_file():
         return
     config_parser = _read_config(config_file)
-    plug.manager.hook.config_hook(config_parser=config_parser)
+    plug.manager.hook.config_hook(
+        config_parser=config_parser
+    )  # TODO remove by 3.8.0
+    plug.manager.hook.handle_config(config=plug.Config(config_file))
 
 
 def check_config_integrity(config_file: Union[str, pathlib.Path]) -> None:

--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -9,7 +9,7 @@ a short configuration wizard that lets the user set RepoBee's defaults.
 import argparse
 import collections
 
-from typing import Mapping, List
+from typing import Mapping, List, Optional
 
 import bullet  # type: ignore
 
@@ -29,8 +29,14 @@ class Wizard(plug.Plugin, plug.cli.Command):
         ),
     )
 
+    _config: Optional[plug.Config]
+
     def command(self) -> None:
-        return callback(self.args, plug.Config(constants.DEFAULT_CONFIG_FILE))
+        assert self._config is not None
+        return callback(self.args, self._config)
+
+    def handle_config(self, config: plug.Config) -> None:
+        self._config = config
 
 
 def callback(args: argparse.Namespace, config: plug.Config) -> None:

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -125,7 +125,7 @@ def get_configurable_args() -> ConfigurableArguments:
 def config_hook(config_parser: configparser.ConfigParser) -> None:
     """Hook into the config file parsing.
 
-    .. deprecated::
+    .. deprecated:: 3.6.0
 
         Use :py:func:`handle_config` instead.
 

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -9,13 +9,14 @@ cloning repos.
 """
 
 import argparse
-import configparser
 from typing import Optional
+from configparser import ConfigParser
 
 from repobee_plug.cli.args import ConfigurableArguments
 from repobee_plug.platform import PlatformAPI
 from repobee_plug.hook import hookspec, Result
 from repobee_plug.deprecation import deprecate
+from repobee_plug.config import Config
 
 from repobee_plug.localreps import StudentRepo, TemplateRepo
 
@@ -119,12 +120,29 @@ def get_configurable_args() -> ConfigurableArguments:
     """
 
 
+@deprecate(remove_by_version="3.8.0", replacement="handle_config")
 @hookspec
-def config_hook(config_parser: configparser.ConfigParser) -> None:
+def config_hook(config_parser: ConfigParser) -> None:
     """Hook into the config file parsing.
 
+    .. deprecated::
+
+        Use :py:func:`handle_config` instead.
+
     Args:
-        config: the config parser after config has been read.
+        config_parser: The config parser after config has been read.
+    """
+
+
+@hookspec
+def handle_config(config: Config) -> None:
+    """Handle the config.
+
+    This hook is allowed both to read the config, and to modify it before it's
+    passed to the core RepoBee application.
+
+    Args:
+        config: RepoBee's config.
     """
 
 

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -9,8 +9,8 @@ cloning repos.
 """
 
 import argparse
+import configparser
 from typing import Optional
-from configparser import ConfigParser
 
 from repobee_plug.cli.args import ConfigurableArguments
 from repobee_plug.platform import PlatformAPI
@@ -122,7 +122,7 @@ def get_configurable_args() -> ConfigurableArguments:
 
 @deprecate(remove_by_version="3.8.0", replacement="handle_config")
 @hookspec
-def config_hook(config_parser: ConfigParser) -> None:
+def config_hook(config_parser: configparser.ConfigParser) -> None:
     """Hook into the config file parsing.
 
     .. deprecated::

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -1,6 +1,9 @@
 """Tests for the config category of commands."""
 import tempfile
 import pathlib
+import shlex
+
+from unittest import mock
 
 import pytest
 
@@ -67,3 +70,31 @@ class TestConfigVerify:
             )
 
         assert f"'{non_existing_file}' is not a file" in str(exc_info.value)
+
+
+class TestConfigWizard:
+    """Tests for the ``config wizard`` command."""
+
+    def test_respects_config_file_argument(self, platform_url, tmp_path):
+        # arrange
+        config_file = tmp_path / "repobee.ini"
+        unlikely_value = "badabimbadabum"
+
+        # act
+        with mock.patch(
+            "bullet.Bullet.launch",
+            autospec=True,
+            return_value=_repobee.constants.CORE_SECTION_HDR,
+        ), mock.patch("builtins.input", return_value=unlikely_value):
+            _repobee.main.main(
+                shlex.split(
+                    f"repobee --config-file {config_file} config wizard"
+                )
+            )
+
+        # assert
+        config = plug.Config(config_file)
+        assert (
+            config.get(_repobee.constants.CORE_SECTION_HDR, "students_file")
+            == unlikely_value
+        )


### PR DESCRIPTION
Fix #824 

This PR adds the `handle_config` hook, which uses the new Config wrapper. It replaces the `config_hook`, which is now deprecated and is to be removed by 3.8.0.

As a proof of concept, the config wizard uses the new hook, which is what fixes #824.