### PR TITLE
[fix] Automatically lowercase all usernames

### DIFF
--- a/src/repobee_plug/localreps.py
+++ b/src/repobee_plug/localreps.py
@@ -38,7 +38,7 @@ class StudentTeam:
         return self.name
 
     def __post_init__(self):
-        object.__setattr__(self, "memebers", list(self.members))
+        object.__setattr__(self, "members", [m.lower() for m in self.members])
         object.__setattr__(
             self, "name", self.name or "-".join(sorted(self.members))
         )

--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -62,6 +62,9 @@ class Team(APIObject):
     id: Any = dataclasses.field(compare=False)
     implementation: Any = dataclasses.field(compare=False, repr=False)
 
+    def __post_init__(self):
+        object.__setattr__(self, "members", [m.lower() for m in self.members])
+
     def __str__(self):
         return self.name
 

--- a/system_tests/gitlab/test_gitlab_system.py
+++ b/system_tests/gitlab/test_gitlab_system.py
@@ -287,6 +287,38 @@ class TestSetup:
             [plug.StudentTeam(members=[student])], assignment_names
         )
 
+    def test_setup_with_wrong_case_on_student(self, extra_args):
+        """User names are case insensitive on GitLab, and so setup should work
+        fine even if the case of some character in a student's username is
+        "incorrect".
+
+        See https://github.com/repobee/repobee/issues/900
+        """
+        student = STUDENT_TEAMS[0].members[0]
+        student_wrong_case = student.upper()
+        assert (
+            student != student_wrong_case
+        ), "cases match, test is pointless :("
+
+        command = " ".join(
+            [
+                REPOBEE_GITLAB,
+                *repobee_plug.cli.CoreCommand.repos.setup.as_name_tuple(),
+                *BASE_ARGS,
+                *TEMPLATE_ORG_ARG,
+                *MASTER_REPOS_ARG,
+                "--students",
+                student_wrong_case,
+            ]
+        )
+
+        result = run_in_docker_with_coverage(command, extra_args=extra_args)
+
+        assert result.returncode == 0
+        assert_repos_exist(
+            [plug.StudentTeam(members=student)], assignment_names
+        )
+
 
 @pytest.mark.filterwarnings("ignore:.*Unverified HTTPS request.*")
 class TestUpdate:

--- a/system_tests/gitlab/test_gitlab_system.py
+++ b/system_tests/gitlab/test_gitlab_system.py
@@ -316,7 +316,7 @@ class TestSetup:
 
         assert result.returncode == 0
         assert_repos_exist(
-            [plug.StudentTeam(members=student)], assignment_names
+            [plug.StudentTeam(members=[student])], assignment_names
         )
 
 

--- a/tests/unit_tests/repobee_plug/test_localreps.py
+++ b/tests/unit_tests/repobee_plug/test_localreps.py
@@ -1,0 +1,13 @@
+"""Tests of the localreps classes and functions."""
+
+import repobee_plug as plug
+
+
+class TestStudentTeam:
+    """Tests for the StudentTeam class."""
+
+    def test_constructor_lowercases_member_names(self):
+        members = ["siMON", "alIce", "EVE"]
+        members_lowercase = ["simon", "alice", "eve"]
+        team = plug.StudentTeam(members=members)
+        assert team.members == members_lowercase

--- a/tests/unit_tests/repobee_plug/test_platform.py
+++ b/tests/unit_tests/repobee_plug/test_platform.py
@@ -156,3 +156,22 @@ class TestIssue:
         reconstructed = platform.Issue.from_dict(asdict)
 
         assert reconstructed == issue
+
+
+class TestTeam:
+    """Tests for the Team class."""
+
+    def test_lowercases_usernames(self):
+        """While all of the platforms currently supported are case insensitive,
+        some still allow usernames to contain e.g. capital letters. We don't
+        want this to appear in RepoBee, as it can case problems such as those
+        reported in https://github.com/repobee/repobee/issues/900.
+        """
+        usernames = ["siMon", "ALICE", "eVe"]
+        lowercase_usernames = ["simon", "alice", "eve"]
+
+        team = platform.Team(
+            members=usernames, name="yep", id=1, implementation="fake"
+        )
+
+        assert team.members == lowercase_usernames


### PR DESCRIPTION
Fix #900 

This PR fixes a problem where student usernames were treated case sensitively, while all of the supported platforms are case insensitive. The fix is simply that `StudentTeam` and `Team` both automatically lowercase the names of all members.

* `StudentTeam` lowercasing names ensures that user input is lowercase (as all student usernames provided by the user are wrapped in this class)
* `Team` ensures that usernames fetched from the platform are lowercase

This however does not guard against plugins using the `PlatformAPI` directly, and additional work is needed to safeguard there. But that can wait for another time.