### PR TITLE
[docs] add workflow scope if using GitHub Actions

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -134,9 +134,10 @@ Editing the global configuration file (the ``wizard`` and ``show`` actions)
 For RepoBee to work at all, it needs to be provided with an access token to
 whichever platform instance you intend to use. See the `GitHub access token
 docs`_ for how to create a token. The token should have the ``repo`` and
-``admin:org`` scopes. You can either set this token in the ``REPOBEE_TOKEN``
-environment variable with whatever method you deem appropriate, or you can put
-it in the configuration file as described next.
+``admin:org`` scopes. If you will be using GitHub Actions, the token should have
+the ``workflow`` scope as well. You can either set this token in the
+``REPOBEE_TOKEN`` environment variable with whatever method you deem
+appropriate, or you can put it in the configuration file as described next.
 
 .. note::
 


### PR DESCRIPTION
I found this the hard way, and thought it might be useful to save others the effort. If one is using GitHub Actions, such as for autotesting, it doesn't get enabled in the student repos unless the `workflow` scope is enabled.