### PR TITLE
[fact] Rewrite str.format to f-strings in config module

### DIFF
--- a/src/_repobee/config.py
+++ b/src/_repobee/config.py
@@ -50,10 +50,8 @@ def check_defaults(
         configured - constants.CONFIGURABLE_ARGS
     ):  # there are surpluss arguments
         raise exception.FileError(
-            "config file at {} contains invalid default keys: {}".format(
-                config_file,
-                ", ".join(configured - constants.CONFIGURABLE_ARGS),
-            )
+            f"config file at {config_file} contains invalid default keys: "
+            f"{', '.join(configured - constants.CONFIGURABLE_ARGS)}"
         )
 
 
@@ -91,12 +89,12 @@ def check_config_integrity(config_file: Union[str, pathlib.Path]) -> None:
         defaults = _read_defaults(config_file)
     except configparser.ParsingError as exc:
         errors = ", ".join(
-            "(line {}: {})".format(line_nr, line)
-            for line_nr, line in exc.errors
+            f"(line {line_nr}: {line})" for line_nr, line in exc.errors
         )
         raise exception.FileError(
-            msg="config file at {} contains syntax errors: {}".format(
-                config_file, errors
+            msg=(
+                f"config file at {config_file} contains syntax errors: "
+                f"{errors}"
             )
         )
     check_defaults(defaults, config_file)
@@ -126,8 +124,8 @@ def _read_config(config_file: pathlib.Path) -> configparser.ConfigParser:
 
     if constants.CORE_SECTION_HDR not in config_parser:
         raise exception.FileError(
-            "config file at '{!s}' does not contain the required "
-            "[repobee] header".format(config_file)
+            f"config file at '{str(config_file)}' does not contain the "
+            f"required [repobee] header"
         )
 
     return config_parser

--- a/tests/unit_tests/repobee/test_config.py
+++ b/tests/unit_tests/repobee/test_config.py
@@ -60,13 +60,13 @@ class TestGetConfiguredDefaults:
         invalid_key = "not_valid_key"
         config_contents = os.linesep.join(
             [
-                "[{}]".format(_repobee.constants.CORE_SECTION_HDR),
-                "base_url = {}".format(BASE_URL),
-                "user = {}".format(USER),
-                "org_name = {}".format(ORG_NAME),
-                "template_org_name = {}".format(TEMPLATE_ORG_NAME),
-                "students_file = {!s}".format(students_file),
-                "{} = whatever".format(invalid_key),
+                f"[{_repobee.constants.CORE_SECTION_HDR}]"
+                f"base_url = {BASE_URL}",
+                f"user = {USER}",
+                f"org_name = {ORG_NAME}",
+                f"template_org_name = {TEMPLATE_ORG_NAME}",
+                f"students_file = {str(students_file)}",
+                f"{invalid_key} = whatever",
             ]
         )
         empty_config_mock.write(config_contents)
@@ -74,8 +74,8 @@ class TestGetConfiguredDefaults:
         with pytest.raises(exception.FileError) as exc_info:
             config.get_configured_defaults(str(empty_config_mock))
 
-        assert "config file at {} contains invalid default keys".format(
-            empty_config_mock
+        assert (
+            f"config file at {empty_config_mock} contains invalid default keys"
         ) in str(exc_info.value)
         assert str(empty_config_mock) in str(exc_info.value)
         assert invalid_key in str(exc_info.value)
@@ -85,10 +85,10 @@ class TestGetConfiguredDefaults:
     ):
         config_contents = os.linesep.join(
             [
-                "base_url = {}".format(BASE_URL),
-                "user = {}".format(USER),
-                "org_name = {}".format(ORG_NAME),
-                "students_file = {!s}".format(students_file),
+                f"base_url = {BASE_URL}",
+                f"user = {USER}",
+                f"org_name = {ORG_NAME}",
+                f"students_file = {str(students_file)}",
             ]
         )
         empty_config_mock.write(config_contents)
@@ -141,7 +141,7 @@ class TestCheckConfigIntegrity:
         empty_config_mock.write(
             os.linesep.join(
                 [
-                    "[{}]".format(_repobee.constants.CORE_SECTION_HDR),
+                    f"[{_repobee.constants.CORE_SECTION_HDR}]",
                     "user = someone",
                     "option = value",
                 ]
@@ -150,8 +150,8 @@ class TestCheckConfigIntegrity:
         with pytest.raises(exception.FileError) as exc_info:
             config.check_config_integrity(str(empty_config_mock))
 
-        assert "config file at {} contains invalid default keys".format(
-            empty_config_mock
+        assert (
+            f"config file at {empty_config_mock} contains invalid default keys"
         ) in str(exc_info.value)
         assert "option" in str(exc_info.value)
         assert "user" not in str(exc_info.value)
@@ -162,7 +162,7 @@ class TestCheckConfigIntegrity:
         empty_config_mock.write(
             os.linesep.join(
                 [
-                    "[{}]".format(_repobee.constants.CORE_SECTION_HDR),
+                    f"[{_repobee.constants.CORE_SECTION_HDR}]",
                     "user = someone",
                     "base_url",
                     "org_name = cool",


### PR DESCRIPTION
#460

Rewrites all instances of `str.format` in the config module (and its unit test file) to use f-strings instead.
