### PR TITLE
[fix](gitlab) Disable student group branch protection

### DIFF
--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -4,6 +4,7 @@ This plugin allows RepoBee to be used with GitLab. If you want to use RepoBee
 with GitLab, then you should first activate this plugin persistently. See
 :ref:`activate_plugins` for details on how to do that.
 """
+import enum
 import os
 import collections
 import contextlib
@@ -23,7 +24,6 @@ PLUGIN_DESCRIPTION = "Makes RepoBee compatible with GitLab"
 
 ISSUE_GENERATOR = Generator[plug.Issue, None, None]
 
-
 # see https://docs.gitlab.com/ee/api/issues.html for mapping details
 _ISSUE_STATE_MAPPING = {
     plug.IssueState.OPEN: "opened",
@@ -38,6 +38,16 @@ _TEAM_PERMISSION_MAPPING = {
     plug.TeamPermission.PULL: gitlab.REPORTER_ACCESS,
     plug.TeamPermission.PUSH: gitlab.DEVELOPER_ACCESS,
 }
+
+
+class DefaultBranchProtection(enum.Enum):
+    """Default branch protection values, see
+    https://docs.gitlab.com/ee/api/groups.html#options-for-default_branch_protection
+    """
+
+    NONE = 0
+    PARTIAL = 1
+    FULL = 2
 
 
 @contextlib.contextmanager
@@ -116,7 +126,12 @@ class GitLabAPI(plug.PlatformAPI):
         with _try_api_request():
             team = self._wrap_group(
                 self._gitlab.groups.create(
-                    {"name": name, "path": name, "parent_id": self._group.id}
+                    {
+                        "name": name,
+                        "path": name,
+                        "parent_id": self._group.id,
+                        "default_branch_protection": DefaultBranchProtection.NONE.value,  # noqa: E501
+                    }
                 )
             )
 

--- a/system_tests/gitlab/_helpers/const.py
+++ b/system_tests/gitlab/_helpers/const.py
@@ -10,6 +10,7 @@ VOLUME_DST = "/workdir"
 COVERAGE_VOLUME_DST = "/coverage"
 DIR = pathlib.Path(__file__).resolve().parent
 TOKEN = (DIR.parent / "token").read_text(encoding="utf-8").strip()
+ADMIN_TOKEN = "".join(reversed(TOKEN))
 OAUTH_USER = "oauth2"
 BASE_DOMAIN = "gitlab.integrationtest.local"
 BASE_URL = "https://" + BASE_DOMAIN

--- a/system_tests/gitlab/gitlabmanager.py
+++ b/system_tests/gitlab/gitlabmanager.py
@@ -15,6 +15,7 @@ from _helpers.const import (
     TEACHER,
     STUDENT_TEAM_NAMES,
     TOKEN,
+    ADMIN_TOKEN,
     TEMPLATE_REPO_PATHS,
 )
 
@@ -67,7 +68,12 @@ def setup():
     if not await_gitlab_started():
         raise OSError("GitLab failed to start")
 
-    setup_users(students=STUDENT_TEAM_NAMES, teacher=TEACHER, token=TOKEN)
+    setup_users(
+        students=STUDENT_TEAM_NAMES,
+        teacher=TEACHER,
+        teacher_token=TOKEN,
+        admin_token=ADMIN_TOKEN,
+    )
 
 
 def teardown():
@@ -105,7 +111,9 @@ def exec_gitlab_rails_cmd(cmd: str) -> subprocess.CompletedProcess:
     )
 
 
-def setup_users(students: List[str], teacher: str, token: str) -> None:
+def setup_users(
+    students: List[str], teacher: str, teacher_token: str, admin_token: str
+) -> None:
     print("Setting up users")
     users = students + [teacher]
     create_users_cmd = (
@@ -128,14 +136,18 @@ teacher_user = User.find_by_username('{teacher}')
 token = teacher_user.personal_access_tokens.create(
     name: 'repobee',
     scopes: [:api, :read_repository, :write_repository])
-token.set_token('{token}')
+token.set_token('{teacher_token}')
 token.save!
 """
-    set_root_password_cmd = """
+    set_root_password_cmd = f"""
 root_user = User.where(id: 1).first
 root_user.password = 'password'
 root_user.password_confirmation = 'password'
 root_user.save!
+token = root_user.personal_access_tokens.create(
+    name: 'repobee',
+    scopes: [:api, :read_repository, :write_repository, :sudo])
+token.set_token('{admin_token}')
 """
     compound_cmd = create_users_cmd + create_token_cmd + set_root_password_cmd
     exec_gitlab_rails_cmd(compound_cmd)

--- a/system_tests/gitlab/gitlabmanager.py
+++ b/system_tests/gitlab/gitlabmanager.py
@@ -148,6 +148,7 @@ token = root_user.personal_access_tokens.create(
     name: 'repobee',
     scopes: [:api, :read_repository, :write_repository, :sudo])
 token.set_token('{admin_token}')
+token.save!
 """
     compound_cmd = create_users_cmd + create_token_cmd + set_root_password_cmd
     exec_gitlab_rails_cmd(compound_cmd)

--- a/system_tests/gitlab/test_gitlab_system.py
+++ b/system_tests/gitlab/test_gitlab_system.py
@@ -259,7 +259,7 @@ class TestSetup:
         gl.auth()
         settings = gl.settings.get()
         settings.default_branch_protection = (
-            2  # this is the default, but we want to make sure it's set
+            _repobee.ext.gitlab.DefaultBranchProtection.FULL.value
         )
         settings.save()
         command = " ".join(

--- a/system_tests/gitlab/test_gitlab_system.py
+++ b/system_tests/gitlab/test_gitlab_system.py
@@ -256,9 +256,9 @@ class TestSetup:
         gl = gitlab.Gitlab(
             url=LOCAL_BASE_URL, private_token=ADMIN_TOKEN, ssl_verify=False
         )
-        print(gl.settings.default_branch_protection)
+        print(gl.settings.attributes)
         settings = gl.settings.get()
-        settings.default_branch_protection = 2
+        settings.attributes["default_branch_protection"] = 2
         settings.save()
         command = " ".join(
             [

--- a/system_tests/gitlab/test_gitlab_system.py
+++ b/system_tests/gitlab/test_gitlab_system.py
@@ -29,9 +29,8 @@ from _helpers.const import (
     VOLUME_DST,
     BASE_DOMAIN,
     LOCAL_DOMAIN,
-    ORG_NAME,
     TEMPLATE_ORG_NAME,
-    TARGET_ORG_NAME,
+    ORG_NAME,
     assignment_names,
     STUDENT_TEAMS,
     STUDENT_TEAM_NAMES,
@@ -279,7 +278,7 @@ class TestSetup:
 
             # assert
             assert result.returncode == 0
-            api = api_instance(TARGET_ORG_NAME)
+            api = api_instance(ORG_NAME)
             loop_ran = False
             for repo in api.get_repos():
                 loop_ran = True

--- a/system_tests/gitlab/test_gitlab_system.py
+++ b/system_tests/gitlab/test_gitlab_system.py
@@ -256,9 +256,11 @@ class TestSetup:
         gl = gitlab.Gitlab(
             url=LOCAL_BASE_URL, private_token=ADMIN_TOKEN, ssl_verify=False
         )
-        print(gl.settings.attributes)
+        gl.auth()
         settings = gl.settings.get()
-        settings.attributes["default_branch_protection"] = 2
+        settings.default_branch_protection = (
+            2  # this is the default, but we want to make sure it's set
+        )
         settings.save()
         command = " ".join(
             [

--- a/system_tests/gitlab/test_gitlab_system.py
+++ b/system_tests/gitlab/test_gitlab_system.py
@@ -245,46 +245,44 @@ class TestSetup:
             [plug.StudentTeam(members=[TEACHER])], assignment_names
         )
 
-        def test_setup_with_default_branch_protection_does_not_carry_over(
-            self, extra_args
-        ):
-            """Student repositories created when global default branch
-            protection is enabled on the GitLab instance, should still not have
-            default branch protection.
-            """
-            # arrange
-            gl = gitlab.Gitlab(
-                url=LOCAL_BASE_URL, private_token=ADMIN_TOKEN, ssl_verify=False
-            )
-            print(gl.settings.default_branch_protection)
-            settings = gl.settings.get()
-            settings.default_branch_protection = 2
-            settings.save()
-            command = " ".join(
-                [
-                    REPOBEE_GITLAB,
-                    *repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(),
-                    *BASE_ARGS,
-                    *TEMPLATE_ORG_ARG,
-                    *MASTER_REPOS_ARG,
-                    *STUDENTS_ARG,
-                ]
-            )
+    def test_setup_with_default_branch_protection_does_not_carry_over(
+        self, extra_args
+    ):
+        """Student repositories created when global default branch
+        protection is enabled on the GitLab instance, should still not have
+        default branch protection.
+        """
+        # arrange
+        gl = gitlab.Gitlab(
+            url=LOCAL_BASE_URL, private_token=ADMIN_TOKEN, ssl_verify=False
+        )
+        print(gl.settings.default_branch_protection)
+        settings = gl.settings.get()
+        settings.default_branch_protection = 2
+        settings.save()
+        command = " ".join(
+            [
+                REPOBEE_GITLAB,
+                *repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(),
+                *BASE_ARGS,
+                *TEMPLATE_ORG_ARG,
+                *MASTER_REPOS_ARG,
+                *STUDENTS_ARG,
+            ]
+        )
 
-            # act
-            result = run_in_docker_with_coverage(
-                command, extra_args=extra_args
-            )
+        # act
+        result = run_in_docker_with_coverage(command, extra_args=extra_args)
 
-            # assert
-            assert result.returncode == 0
-            api = api_instance(ORG_NAME)
-            loop_ran = False
-            for repo in api.get_repos():
-                loop_ran = True
-                assert not repo.implementation.protectedbranches.list()
+        # assert
+        assert result.returncode == 0
+        api = api_instance(ORG_NAME)
+        loop_ran = False
+        for repo in api.get_repos():
+            loop_ran = True
+            assert not repo.implementation.protectedbranches.list()
 
-            assert loop_ran, "assertion loop did not execute"
+        assert loop_ran, "assertion loop did not execute"
 
 
 @pytest.mark.filterwarnings("ignore:.*Unverified HTTPS request.*")


### PR DESCRIPTION
Fix #896 

The whole issue is thoroughly detailed in #896. This PR fixes the problem by unconditionally setting branch protection to none (0) for groups created with the GitLabAPI class.