### PR TITLE
[feat] Add `--directory-layout` option to choose layout of cloned repositories

### DIFF
--- a/src/_repobee/cli/dispatch.py
+++ b/src/_repobee/cli/dispatch.py
@@ -89,7 +89,9 @@ def _dispatch_repos_command(
         command.migrate_repos(args.template_repo_urls, api)
         return None
     elif action == repos.clone:
-        return command.clone_repos(args.repos, args.update_local, api)
+        return command.clone_repos(
+            args.repos, args.update_local, args.directory_layout, api
+        )
     _raise_illegal_action_error(args)
 
 

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -13,6 +13,7 @@ import functools
 
 from typing import Union, Callable, Optional, Any
 from _repobee.cli import preparser
+from _repobee.command.repos import DirectoryLayout
 
 import repobee_plug as plug
 
@@ -329,6 +330,15 @@ def _add_repo_parsers(
         help="attempt to update local student repositories, "
         "stashing any unstaged changes (beta feature)",
         action="store_true",
+    )
+    clone.add_argument(
+        "--dl",
+        "--directory-layout",
+        help="how to arrange cloned repositories",
+        choices=list(DirectoryLayout),
+        dest="directory_layout",
+        default=DirectoryLayout.NESTED_BY_TEAM,
+        type=DirectoryLayout,
     )
 
     add_parser(

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -337,7 +337,7 @@ def _add_repo_parsers(
         help="how to arrange cloned repositories",
         choices=list(DirectoryLayout),
         dest="directory_layout",
-        default=DirectoryLayout.NESTED_BY_TEAM,
+        default=DirectoryLayout.BY_TEAM,
         type=DirectoryLayout,
     )
 

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -18,7 +18,17 @@ import re
 import os
 import sys
 import tempfile
-from typing import Iterable, List, Optional, Mapping, Union, Tuple, Any
+import enum
+from typing import (
+    Iterable,
+    List,
+    Optional,
+    Mapping,
+    Union,
+    Tuple,
+    Any,
+    Callable,
+)
 
 import repobee_plug as plug
 
@@ -401,9 +411,18 @@ def _open_issue_by_urls(
         plug.log.info(msg)
 
 
+class DirectoryLayout(enum.Enum):
+    FLAT = "flat"
+    NESTED_BY_TEAM = "by-team"
+
+    def __str__(self):
+        return str(self.value)
+
+
 def clone_repos(
     repos: Iterable[plug.StudentRepo],
     update_local: bool,
+    directory_layout: DirectoryLayout,
     api: plug.PlatformAPI,
 ) -> Mapping[str, List[plug.Result]]:
     """Clone all student repos related to the provided master repos and student
@@ -414,6 +433,8 @@ def clone_repos(
             ``implementation`` attribute, so it does not need to be set.
         update_local: Whether or nut to attempt to update student repos
             that already exist locally.
+        directory_layout: The layout to use for organizing cloned
+            repositories.
         api: An implementation of :py:class:`repobee_plug.PlatformAPI` used to
             interface with the platform (e.g. GitHub or GitLab) instance.
     Returns:
@@ -422,8 +443,9 @@ def clone_repos(
 
     plug.echo("Cloning into student repos ...")
     with tempfile.TemporaryDirectory() as tmpdir:
+        pathed_repos = _with_output_paths(repos, directory_layout)
         local_repos = _clone_repos(
-            repos, pathlib.Path(tmpdir), update_local, api
+            pathed_repos, pathlib.Path(tmpdir), update_local, api
         )
         _set_pull_ff_only(local_repos)
 
@@ -441,17 +463,44 @@ def _set_pull_ff_only(local_repos: List[plug.StudentRepo]) -> None:
         git.set_gitconfig_options(repo.path, {"pull.ff": "only"})
 
 
+def _with_output_paths(
+    repos: Iterable[plug.StudentRepo], directory_layout: DirectoryLayout
+) -> List[plug.StudentRepo]:
+    base_dir = pathlib.Path(".").resolve()
+    repo_path_func = _select_repo_path_function(directory_layout)
+    return [repo.with_path(repo_path_func(base_dir, repo)) for repo in repos]
+
+
+def _select_repo_path_function(
+    layout: DirectoryLayout,
+) -> Callable[[pathlib.Path, plug.StudentRepo], pathlib.Path]:
+    if layout == DirectoryLayout.FLAT:
+        return _flat_repo_path
+    elif layout == DirectoryLayout.NESTED_BY_TEAM:
+        return _nested_team_repo_path
+    else:
+        raise ValueError(f"unknown directory layout: {layout}")
+
+
+def _flat_repo_path(
+    base: pathlib.Path, repo: plug.StudentRepo
+) -> pathlib.Path:
+    return base / repo.name
+
+
+def _nested_team_repo_path(
+    base: pathlib.Path, repo: plug.StudentRepo
+) -> pathlib.Path:
+    return base / repo.team.name / repo.name
+
+
 def _clone_repos(
-    repos: Iterable[plug.StudentRepo],
+    pathed_repos: List[plug.StudentRepo],
     dst_dirpath: pathlib.Path,
     update_local: bool,
     api: plug.PlatformAPI,
 ) -> List[plug.StudentRepo]:
     """Clone the specified repo urls into the destination directory."""
-    cur_dir = pathlib.Path(".").resolve()
-    pathed_repos: List[plug.StudentRepo] = [
-        repo.with_path(cur_dir / repo.team.name / repo.name) for repo in repos
-    ]
     _check_for_non_git_dir_path_clashes(pathed_repos)
 
     cloned_repos = git.clone_student_repos(

--- a/src/_repobee/fileutil.py
+++ b/src/_repobee/fileutil.py
@@ -1,0 +1,40 @@
+"""Utility functions for dealing with files and directories.
+
+.. module:: fileutil
+    :synopsis: Utility functions for dealing with files and directories.
+"""
+import enum
+import pathlib
+
+import repobee_plug as plug
+
+__all__ = ["DirectoryLayout"]
+
+
+def _flat_repo_path(
+    base: pathlib.Path, repo: plug.StudentRepo
+) -> pathlib.Path:
+    return base / repo.name
+
+
+def _by_team_repo_path(
+    base: pathlib.Path, repo: plug.StudentRepo
+) -> pathlib.Path:
+    return base / repo.team.name / repo.name
+
+
+class DirectoryLayout(enum.Enum):
+    """Layouts for arranging repositories on disk."""
+
+    FLAT = "flat"
+    BY_TEAM = "by-team"
+
+    def __init__(self, label: str):
+        self.label = label
+        self.get_repo_path = {
+            "flat": _flat_repo_path,
+            "by-team": _by_team_repo_path,
+        }[label]
+
+    def __str__(self):
+        return str(self.label)

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -360,6 +360,9 @@ class TestClone:
     def test_clone_all_repos_flat(
         self, platform_url, with_student_repos, tmp_path
     ):
+        """Test that cloning with flat directory layout results in all
+        repositories ending up in the current working directory.
+        """
         expected_dirnames = plug.generate_repo_names(
             STUDENT_TEAMS, TEMPLATE_REPO_NAMES
         )

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -8,6 +8,7 @@ from typing import List, Mapping, Tuple, Iterable
 import git
 import pytest
 
+import _repobee.command.repos
 import _repobee.ext.javac
 import _repobee.ext.pylint
 
@@ -355,6 +356,26 @@ class TestClone:
         assert_cloned_student_repos_match_templates(
             STUDENT_TEAMS, TEMPLATE_REPO_NAMES, tmp_path
         )
+
+    def test_clone_all_repos_flat(
+        self, platform_url, with_student_repos, tmp_path
+    ):
+        expected_dirnames = plug.generate_repo_names(
+            STUDENT_TEAMS, TEMPLATE_REPO_NAMES
+        )
+
+        funcs.run_repobee(
+            f"repos clone -a {TEMPLATE_REPOS_ARG} "
+            f"--base-url {platform_url} "
+            "--directory-layout "
+            f"{_repobee.command.repos.DirectoryLayout.FLAT.value}",
+            workdir=tmp_path,
+        )
+
+        actual_dirnames = [
+            path.name for path in tmp_path.iterdir() if path.is_dir()
+        ]
+        assert sorted(actual_dirnames) == sorted(expected_dirnames)
 
     def test_clone_local_gitconfig(
         self, platform_url, with_student_repos, tmp_path

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -371,7 +371,7 @@ class TestClone:
             f"repos clone -a {TEMPLATE_REPOS_ARG} "
             f"--base-url {platform_url} "
             "--directory-layout "
-            f"{_repobee.command.repos.DirectoryLayout.FLAT.value}",
+            f"{_repobee.command.repos.DirectoryLayout.FLAT}",
             workdir=tmp_path,
         )
 

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -78,7 +78,7 @@ VALID_PARSED_ARGS = dict(
     secrets=False,
     update_local=False,
     double_blind_key=None,
-    directory_layout=_repobee.command.repos.DirectoryLayout.NESTED_BY_TEAM,
+    directory_layout=_repobee.command.repos.DirectoryLayout.BY_TEAM,
 )
 
 
@@ -385,7 +385,7 @@ class TestDispatchCommand:
         command_mock.clone_repos.assert_called_once_with(
             args.repos,
             False,
-            _repobee.command.repos.DirectoryLayout.NESTED_BY_TEAM,
+            _repobee.command.repos.DirectoryLayout.BY_TEAM,
             dummyapi_instance,
         )
 

--- a/tests/unit_tests/repobee/test_cli.py
+++ b/tests/unit_tests/repobee/test_cli.py
@@ -78,6 +78,7 @@ VALID_PARSED_ARGS = dict(
     secrets=False,
     update_local=False,
     double_blind_key=None,
+    directory_layout=_repobee.command.repos.DirectoryLayout.NESTED_BY_TEAM,
 )
 
 
@@ -382,7 +383,10 @@ class TestDispatchCommand:
         )
 
         command_mock.clone_repos.assert_called_once_with(
-            args.repos, False, dummyapi_instance
+            args.repos,
+            False,
+            _repobee.command.repos.DirectoryLayout.NESTED_BY_TEAM,
+            dummyapi_instance,
         )
 
     def test_verify_settings_called_with_correct_args(


### PR DESCRIPTION
Fix #881 

This PR introduces the `--dl|--directory-layout`, which allows a user to choose how repositories the layout into which repositories are cloned.

Currently, there are only two options: `by-team` and `flat`

* `by-team`: This is the default, where the repositories of each team are placed in a subdirectory with the name of the team
* `flat`: This is a new layout in which each repository is cloned into the current working directory, without organizing into subdirectories

I also plan to add a `by-task` layout, which is something that I've personally wanted to have for quite some time.

@davbeek Any thoughts?

@tohanss ping for review