### PR TITLE
[misc] Trigger GitLab system tests with label on PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
 
   gitlab-system-tests:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'create' }}
+    if: ${{ github.event_name == 'create' || contains(github.event.head_commit.message, '[gitlab-system-tests]') }}
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
 
   gitlab-system-tests:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'create' || (github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[gitlab-system-tests]')) }}
+    if: ${{ github.event_name == 'create' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'gitlab')) }}
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
 
   gitlab-system-tests:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'create' || contains(github.event.head_commit.message, '[gitlab-system-tests]') }}
+    if: ${{ github.event_name == 'create' || (github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[gitlab-system-tests]')) }}
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Fix #892 

This PR makes it possible to run GitLab system tests on pull requests by adding the `gitlab` label to the PR (and then e.g. close and reopen, or push anything). This makes it easy for a maintainer to trigger the system tests, but avoids abuse from others as you need issue triage rights to set labels.