### PR TITLE
feat: Add option to install plugins from Git URL

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -118,6 +118,25 @@ Note that a local install may sometimes be dependent on its location in the
 local file system. If you move or delete the local plugin, it may break
 RepoBee's installation of it.
 
+Finally, one can also install plugins directly from a remote Git repository,
+which is primarily intended to allow users to easily install unofficial plugins.
+For example, we can install the ``junit4`` plugin directly from its repository
+like so:
+
+.. code-block:: bash
+    :caption: Example of install of plugin from Git repository
+
+    $ repobee plugin install --git-url https://github.com/repobee/repobee-junit4@v1.0.0
+
+The version specifier (here, ``@v1.0.0``) can be any Git ref (e.g. branch, tag
+or commit sha), **and is optional**. If omitted, RepoBee will install the latest
+version from the default branch of the repository.
+
+.. important::
+
+    For a plugin to be installable directly from a Git repository, the project
+    must follow the packaging conventions detailed in :ref:`packaging_plugins`.
+
 Uninstalling plugins (the ``uninstall`` action)
 ===============================================
 

--- a/src/_repobee/disthelpers.py
+++ b/src/_repobee/disthelpers.py
@@ -149,6 +149,7 @@ def pip(command: str, *args, **kwargs) -> subprocess.CompletedProcess:
         DependencyResolutionError: If the 2020-resolver fails to resolve
             dependencies.
     """
+    cli_args = set(args)
     cli_kwargs = [
         f"--{key.replace('_', '-')}"
         # True is interpreted as a flag
@@ -157,7 +158,7 @@ def pip(command: str, *args, **kwargs) -> subprocess.CompletedProcess:
     ]
     env = dict(os.environ)
     if command == "install":
-        if "pip" not in args:
+        if "pip" not in cli_args:
             # always upgrade pip before running an install to ensure that the
             # 2020-resolver is available
             pip_upgrade_rc = pip("install", "-U", "pip").returncode
@@ -171,7 +172,10 @@ def pip(command: str, *args, **kwargs) -> subprocess.CompletedProcess:
         # RepoBee from source
         cli_kwargs.append("--no-binary=repobee")
 
-    cmd = [str(get_pip_path()), command, *args, *cli_kwargs]
+    # we don't want any prompting
+    cli_args.add("--no-input")
+
+    cmd = [str(get_pip_path()), command, *cli_args, *cli_kwargs]
     proc = subprocess.run(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
     )

--- a/src/_repobee/disthelpers.py
+++ b/src/_repobee/disthelpers.py
@@ -149,7 +149,7 @@ def pip(command: str, *args, **kwargs) -> subprocess.CompletedProcess:
         DependencyResolutionError: If the 2020-resolver fails to resolve
             dependencies.
     """
-    cli_args = set(args)
+    cli_args = list(args)
     cli_kwargs = [
         f"--{key.replace('_', '-')}"
         # True is interpreted as a flag
@@ -172,8 +172,9 @@ def pip(command: str, *args, **kwargs) -> subprocess.CompletedProcess:
         # RepoBee from source
         cli_kwargs.append("--no-binary=repobee")
 
-    # we don't want any prompting
-    cli_args.add("--no-input")
+    if "--no-input" not in cli_args:
+        # we don't want any prompting
+        cli_args.insert(0, "--no-input")
 
     cmd = [str(get_pip_path()), command, *cli_args, *cli_kwargs]
     proc = subprocess.run(

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -25,6 +25,8 @@ PLUGIN = "pluginmanager"
 
 PLUGIN_SPEC_SEP = "@"
 
+PLUGIN_PREFIX = "repobee-"
+
 plugin_category = plug.cli.category(
     name="plugin",
     action_names=["install", "uninstall", "list", "activate"],
@@ -147,11 +149,7 @@ def _install_local_plugin(plugin_path: pathlib.Path, installed_plugins: dict):
     install_info: Dict[str, Any] = dict(version="local", path=str(plugin_path))
 
     if plugin_path.is_dir():
-        if not plugin_path.name.startswith("repobee-"):
-            raise plug.PlugError(
-                "RepoBee plugin package names must be prefixed with "
-                "'repobee-'"
-            )
+        _check_has_plugin_prefix(plugin_path.name)
 
         disthelpers.pip(
             "install",
@@ -160,7 +158,7 @@ def _install_local_plugin(plugin_path: pathlib.Path, installed_plugins: dict):
             f"repobee=={__version__}",
             upgrade=True,
         )
-        ident = plugin_path.name[len("repobee-") :]
+        ident = plugin_path.name[len(PLUGIN_PREFIX) :]
     else:
         ident = str(plugin_path)
         install_info["single_file"] = True
@@ -198,15 +196,15 @@ def _install_plugin(name: str, version: str, plugins: dict) -> None:
 def _install_plugin_from_git_repo(
     repo_url: str, installed_plugins: dict
 ) -> None:
+    url, *version = repo_url.split(PLUGIN_SPEC_SEP)
+    plugin_name = _parse_plugin_name_from_git_url(url)
+
     install_url = f"git+{repo_url}"
     install_proc = _install_plugin_from_url_nocheck(install_url)
     if install_proc.returncode != 0:
         raise plug.PlugError(f"could not install plugin from {repo_url}")
 
-    url, *version = repo_url.split(PLUGIN_SPEC_SEP)
-
     install_info = dict(name=url, version=repo_url)
-    plugin_name = _parse_plugin_name_from_git_url(url)
     installed_plugins[plugin_name] = install_info
     disthelpers.write_installed_plugins(installed_plugins)
     plug.echo(f"Installed {plugin_name} from {repo_url}")
@@ -214,7 +212,17 @@ def _install_plugin_from_git_repo(
 
 def _parse_plugin_name_from_git_url(url: str) -> str:
     stripped_url = url[:-4] if url.endswith(".git") else url
-    return pathlib.Path(stripped_url).name[len("repobee-") :]
+    repo_name = pathlib.Path(stripped_url).name
+    _check_has_plugin_prefix(repo_name)
+    return pathlib.Path(stripped_url).name[len(PLUGIN_PREFIX) :]
+
+
+def _check_has_plugin_prefix(s: str) -> None:
+    if not s.startswith(PLUGIN_PREFIX):
+        raise plug.PlugError(
+            "RepoBee plugin package names must be prefixed with "
+            f"'{PLUGIN_PREFIX}'"
+        )
 
 
 def _install_plugin_from_url_nocheck(
@@ -298,7 +306,9 @@ def _uninstall_plugin(plugin_name: str, installed_plugins: dict):
 
 def _pip_uninstall_plugin(plugin_name: str) -> None:
     uninstalled = (
-        disthelpers.pip("uninstall", "-y", f"repobee-{plugin_name}").returncode
+        disthelpers.pip(
+            "uninstall", "-y", f"{PLUGIN_PREFIX}{plugin_name}"
+        ).returncode
         == 0
     )
     if not uninstalled:

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -205,12 +205,16 @@ def _install_plugin_from_git_repo(
 
     url, *version = repo_url.split(PLUGIN_SPEC_SEP)
 
-    install_info = dict(
-        name=url, version="remote" if not version else f"remote@{version[0]}"
-    )
-    installed_plugins[url] = install_info
+    install_info = dict(name=url, version=repo_url)
+    plugin_name = _parse_plugin_name_from_git_url(url)
+    installed_plugins[plugin_name] = install_info
     disthelpers.write_installed_plugins(installed_plugins)
-    plug.echo(f"Installed {repo_url}")
+    plug.echo(f"Installed {plugin_name} from {repo_url}")
+
+
+def _parse_plugin_name_from_git_url(url: str) -> str:
+    stripped_url = url[:-4] if url.endswith(".git") else url
+    return pathlib.Path(stripped_url).name[len("repobee-") :]
 
 
 def _install_plugin_from_url_nocheck(

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -83,7 +83,9 @@ class InstallPluginCommand(plug.Plugin, plug.cli.Command):
         ),
         git_url=plug.cli.option(
             help="url to a Git repository to install a plugin from (e.g. "
-            "'https://github.com/repobee/repobee-junit4')"
+            "'https://github.com/repobee/repobee-junit4.git'), optionally "
+            "followed by a version specifier '@<VERSION>' (e.g. "
+            "'https://github.com/repobee/repobee-junit4.git@v1.0.0')"
         ),
     )
 

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -195,7 +195,7 @@ def _install_plugin(name: str, version: str, plugins: dict) -> None:
         raise plug.PlugError(f"could not install {name} {version}")
 
 
-def _install_plugin_from_git_repo(repo_url: str) -> bool:
+def _install_plugin_from_git_repo(repo_url: str) -> None:
     install_url = f"git+{repo_url}"
     install_proc = _install_plugin_from_url_nocheck(install_url)
     if install_proc.returncode != 0:

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -100,8 +100,7 @@ class InstallPluginCommand(plug.Plugin, plug.cli.Command):
 
             _install_local_plugin(abspath, installed_plugins)
         elif self.git_url:
-            pip_git_url = f"git+{self.git_url}"
-            _install_plugin_from_url(pip_git_url)
+            _install_plugin_from_git_repo(self.git_url)
         else:
             plug.echo("Available plugins:")
 
@@ -194,8 +193,11 @@ def _install_plugin(name: str, version: str, plugins: dict) -> None:
         raise plug.PlugError(f"could not install {name} {version}")
 
 
-def _install_plugin_from_url(install_url: str) -> None:
-    _install_plugin_from_url_nocheck(install_url)
+def _install_plugin_from_git_repo(repo_url: str) -> bool:
+    install_url = f"git+{repo_url}"
+    install_proc = _install_plugin_from_url_nocheck(install_url)
+    if install_proc.returncode != 0:
+        raise plug.PlugError(f"could not install plugin from {repo_url}")
 
 
 def _install_plugin_from_url_nocheck(

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -245,6 +245,8 @@ class Hello(plug.Plugin, plug.cli.Command):
 
         repobee.run(f"plugin install --git-url {url}".split())
 
+        install_info = disthelpers.get_installed_plugins()[url]
+        assert install_info["version"] == "remote"
         assert get_pkg_version("repobee-junit4")
 
     def test_install_specific_plugin_from_remote_git_repository(self,):
@@ -253,6 +255,8 @@ class Hello(plug.Plugin, plug.cli.Command):
 
         repobee.run(f"plugin install --git-url {url}@{version}".split())
 
+        install_info = disthelpers.get_installed_plugins()[url]
+        assert install_info["version"] == f"remote@{version}"
         assert get_pkg_version("repobee-junit4") == version.lstrip("v")
 
     def test_raises_on_non_existing_git_url(self):

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -247,6 +247,14 @@ class Hello(plug.Plugin, plug.cli.Command):
 
         assert get_pkg_version("repobee-junit4")
 
+    def test_raises_on_non_existing_git_url(self):
+        url = "https://repobee.org/no/repo/here.git"
+
+        with pytest.raises(plug.PlugError) as exc_info:
+            repobee.run(f"plugin install --git-url {url}".split())
+
+        assert f"could not install plugin from {url}" in str(exc_info.value)
+
 
 class TestPluginUninstall:
     """Tests for the ``plugin uninstall`` command."""

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -240,6 +240,13 @@ class Hello(plug.Plugin, plug.cli.Command):
             old_pip_version
         )
 
+    def test_install_junit4_plugin_from_remote_git_repository(self):
+        url = "https://github.com/repobee/repobee-junit4.git"
+
+        repobee.run(f"plugin install --git-url {url}".split())
+
+        assert get_pkg_version("repobee-junit4")
+
 
 class TestPluginUninstall:
     """Tests for the ``plugin uninstall`` command."""

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -247,6 +247,14 @@ class Hello(plug.Plugin, plug.cli.Command):
 
         assert get_pkg_version("repobee-junit4")
 
+    def test_install_specific_plugin_from_remote_git_repository(self,):
+        url = "https://github.com/repobee/repobee-junit4.git"
+        version = "v1.0.0"
+
+        repobee.run(f"plugin install --git-url {url}@{version}".split())
+
+        assert get_pkg_version("repobee-junit4") == version.lstrip("v")
+
     def test_raises_on_non_existing_git_url(self):
         url = "https://repobee.org/no/repo/here.git"
 

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -249,7 +249,7 @@ class Hello(plug.Plugin, plug.cli.Command):
         assert install_info["version"] == url
         assert get_pkg_version("repobee-junit4")
 
-    def test_install_specific_version_from_remote_git_repository(self,):
+    def test_install_specific_version_from_remote_git_repository(self):
         url = "https://github.com/repobee/repobee-junit4.git"
         version = "v1.0.0"
 
@@ -259,8 +259,21 @@ class Hello(plug.Plugin, plug.cli.Command):
         assert install_info["version"] == f"{url}@{version}"
         assert get_pkg_version("repobee-junit4") == version.lstrip("v")
 
+    def test_raises_on_incorrectly_named_remote_git_repo(self):
+        """If a remote Git repo is not named "repobee-<PLUGIN_NAME>", it should
+        not be possible to install.
+        """
+        url = "https://github.com/slarse/slarse.git"
+
+        with pytest.raises(plug.PlugError) as exc_info:
+            repobee.run(f"plugin install --git-url {url}".split())
+
+        assert (
+            "RepoBee plugin package names must be prefixed with 'repobee-'"
+        ) in str(exc_info.value)
+
     def test_raises_on_non_existing_git_url(self):
-        url = "https://repobee.org/no/repo/here.git"
+        url = "https://repobee.org/no/repo/repobee-here.git"
 
         with pytest.raises(plug.PlugError) as exc_info:
             repobee.run(f"plugin install --git-url {url}".split())

--- a/tests/new_integration_tests/test_dist.py
+++ b/tests/new_integration_tests/test_dist.py
@@ -245,18 +245,18 @@ class Hello(plug.Plugin, plug.cli.Command):
 
         repobee.run(f"plugin install --git-url {url}".split())
 
-        install_info = disthelpers.get_installed_plugins()[url]
-        assert install_info["version"] == "remote"
+        install_info = disthelpers.get_installed_plugins()["junit4"]
+        assert install_info["version"] == url
         assert get_pkg_version("repobee-junit4")
 
-    def test_install_specific_plugin_from_remote_git_repository(self,):
+    def test_install_specific_version_from_remote_git_repository(self,):
         url = "https://github.com/repobee/repobee-junit4.git"
         version = "v1.0.0"
 
         repobee.run(f"plugin install --git-url {url}@{version}".split())
 
-        install_info = disthelpers.get_installed_plugins()[url]
-        assert install_info["version"] == f"remote@{version}"
+        install_info = disthelpers.get_installed_plugins()["junit4"]
+        assert install_info["version"] == f"{url}@{version}"
         assert get_pkg_version("repobee-junit4") == version.lstrip("v")
 
     def test_raises_on_non_existing_git_url(self):


### PR DESCRIPTION
Fix #865 

This PR makes it possible to install a plugin from a remote Git repository. Usage like so:

```
# install latest version from default branch
$ repobee plugin install --git-url https://github.com/repobee/repobee-junit4.git
# install specific version
$ repobee plugin install --git-url https://github.com/repobee/repobee-junit4.git@v1.0.0
```

The version specifier (here, `v1.0.0`) can be any Git ref.