### PR TITLE
[fix] Replace --use-feature=2020-resolver with pip auto-update

### DIFF
--- a/src/_repobee/disthelpers.py
+++ b/src/_repobee/disthelpers.py
@@ -146,8 +146,8 @@ def pip(command: str, *args, **kwargs) -> subprocess.CompletedProcess:
     Returns:
         True iff the command exited with a zero exit status.
     Raises:
-        DependencyResolutionError: If the 2020-resolver encounters fails to
-            resolve dependencies.
+        DependencyResolutionError: If the 2020-resolver fails to resolve
+            dependencies.
     """
     cli_kwargs = [
         f"--{key.replace('_', '-')}"
@@ -157,9 +157,11 @@ def pip(command: str, *args, **kwargs) -> subprocess.CompletedProcess:
     ]
     env = dict(os.environ)
     if command == "install":
-        # the resolver allows us to avoid installing plugins that are
-        # incompatible with the current version of RepoBee
-        cli_kwargs.append("--use-feature=2020-resolver")
+        if "pip" not in args:
+            # always upgrade pip before running an install to ensure that the
+            # 2020-resolver is available
+            pip_upgrade_rc = pip("install", "-U", "pip").returncode
+            assert pip_upgrade_rc == 0
 
         # REPOBEE_INSTALL_DIR must be available when upgrading RepoBee,
         # or the dist plugins aren't activated

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -203,6 +203,43 @@ class Hello(plug.Plugin, plug.cli.Command):
             exc_info.value
         )
 
+    def test_auto_updates_pip(self):
+        """Installing a plugin should automatically update pip if it's
+        out-of-date.
+        """
+        # arrange
+        old_pip_version = "20.0.1"
+        assert (
+            subprocess.run(
+                [
+                    disthelpers.get_pip_path(),
+                    "install",
+                    "-U",
+                    f"pip=={old_pip_version}",
+                ]
+            ).returncode
+            == 0
+        )
+        assert version.Version(get_pkg_version("pip")) == version.Version(
+            old_pip_version
+        )
+
+        plugin_name = "junit4"
+        plugin_version = "v1.0.0"
+        cmd = [
+            *pluginmanager.plugin_category.install.as_name_tuple(),
+            "--plugin-spec",
+            f"{plugin_name}{pluginmanager.PLUGIN_SPEC_SEP}{plugin_version}",
+        ]
+
+        # act
+        repobee.run(cmd)
+
+        # assert
+        assert version.Version(get_pkg_version("pip")) > version.Version(
+            old_pip_version
+        )
+
 
 class TestPluginUninstall:
     """Tests for the ``plugin uninstall`` command."""


### PR DESCRIPTION
Fix #848 

This PR replaces the use of `--use-feature=2020-resolver` with an auto-update of `pip` on each install. This is because the latest version of `pip` has the resolver enabled by default, and `--use-feature=2020-resolver` will soon cause errors for users (it already causes test failures).