### PR TITLE
[fix] Avoid assigning token owner as member of GitLab group

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
 
   gitlab-system-tests:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'create' }}
+    #if: ${{ github.event_name == 'create' }}
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
 
   gitlab-system-tests:
     runs-on: ubuntu-latest
-    #if: ${{ github.event_name == 'create' }}
+    if: ${{ github.event_name == 'create' }}
     steps:
     - uses: actions/checkout@v2
       with:

--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -153,7 +153,13 @@ class GitLabAPI(plug.PlatformAPI):
         group = team.implementation
 
         with _try_api_request():
-            for user in self._get_users(members):
+            # never assign the token owner to a group as the creator of a group
+            # is automatically a member. See issue #812.
+            token_owner = self._gitlab.user.username
+            members_without_owner = [
+                member for member in members if member != token_owner
+            ]
+            for user in self._get_users(members_without_owner):
                 group.members.create(
                     {"user_id": user.id, "access_level": raw_permission}
                 )

--- a/system_tests/gitlab/test_gitlab_system.py
+++ b/system_tests/gitlab/test_gitlab_system.py
@@ -220,6 +220,28 @@ class TestSetup:
         assert_repos_exist(STUDENT_TEAMS, assignment_names)
         assert_on_groups(STUDENT_TEAMS)
 
+    def test_setup_with_token_owner_as_student(self, extra_args):
+        """Setting up with the token owner as a student should not cause
+        a crash (see #812)
+        """
+        command = " ".join(
+            [
+                REPOBEE_GITLAB,
+                *repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(),
+                *BASE_ARGS,
+                *TEMPLATE_ORG_ARG,
+                *MASTER_REPOS_ARG,
+                "--students",
+                TEACHER,
+            ]
+        )
+
+        result = run_in_docker_with_coverage(command, extra_args=extra_args)
+        assert result.returncode == 0
+        assert_repos_exist(
+            [plug.StudentTeam(members=[TEACHER])], assignment_names
+        )
+
 
 @pytest.mark.filterwarnings("ignore:.*Unverified HTTPS request.*")
 class TestUpdate:


### PR DESCRIPTION
Fix #812 

The token owner should not be assigned as a member of a group in GitLab as it is by default part of any group it creates.