### PR TITLE
[feat] Resolve parent path relative to config file path

### DIFF
--- a/src/repobee_plug/config.py
+++ b/src/repobee_plug/config.py
@@ -65,9 +65,22 @@ class Config:
         """
         if self._config_path.exists():
             self._config_parser.read(self._config_path)
-            parent_path = self.get(self.CORE_SECTION_NAME, "parent")
-            if parent_path:
-                self._parent = Config(pathlib.Path(parent_path))
+            raw_parent_path = self.get(self.CORE_SECTION_NAME, "parent")
+            if raw_parent_path:
+                parent_path = self._resolve_absolute_parent_path(
+                    raw_parent_path
+                )
+                self._parent = Config(parent_path)
+
+    def _resolve_absolute_parent_path(
+        self, raw_parent_path: str
+    ) -> pathlib.Path:
+        parent_path = pathlib.Path(raw_parent_path)
+        return (
+            parent_path
+            if parent_path.is_absolute()
+            else (self.path.parent / parent_path).resolve(strict=False)
+        )
 
     def store(self) -> None:
         """Write the current state of the config to the config file. If the


### PR DESCRIPTION
Fix #920 

With this PR, relative parent paths are resolved relative to the config file in which they are written. Absolute parent paths are still allowed and are used as-is.