### PR TITLE
[fix] Convert case of name and URL of repsoitories to lowercase

### DIFF
--- a/src/repobee_plug/localreps.py
+++ b/src/repobee_plug/localreps.py
@@ -94,6 +94,7 @@ class StudentRepo(_RepoPathMixin):
     def __post_init__(self):
         _check_name_length(self.name)
         object.__setattr__(self, "name", self.name.lower())
+        object.__setattr__(self, "url", self.url.lower())
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/repobee_plug/localreps.py
+++ b/src/repobee_plug/localreps.py
@@ -93,6 +93,7 @@ class StudentRepo(_RepoPathMixin):
 
     def __post_init__(self):
         _check_name_length(self.name)
+        object.__setattr__(self, "name", self.name.lower())
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -123,6 +123,7 @@ class Repo(APIObject):
 
     def __post_init__(self):
         object.__setattr__(self, "name", self.name.lower())
+        object.__setattr__(self, "url", self.url.lower())
 
 
 class _APISpec:

--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -121,6 +121,9 @@ class Repo(APIObject):
     url: str
     implementation: Any = dataclasses.field(compare=False, repr=False)
 
+    def __post_init__(self):
+        object.__setattr__(self, "name", self.name.lower())
+
 
 class _APISpec:
     """Wrapper class for API method stubs.

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -381,7 +381,7 @@ class TestClone:
         """
         # arrange
         def generate_repo_name(team_name, assignment_name):
-            return f"{assignment_name}-BONKERS-{team_name}"
+            return f"{assignment_name}-bonkers-{team_name}"
 
         class StrangeNamingConvention(plug.Plugin):
             def generate_repo_name(self, team_name, assignment_name):

--- a/tests/unit_tests/repobee_plug/test_localreps.py
+++ b/tests/unit_tests/repobee_plug/test_localreps.py
@@ -11,3 +11,18 @@ class TestStudentTeam:
         members_lowercase = ["simon", "alice", "eve"]
         team = plug.StudentTeam(members=members)
         assert team.members == members_lowercase
+
+
+class TestStudentRepo:
+    """Tests for the StudentRepo class"""
+
+    def test_constructor_lowercases_name(self):
+        name = "TeStREpo"
+        name_lowercase = "testrepo"
+
+        members = ["simon", "alice", "eve"]
+        team = plug.StudentTeam(members=members)
+        url = "https://github.com/SpoonLabs/diffmin"
+
+        student_repo = plug.StudentRepo(name, team, url)
+        assert student_repo.name == name_lowercase

--- a/tests/unit_tests/repobee_plug/test_localreps.py
+++ b/tests/unit_tests/repobee_plug/test_localreps.py
@@ -26,3 +26,14 @@ class TestStudentRepo:
 
         student_repo = plug.StudentRepo(name, team, url)
         assert student_repo.name == name_lowercase
+
+    def test_constructor_lowercases_url(self):
+        name = "testrepo"
+        members = ["simon", "alice", "eve"]
+        team = plug.StudentTeam(members=members)
+
+        url = "hTTpS://GitHub.com/spoOnLaBs/DiFfMIN"
+        url_lowercase = "https://github.com/spoonlabs/diffmin"
+
+        student_repo = plug.StudentRepo(name, team, url)
+        assert student_repo.url == url_lowercase

--- a/tests/unit_tests/repobee_plug/test_platform.py
+++ b/tests/unit_tests/repobee_plug/test_platform.py
@@ -192,3 +192,16 @@ class TestRepo:
             implementation="fake",
         )
         assert repo.name == name_lowercase
+
+    def test_lowercase_url(self):
+        url = "hTTps://sAmpLe.cOM"
+        url_lowercase = "https://sample.com"
+
+        repo = platform.Repo(
+            name="testrepo",
+            description="descr",
+            private=False,
+            url=url,
+            implementation="fake",
+        )
+        assert repo.url == url_lowercase

--- a/tests/unit_tests/repobee_plug/test_platform.py
+++ b/tests/unit_tests/repobee_plug/test_platform.py
@@ -175,3 +175,20 @@ class TestTeam:
         )
 
         assert team.members == lowercase_usernames
+
+
+class TestRepo:
+    """Tests for Repo class"""
+
+    def test_lowercase_name(self):
+        name = "TeStREpo"
+        name_lowercase = "testrepo"
+
+        repo = platform.Repo(
+            name=name,
+            description="descr",
+            private=False,
+            url="https://sample.com",
+            implementation="fake",
+        )
+        assert repo.name == name_lowercase


### PR DESCRIPTION
Fixes https://github.com/repobee/repobee/issues/903

I am working on two more things which are required for this PR to be merged.
- [ ] Write system tests.
- [ ] Fix platform API metaclass.

@slarse I tried adding `__post_init__` method inside the [metaclass](https://github.com/repobee/repobee/blob/f2346a67ca996b965196d700e32a08abd3eb064c/src/repobee_plug/platform.py#L501-L519) so that I could get iterate over the arguments there and change their case. However, the flow of the program was not calling `__post_init__` so I am not sure how to go about it. I could probably override the `__init__` to explicitly call `__post_init__` but this did not seem like a good way to achieve it.