### PR TITLE
[test] improve config wizard test assert

### DIFF
--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -164,7 +164,6 @@ class TestConfigWizard:
             )
 
         # assert
-        assert (
-            f"Configuration file written to {config_file}"
-            in capsys.readouterr().out
+        assert capsys.readouterr().out.endswith(
+            f"Configuration file written to {config_file}\n"
         )


### PR DESCRIPTION
Per comment in #883, splitting this test change into its own PR. This change narrows the assert so that the string has to appear at the end of the output, rather than anywhere within the input.