### PR TITLE
[misc] Set Sphinx version number >=4.0.1

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,4 +1,4 @@
-sphinx>=3.1.1,<=3.5.4
+sphinx>=4.0.1
 sphinx-autodoc-typehints
 sphinx_rtd_theme
 sphinx-argparse

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ test_requirements = [
     "virtualenv",
 ]
 docs_requirements = [
-    "sphinx>=3.1.1,<=3.5.4",
+    "sphinx>=4.0.1",
     "sphinx-autodoc-typehints",
     "sphinx_rtd_theme",
     "sphinx-argparse",


### PR DESCRIPTION
Fix #906 

The bug causing doc build failures was swiftly fixed by the Sphinx maintainer.