### PR TITLE
[fix] Print actual config file path in wizard

### DIFF
--- a/src/_repobee/ext/defaults/configwizard.py
+++ b/src/_repobee/ext/defaults/configwizard.py
@@ -23,7 +23,7 @@ class Wizard(plug.Plugin, plug.cli.Command):
         category=plug.cli.CoreCommand.config,
         help="Interactive configuration wizard to set up the config file.",
         description=(
-            "A configuration wizard that sets up the configuration file."
+            "A configuration wizard that sets up the configuration file. "
             "Warns if there already is a configuration file, as it will be "
             "overwritten."
         ),
@@ -41,12 +41,8 @@ class Wizard(plug.Plugin, plug.cli.Command):
 
 def callback(args: argparse.Namespace, config: plug.Config) -> None:
     """Run through a configuration wizard."""
-    if constants.DEFAULT_CONFIG_FILE.exists():
-        plug.echo(
-            "Editing config file at {}".format(
-                str(constants.DEFAULT_CONFIG_FILE)
-            )
-        )
+    if config.path.exists():
+        plug.echo("Editing config file at {}".format(str(config.path)))
 
     if constants.CORE_SECTION_HDR not in config:
         config.create_section(constants.CORE_SECTION_HDR)

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -120,6 +120,31 @@ class TestConfigWizard:
             == unlikely_value
         )
 
+    def test_start_message_respects_config_file_argument(
+        self, platform_url, tmp_path, capsys
+    ):
+        # arrange
+        config_file = tmp_path / "repobee.ini"
+
+        config_file.write_text("[repobee]\n")
+
+        # act
+        with mock.patch(
+            "bullet.Bullet.launch",
+            autospec=True,
+            return_value=_repobee.constants.CORE_SECTION_HDR,
+        ), mock.patch("builtins.input", return_value="dontcare"):
+            _repobee.main.main(
+                shlex.split(
+                    f"repobee --config-file {config_file} config wizard"
+                )
+            )
+
+        # assert
+        assert capsys.readouterr().out.startswith(
+            f"Editing config file at {config_file}\n"
+        )
+
     def test_end_message_respects_config_file_argument(
         self, platform_url, tmp_path, capsys
     ):
@@ -139,7 +164,6 @@ class TestConfigWizard:
             )
 
         # assert
-        assert (
-            f"Configuration file written to {config_file}"
-            in capsys.readouterr().out
+        assert capsys.readouterr().out.endswith(
+            f"Configuration file written to {config_file}\n"
         )

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -164,6 +164,7 @@ class TestConfigWizard:
             )
 
         # assert
-        assert capsys.readouterr().out.endswith(
-            f"Configuration file written to {config_file}\n"
+        assert (
+            f"Configuration file written to {config_file}"
+            in capsys.readouterr().out
         )


### PR DESCRIPTION
Closes #870

This fixes the output for `repobee config wizard` so that it will use the actual config file path in the initial print of the file that will be overwritten, instead of the constant value.