### PR TITLE
[docs] Require Sphinx version 3.1.1 to 3.5.4

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-sphinx>=3.1.1
+sphinx>=3.1.1,<=3.5.4
 sphinx-autodoc-typehints
 sphinx_rtd_theme
 sphinx-argparse

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ test_requirements = [
     "virtualenv",
 ]
 docs_requirements = [
-    "sphinx>=1.8.2",
+    "sphinx>=3.1.1,<=3.5.4",
     "sphinx-autodoc-typehints",
     "sphinx_rtd_theme",
     "sphinx-argparse",


### PR DESCRIPTION
#906 

Due to problems with Sphinx 4.0.0, we use 3.5.4 for the time being.