### PR TITLE
[feat] Add squash plugin for squashing template repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 21.7b0
     hooks:
     - id: black
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -278,6 +278,7 @@ def _clone_all(
             url = _try_insert_auth(repo, api)
             plug.log.info(f"Cloning into '{url}'")
             git.clone_single(url, cwd=str(cwd))
+            plug.manager.hook.preprocess_template(repo=repo, api=api)
     except exception.CloneFailedError:
         plug.log.error(f"Error cloning into {url}, aborting ...")
         raise

--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -279,7 +279,6 @@ def _clone_all(
             url = _try_insert_auth(repo, api)
             plug.log.info(f"Cloning into '{url}'")
             git.clone_single(url, cwd=str(cwd))
-            plug.manager.hook.preprocess_template(repo=repo, api=api)
     except exception.CloneFailedError:
         plug.log.error(f"Error cloning into {url}, aborting ...")
         raise

--- a/src/_repobee/ext/squash.py
+++ b/src/_repobee/ext/squash.py
@@ -35,7 +35,7 @@ class Squash(plug.Plugin, plug.cli.CommandExtension):
         assert repo.path
 
         initial_branch = _repobee.git.active_branch(repo.path)
-        tmp_branch = hashlib.sha1(
+        tmp_branch = hashlib.sha256(
             str(datetime.datetime.now()).replace(" ", "_").encode("utf8")
         ).hexdigest()
 

--- a/src/_repobee/ext/squash.py
+++ b/src/_repobee/ext/squash.py
@@ -1,0 +1,49 @@
+"""Plugin that squashes template repos before they are pushed to students.
+"""
+import datetime
+import hashlib
+import shlex
+
+import repobee_plug as plug
+import subprocess
+
+import _repobee.git
+
+
+class Squash(plug.Plugin, plug.cli.CommandExtension):
+    __settings__ = plug.cli.command_extension_settings(
+        actions=[plug.cli.CoreCommand.repos.setup]
+    )
+
+    squash_message = plug.cli.option(
+        "--squash-message",
+        help="commit message to use for the squash commit",
+        converter=str,
+        default="Initial commit",
+    )
+
+    def preprocess_template(
+        self, repo: plug.TemplateRepo, api: plug.PlatformAPI
+    ) -> None:
+        assert repo.path
+
+        initial_branch = _repobee.git.active_branch(repo.path)
+        tmp_branch = hashlib.sha1(
+            str(datetime.datetime.now()).replace(" ", "_").encode("utf8")
+        ).hexdigest()
+
+        subprocess.run(
+            f"git symbolic-ref HEAD refs/heads/{tmp_branch}".split(),
+            cwd=repo.path,
+        )
+        subprocess.run("git add .".split(), cwd=repo.path)
+        subprocess.run(
+            shlex.split(f"git commit -m '{self.squash_message}'"),
+            cwd=repo.path,
+        )
+        subprocess.run(
+            shlex.split(f"git branch -D {initial_branch}"), cwd=repo.path
+        )
+        subprocess.run(
+            shlex.split(f"git branch -m '{initial_branch}'"), cwd=repo.path
+        )

--- a/src/_repobee/ext/squash.py
+++ b/src/_repobee/ext/squash.py
@@ -20,6 +20,7 @@ class Squash(plug.Plugin, plug.cli.CommandExtension):
         help="commit message to use for the squash commit",
         converter=str,
         default="Initial commit",
+        configurable=True,
     )
 
     def preprocess_template(

--- a/src/_repobee/ext/squash.py
+++ b/src/_repobee/ext/squash.py
@@ -29,7 +29,7 @@ class Squash(plug.Plugin, plug.cli.CommandExtension):
         configurable=True,
     )
 
-    def preprocess_template(
+    def pre_setup(
         self, repo: plug.TemplateRepo, api: plug.PlatformAPI
     ) -> None:
         initial_branch = _repobee.git.active_branch(repo.path)

--- a/src/_repobee/ext/squash.py
+++ b/src/_repobee/ext/squash.py
@@ -32,8 +32,6 @@ class Squash(plug.Plugin, plug.cli.CommandExtension):
     def preprocess_template(
         self, repo: plug.TemplateRepo, api: plug.PlatformAPI
     ) -> None:
-        assert repo.path
-
         initial_branch = _repobee.git.active_branch(repo.path)
         tmp_branch = hashlib.sha256(
             str(datetime.datetime.now()).replace(" ", "_").encode("utf8")

--- a/src/_repobee/plugin.py
+++ b/src/_repobee/plugin.py
@@ -376,7 +376,9 @@ def get_module_names(pkg: ModuleType) -> List[str]:
         name
         for file_finder, name, _ in pkgutil.iter_modules(pkg_path)
         # only include modules (i.e. files), not subpackages
-        if (pathlib.Path(file_finder.path) / (name + ".py")).is_file()  # type: ignore
+        if (
+            pathlib.Path(file_finder.path) / (name + ".py")
+        ).is_file()  # type: ignore
     ]
 
 
@@ -411,7 +413,9 @@ def execute_setup_tasks(
     Returns:
         A mapping from repo name to hook result.
     """
-    return execute_tasks(repos, plug.manager.hook.pre_setup, api, cwd)
+    return execute_tasks(
+        repos, plug.manager.hook.pre_setup, api, cwd, copy_repos=False
+    )
 
 
 def execute_tasks(
@@ -439,7 +443,13 @@ def execute_tasks(
         ):
             plug.log.info(f"Processing {repo.name}")
 
-            valid_results: List[plug.Result] = [result for result in hook_function(repo=repo, api=api, **(extra_kwargs or {})) if result]  # type: ignore
+            valid_results: List[plug.Result] = [
+                result
+                for result in hook_function(
+                    repo=repo, api=api, **(extra_kwargs or {})
+                )
+                if result
+            ]  # type: ignore
             all_results[repo.name].extend(valid_results)
     return all_results
 

--- a/src/_repobee/plugin.py
+++ b/src/_repobee/plugin.py
@@ -376,9 +376,7 @@ def get_module_names(pkg: ModuleType) -> List[str]:
         name
         for file_finder, name, _ in pkgutil.iter_modules(pkg_path)
         # only include modules (i.e. files), not subpackages
-        if (
-            pathlib.Path(file_finder.path) / (name + ".py")
-        ).is_file()  # type: ignore
+        if (pathlib.Path(file_finder.path) / (name + ".py")).is_file()  # type: ignore
     ]
 
 
@@ -443,13 +441,7 @@ def execute_tasks(
         ):
             plug.log.info(f"Processing {repo.name}")
 
-            valid_results: List[plug.Result] = [
-                result
-                for result in hook_function(
-                    repo=repo, api=api, **(extra_kwargs or {})
-                )
-                if result
-            ]  # type: ignore
+            valid_results: List[plug.Result] = [result for result in hook_function(repo=repo, api=api, **(extra_kwargs or {})) if result]  # type: ignore
             all_results[repo.name].extend(valid_results)
     return all_results
 

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -70,10 +70,12 @@ def pre_setup(repo: TemplateRepo, api: PlatformAPI) -> Optional[Result]:
 
     .. note::
 
-        Structural changes to the master repo are not currently supported.
-        Changes to the repository during the callback will not be reflected
-        in the generated repositories. Support for preprocessing is not
-        planned as it is technically difficult to implement.
+        Changes to the template repo can be persisted by comitting them, making
+        on-the-fly preprocessing possible. An example of this would be squashing
+        the commits of the template repo before pushing it to students. Note
+        that making any commit makes it impossible to later update student
+        repos with the ``repos update`` command, as on-the-fly commits are
+        unique by timestamp.
 
     Args:
         repo: Representation of a local template repo.
@@ -82,37 +84,6 @@ def pre_setup(repo: TemplateRepo, api: PlatformAPI) -> Optional[Result]:
         Optionally returns a Result for reporting the outcome of the hook.
         May also return None, in which case no reporting will be performed
         for the hook.
-    """
-
-
-@hookspec
-def preprocess_template(repo: TemplateRepo, api: PlatformAPI) -> None:
-    """Perform on-the-fly preprocessing of a template repository before
-    distributing it to students.
-
-    The intention of this hook is to allow users to perform preprocessing of
-    template repositories before they are pushed to students. A simple example
-    of this would be to squash the commits of the template repo before pushing
-    (see :py:mod:`_repobee.ext.squashtemplates`).
-
-    Only committed changes are respected. It is the responsibility of the
-    hook implementation to commit changes they wish to persist.
-
-    .. warning::
-
-        Committing changes to the template repo with this hook makes it
-        impossible to update student repos with ``repos update``, as on-the-fly
-        commits are unique by timestamp. There are currently no plans to
-        implement support ``repos update`` together with template
-        preprocessing.
-
-    .. danger::
-
-        This hook is unstable and may change without notice.
-
-    Args:
-        repo: Representation of a local template repo.
-        api: An instance of the platform API.
     """
 
 

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -86,6 +86,30 @@ def pre_setup(repo: TemplateRepo, api: PlatformAPI) -> Optional[Result]:
 
 
 @hookspec
+def preprocess_template(repo: TemplateRepo, api: PlatformAPI) -> None:
+    """Perform on-the-fly preprocessing of a template repository before
+    distributing it to students.
+
+    The intention of this hook is to allow users to perform preprocessing of
+    template repositories before they are pushed to students. A simple example
+    of this would be to squash the commits of the template repo before pushing
+    (see :py:mod:`_repobee.ext.squashtemplates`).
+
+    .. important::
+
+        Only committed changes are respected. It is the responsibility of the
+        hook implementation to commit changes they wish to persist.
+
+    .. warning::
+
+        Using this hook or any plugin that implements it makes running ``repos
+        update`` impossible, as on-the-fly commits are unique by timestamp.
+        There are currently no plans to implement support ``repos update``
+        together with template preprocessing.
+    """
+
+
+@hookspec
 def post_setup(
     repo: StudentRepo, api: PlatformAPI, newly_created: bool
 ) -> Optional[Result]:

--- a/src/repobee_plug/_exthooks.py
+++ b/src/repobee_plug/_exthooks.py
@@ -95,17 +95,24 @@ def preprocess_template(repo: TemplateRepo, api: PlatformAPI) -> None:
     of this would be to squash the commits of the template repo before pushing
     (see :py:mod:`_repobee.ext.squashtemplates`).
 
-    .. important::
-
-        Only committed changes are respected. It is the responsibility of the
-        hook implementation to commit changes they wish to persist.
+    Only committed changes are respected. It is the responsibility of the
+    hook implementation to commit changes they wish to persist.
 
     .. warning::
 
-        Using this hook or any plugin that implements it makes running ``repos
-        update`` impossible, as on-the-fly commits are unique by timestamp.
-        There are currently no plans to implement support ``repos update``
-        together with template preprocessing.
+        Committing changes to the template repo with this hook makes it
+        impossible to update student repos with ``repos update``, as on-the-fly
+        commits are unique by timestamp. There are currently no plans to
+        implement support ``repos update`` together with template
+        preprocessing.
+
+    .. danger::
+
+        This hook is unstable and may change without notice.
+
+    Args:
+        repo: Representation of a local template repo.
+        api: An instance of the platform API.
     """
 
 


### PR DESCRIPTION
Fix #899 

This PR adds a `squash` plugin that causes template repos to be squashed before being pushed to students. It's an implementation of the `pre_setup` hook that has been modified to allow for persisting changes by committing. To use the plugin, simply activate it and run `repos setup` as usual, optionally providing the `--squash-message` option to decide the message of the squash commit.