### PR TITLE
[docs] Add demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ with repositories managed by GitHub Classroom, or running JUnit4 test classes
 on cloned student repositories.
 
 ### Feature highlights
-
 RepoBee has a lot going for it. Here are some of the things we are most proud
 of:
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-https://user-images.githubusercontent.com/14223379/121573132-2d725380-ca25-11eb-8aa0-8f50ac3f28f0.mp4
-
-> Short video demonstration of using RepoBee and writing a simple plugin. [For a higher-quality version of this demo, click this link!](https://repobee.org/media/repobee-demo.mp4)
-
 ## Overview
 RepoBee is a command line tool that allows teachers and teaching assistants to
 work with large amounts of student Git repositories on the GitHub, GitLab and
@@ -37,6 +33,15 @@ Plugins can do a wide range of things, including making RepoBee compatible with
 multiple hosting platforms (GitHub, GitLab, Gitea), providing compatibility
 with repositories managed by GitHub Classroom, or running JUnit4 test classes
 on cloned student repositories.
+
+Still not quite sure what RepoBee actually does? The demo video below briefly
+explains some of the most important concepts, and showcases how RepoBee can be
+used to setup and clone student repositories, as well as how to write a simple
+plugin.
+
+https://user-images.githubusercontent.com/14223379/121573132-2d725380-ca25-11eb-8aa0-8f50ac3f28f0.mp4
+
+> Short video demonstration of using RepoBee and writing a simple plugin. [For a higher-quality version of this demo, click this link!](https://repobee.org/media/repobee-demo.mp4)
 
 ### Feature highlights
 RepoBee has a lot going for it. Here are some of the things we are most proud

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
-
 https://user-images.githubusercontent.com/14223379/121573132-2d725380-ca25-11eb-8aa0-8f50ac3f28f0.mp4
 
 > Short video demonstration of using RepoBee and writing a simple plugin. [For a higher-quality version of this demo, click this link!](https://repobee.org/media/repobee-demo.mp4)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
+
+https://user-images.githubusercontent.com/14223379/121573132-2d725380-ca25-11eb-8aa0-8f50ac3f28f0.mp4
+
+> Short video demonstration of using RepoBee and writing a simple plugin. [For a higher-quality version of this demo, click this link!](https://repobee.org/media/repobee-demo.mp4)
+
 ## Overview
 RepoBee is a command line tool that allows teachers and teaching assistants to
 work with large amounts of student Git repositories on the GitHub, GitLab and
@@ -35,8 +40,6 @@ with repositories managed by GitHub Classroom, or running JUnit4 test classes
 on cloned student repositories.
 
 ### Feature highlights
-
-![RepoBee demo video](https://raw.githubusercontent.com/repobee/repobee.github.io/f16067d0b061315cf69f75594caed040a008dbde/content/extra/repobee-demo.mp4)
 
 RepoBee has a lot going for it. Here are some of the things we are most proud
 of:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ with repositories managed by GitHub Classroom, or running JUnit4 test classes
 on cloned student repositories.
 
 ### Feature highlights
+
+![RepoBee demo video](https://raw.githubusercontent.com/repobee/repobee.github.io/f16067d0b061315cf69f75594caed040a008dbde/content/extra/repobee-demo.mp4)
+
 RepoBee has a lot going for it. Here are some of the things we are most proud
 of:
 


### PR DESCRIPTION
Fix #396 

I just discovered that GitHub now supports embedding MP4 videos into READMEs. This PR embeds a RepoBee demo video at the top of the README.

Note that a little hack is used here: I uploaded the video in an issue (#923), which makes it user content. File size is 10 MB, so the quality is pretty poor, but it's something!

@monperrus it only took a year and a half to fulfill your request :). But this is much better than just a GIF.