### PR TITLE
[fix] Print path to actual storage location of config file in `config wizard`

### DIFF
--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -90,8 +90,4 @@ Current defaults are shown in brackets [].
 
     config.store()
 
-    plug.echo(
-        "Configuration file written to {}".format(
-            constants.DEFAULT_CONFIG_FILE
-        )
-    )
+    plug.echo(f"Configuration file written to {config.path}")

--- a/src/repobee_plug/config.py
+++ b/src/repobee_plug/config.py
@@ -79,6 +79,11 @@ class Config:
         """
         return self._config_parser.get(section_name, key, fallback=fallback)
 
+    @property
+    def path(self) -> pathlib.Path:
+        """Path to the config file."""
+        return self._config_path
+
     def __getitem__(self, section_key: str) -> ConfigSection:
         return _ConfigSection(self._config_parser[section_key])
 

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -98,3 +98,27 @@ class TestConfigWizard:
             config.get(_repobee.constants.CORE_SECTION_HDR, "students_file")
             == unlikely_value
         )
+
+    def test_end_message_respects_config_file_argument(
+        self, platform_url, tmp_path, capsys
+    ):
+        # arrange
+        config_file = tmp_path / "repobee.ini"
+
+        # act
+        with mock.patch(
+            "bullet.Bullet.launch",
+            autospec=True,
+            return_value=_repobee.constants.CORE_SECTION_HDR,
+        ), mock.patch("builtins.input", return_value="dontcare"):
+            _repobee.main.main(
+                shlex.split(
+                    f"repobee --config-file {config_file} config wizard"
+                )
+            )
+
+        # assert
+        assert (
+            f"Configuration file written to {config_file}"
+            in capsys.readouterr().out
+        )


### PR DESCRIPTION
Fix #863 

No prints the path to the config file that's actually used, rather than always printing the path to the default file.