### PR TITLE
[fact] Rename parent config key to "parent_config" and store in constant

### DIFF
--- a/src/_repobee/constants.py
+++ b/src/_repobee/constants.py
@@ -37,7 +37,7 @@ ORDERED_CONFIGURABLE_ARGS = (
     "template_org_name",
     "token",
     "students_file",
-    plug.Config.PARENT_CONFIG_PATH_KEY,
+    plug.Config.PARENT_CONFIG_KEY,
 )
 CONFIGURABLE_ARGS = set(ORDERED_CONFIGURABLE_ARGS)
 

--- a/src/_repobee/constants.py
+++ b/src/_repobee/constants.py
@@ -10,6 +10,8 @@ import pathlib
 
 import appdirs  # type: ignore
 
+import repobee_plug as plug
+
 import _repobee
 
 CONFIG_DIR = pathlib.Path(
@@ -35,7 +37,7 @@ ORDERED_CONFIGURABLE_ARGS = (
     "template_org_name",
     "token",
     "students_file",
-    "parent",
+    plug.Config.PARENT_CONFIG_PATH_KEY,
 )
 CONFIGURABLE_ARGS = set(ORDERED_CONFIGURABLE_ARGS)
 

--- a/src/repobee_plug/config.py
+++ b/src/repobee_plug/config.py
@@ -49,7 +49,7 @@ class Config:
     """
 
     CORE_SECTION_NAME = "repobee"
-    PARENT_CONFIG_PATH_KEY = "parent"
+    PARENT_CONFIG_PATH_KEY = "parent_config"
 
     def __init__(self, config_path: pathlib.Path):
         super().__init__()

--- a/src/repobee_plug/config.py
+++ b/src/repobee_plug/config.py
@@ -49,7 +49,7 @@ class Config:
     """
 
     CORE_SECTION_NAME = "repobee"
-    PARENT_CONFIG_PATH_KEY = "parent_config"
+    PARENT_CONFIG_KEY = "parent_config"
 
     def __init__(self, config_path: pathlib.Path):
         super().__init__()
@@ -67,7 +67,7 @@ class Config:
         if self._config_path.exists():
             self._config_parser.read(self._config_path)
             raw_parent_path = self.get(
-                self.CORE_SECTION_NAME, self.PARENT_CONFIG_PATH_KEY
+                self.CORE_SECTION_NAME, self.PARENT_CONFIG_KEY
             )
             if raw_parent_path:
                 parent_path = self._resolve_absolute_parent_path(
@@ -138,9 +138,7 @@ class Config:
     @parent.setter
     def parent(self, value: "Config") -> None:
         self._parent = value
-        self[self.CORE_SECTION_NAME][self.PARENT_CONFIG_PATH_KEY] = str(
-            value.path
-        )
+        self[self.CORE_SECTION_NAME][self.PARENT_CONFIG_KEY] = str(value.path)
         self._check_for_cycle([])
 
     def __getitem__(self, section_key: str) -> ConfigSection:

--- a/src/repobee_plug/config.py
+++ b/src/repobee_plug/config.py
@@ -49,6 +49,7 @@ class Config:
     """
 
     CORE_SECTION_NAME = "repobee"
+    PARENT_CONFIG_PATH_KEY = "parent"
 
     def __init__(self, config_path: pathlib.Path):
         super().__init__()
@@ -65,7 +66,9 @@ class Config:
         """
         if self._config_path.exists():
             self._config_parser.read(self._config_path)
-            raw_parent_path = self.get(self.CORE_SECTION_NAME, "parent")
+            raw_parent_path = self.get(
+                self.CORE_SECTION_NAME, self.PARENT_CONFIG_PATH_KEY
+            )
             if raw_parent_path:
                 parent_path = self._resolve_absolute_parent_path(
                     raw_parent_path
@@ -135,7 +138,9 @@ class Config:
     @parent.setter
     def parent(self, value: "Config") -> None:
         self._parent = value
-        self[self.CORE_SECTION_NAME]["parent"] = str(value.path)
+        self[self.CORE_SECTION_NAME][self.PARENT_CONFIG_PATH_KEY] = str(
+            value.path
+        )
         self._check_for_cycle([])
 
     def __getitem__(self, section_key: str) -> ConfigSection:

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -234,9 +234,9 @@ class TestConfigInheritance:
         parent_config.store()
 
         child_config = plug.Config(child_config_dir / "config.ini")
-        child_config[plug.Config.CORE_SECTION_NAME]["parent"] = str(
-            pathlib.Path("..") / parent_config.path.relative_to(root_dir)
-        )
+        child_config[plug.Config.CORE_SECTION_NAME][
+            plug.Config.PARENT_CONFIG_PATH_KEY
+        ] = str(pathlib.Path("..") / parent_config.path.relative_to(root_dir))
         child_config.store()
 
         fetched_value = None

--- a/tests/new_integration_tests/test_config_category.py
+++ b/tests/new_integration_tests/test_config_category.py
@@ -235,7 +235,7 @@ class TestConfigInheritance:
 
         child_config = plug.Config(child_config_dir / "config.ini")
         child_config[plug.Config.CORE_SECTION_NAME][
-            plug.Config.PARENT_CONFIG_PATH_KEY
+            plug.Config.PARENT_CONFIG_KEY
         ] = str(pathlib.Path("..") / parent_config.path.relative_to(root_dir))
         child_config.store()
 

--- a/tests/unit_tests/repobee_plug/test_plug_config.py
+++ b/tests/unit_tests/repobee_plug/test_plug_config.py
@@ -2,9 +2,6 @@ import pytest
 from repobee_plug import config
 from repobee_plug import exceptions
 
-CORE_SECTION = "repobee"
-PARENT = "parent"
-
 
 class TestConfig:
     """Tests for the Config class."""


### PR DESCRIPTION
Fix #925 

This PR renames the parent config key from "parent" to "parent_config" to make it more clear what it relates to, and puts the precise name into a constant such that changing it is less of a hassle.