### PR TITLE
[feat] Lookup config file up the directory tree

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -214,10 +214,12 @@ re-configure some of the options, simply run ``config wizard`` again.
 Local ``repobee.ini`` config files
 ----------------------------------
 
-When executing a command, RepoBee will first look for a file called
-``repobee.ini`` in the current working directory. If such a file is found, it
-completely overrides the global config file. This is useful for managing
-different courses or groups within courses, with different settings.
+When executing a command, RepoBee will first look for a "local" config file
+called ``repobee.ini``. It starts looking for this file in the current working
+directory, and then proceeds searching up the directory tree until it hits the
+root of the file system. If a ``repobee.ini`` file is found, it completely
+overrides the global config file. This is useful for managing different courses
+or groups within courses, with different settings.
 
 The easiest way to create a local config file is to use the ``config wizard``
 command, while explicitly specifying the config file path.

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -52,6 +52,27 @@ class TestConfigShow:
 
         assert config_content in capsys.readouterr().out
 
+    def test_finds_local_config_in_parent_directory(self, capsys, tmp_path):
+        """The config lookup should walk up the directory structure and use the
+        first repobee.ini that's encountered.
+        """
+        # arrange
+        config_content = "[repobee]\nuser = some-unlikely-user"
+        local_config = tmp_path / "repobee.ini"
+        local_config.write_text(config_content, encoding="utf8")
+
+        workdir = tmp_path / "some" / "sub" / "dir"
+        workdir.mkdir(parents=True)
+
+        # act
+        _repobee.main.main(
+            ["repobee", *plug.cli.CoreCommand.config.show.as_name_tuple()],
+            workdir=workdir,
+        )
+
+        # assert
+        assert config_content in capsys.readouterr().out
+
 
 class TestConfigVerify:
     """Tests for the ``config verify`` command."""


### PR DESCRIPTION
Fix #873 

PR introduces config file lookup up the directory tree, as opposed to only looking in the current directory.