### PR TITLE
[feat] Add PlatformAPI.for_organization and implementations

### DIFF
--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -162,6 +162,10 @@ class GitHubAPI(plug.PlatformAPI):
     def token(self):
         return self._token
 
+    def for_organization(self, org_name: str) -> "GitHubAPI":
+        """See :py:meth:`repobee_plug.PlatformAPI.for_organization`."""
+        return GitHubAPI(self._base_url, self._token, org_name, self._user)
+
     def create_team(
         self,
         name: str,

--- a/src/_repobee/ext/gitea.py
+++ b/src/_repobee/ext/gitea.py
@@ -101,6 +101,15 @@ class GiteaAPI(plug.PlatformAPI):
         ssl_verify = not os.getenv("REPOBEE_NO_VERIFY_SSL") == "true"
         return ssl_verify
 
+    def for_organization(self, org_name: str) -> "GiteaAPI":
+        """See :py:meth:`repobee_plug.PlatformAPI.for_organization`."""
+        return GiteaAPI(
+            base_url=self._base_url,
+            token=self._token,
+            org_name=org_name,
+            user=self._user,
+        )
+
     def create_team(
         self,
         name: str,

--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -116,10 +116,6 @@ class GitLabAPI(plug.PlatformAPI):
             self._actual_user = self._gitlab.user.username
             self._group = self._get_group(self._group_name, self._gitlab)
 
-    @property
-    def group(self):
-        return self._group
-
     def for_organization(self, org_name: str) -> "GitLabAPI":
         """See :py:meth:`repobee_plug.PlatformAPI.for_organization`."""
         return GitLabAPI(self._base_url, self._token, org_name)

--- a/src/_repobee/ext/gitlab.py
+++ b/src/_repobee/ext/gitlab.py
@@ -116,6 +116,14 @@ class GitLabAPI(plug.PlatformAPI):
             self._actual_user = self._gitlab.user.username
             self._group = self._get_group(self._group_name, self._gitlab)
 
+    @property
+    def group(self):
+        return self._group
+
+    def for_organization(self, org_name: str) -> "GitLabAPI":
+        """See :py:meth:`repobee_plug.PlatformAPI.for_organization`."""
+        return GitLabAPI(self._base_url, self._token, org_name)
+
     def create_team(
         self,
         name: str,

--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -405,6 +405,18 @@ class _APISpec:
         """
         _not_implemented()
 
+    def for_organization(self, org_name: str) -> "PlatformAPI":
+        """Create a copy of this API instance, targeting the given
+        organization.
+
+        Args:
+            org_name: Name of the organization to target.
+        Returns:
+            A copy of the receiver API, but targeting the provided
+            organization.
+        """
+        _not_implemented()
+
     @staticmethod
     def verify_settings(
         user: str,

--- a/system_tests/gitea/test_gitea.py
+++ b/system_tests/gitea/test_gitea.py
@@ -473,3 +473,13 @@ class TestVerifySettings:
         assert f"could not find organization '{non_existant_org}'" in str(
             exc_info.value
         )
+
+
+class TestForOrganization:
+    """Tests for the for_organization function."""
+
+    def test_correctly_sets_provided_group(self, target_api):
+        """Test that the provided group is respected."""
+        new_api = target_api.for_organization(giteamanager.TEMPLATE_ORG_NAME)
+
+        assert new_api._org_name == giteamanager.TEMPLATE_ORG_NAME

--- a/tests/unit_tests/repobee/plugin_tests/test_github.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_github.py
@@ -597,8 +597,11 @@ class TestForOrganization:
     def test_correctly_sets_provided_org(self, happy_github, api):
         """Test that the provided organization is respected."""
         new_org_name = "some-other-org"
+        assert (
+            api._org_name != new_org_name
+        ), "test makes no sense if the new org name matches the existing one"
         mock_org = create_mock_organization(happy_github, new_org_name, [])
-        assert api.org != new_org_name
+
         new_api = api.for_organization(new_org_name)
 
         assert new_api.org is mock_org

--- a/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
@@ -597,3 +597,22 @@ class TestVerifySettings:
         )
 
         log_mock.assert_called_with("GREAT SUCCESS: All settings check out!")
+
+
+class TestForOrganization:
+    """Tests for the for_organization function."""
+
+    def test_correctly_sets_provided_group(self, api, mocker):
+        """Test that the provided group is respected."""
+        new_group_name = "some-other-group"
+        gl = GitLabMock(BASE_URL, TOKEN, False)
+        new_group = gl.groups.create(
+            dict(name=new_group_name, path=new_group_name)
+        )
+        mocker.patch(
+            "_repobee.ext.gitlab.gitlab.Gitlab",
+            side_effect=lambda base_url, private_token, ssl_verify: gl,
+        )
+
+        new_api = api.for_organization(new_group_name)
+        assert new_api.group == new_group

--- a/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_gitlab.py
@@ -615,4 +615,4 @@ class TestForOrganization:
         )
 
         new_api = api.for_organization(new_group_name)
-        assert new_api.group == new_group
+        assert new_api._group == new_group


### PR DESCRIPTION
Fix #882 

This PR adds the `for_organization(org_name: str) -> PlatformAPI` function to the platform API specification. It returns a copy of the API it's called on, but targeting the provided organization instead. The PR also adds implementations for all three API implementations (GitLab, Gitea, GitHub).