### PR TITLE
[feat] Extract parsing of students file into a hook function

### DIFF
--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -245,13 +245,10 @@ def _extract_groups(args: argparse.Namespace) -> List[plug.StudentTeam]:
             raise exception.FileError(f"'{students_file}' is not a file")
         if not students_file.stat().st_size:
             raise exception.FileError(f"'{students_file}' is empty")
-        students = [
-            plug.StudentTeam(members=[s for s in group.strip().split()])
-            for group in students_file.read_text(
-                encoding=sys.getdefaultencoding()
-            ).split(os.linesep)
-            if group  # skip blank lines
-        ]
+
+        students = list(
+            plug.manager.hook.parse_students_file(students_file=students_file)
+        )
     else:
         students = []
 

--- a/src/_repobee/ext/defaults/students_file_parser.py
+++ b/src/_repobee/ext/defaults/students_file_parser.py
@@ -1,0 +1,26 @@
+"""Plugin that provides the default students file parsing for RepoBee.
+
+.. module:: students_file_parser
+    :synopsis: Default students file parsing for RepoBee.
+"""
+
+import os
+import pathlib
+import sys
+
+from typing import Iterable
+
+import repobee_plug as plug
+
+
+@plug.repobee_hook
+def parse_students_file(
+    students_file: pathlib.Path,
+) -> Iterable[plug.StudentTeam]:
+    return [
+        plug.StudentTeam(members=[s for s in group.strip().split()])
+        for group in students_file.read_text(
+            encoding=sys.getdefaultencoding()
+        ).split(os.linesep)
+        if group  # skip blank lines
+    ]

--- a/src/repobee_plug/_corehooks.py
+++ b/src/repobee_plug/_corehooks.py
@@ -8,8 +8,9 @@ to allow for this dynamic override.
 .. module:: corehooks
     :synopsis: Hookspecs for repobee core hooks.
 """
+import pathlib
 
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Iterable
 
 from repobee_plug import localreps, hook, reviews, platform
 
@@ -113,4 +114,25 @@ def generate_repo_name(
     Args:
         team_name: Name of the associated team.
         assignment_name: Name of an assignment.
+    """
+
+
+@hook.hookspec(firstresult=True)
+def parse_students_file(
+    students_file: pathlib.Path,
+) -> Iterable[localreps.StudentTeam]:
+    """Parse the students file and return any student teams from it.
+
+    This hook is responsible for parsing the students file. The file passed to
+    implementations of this hook is guaranteed to be non-empty, but it is up to
+    implementations to verify that it's syntactically correct.
+
+    .. danger::
+
+        This hook is unstable and may change without notice.
+
+    Args:
+        students_file: Path to a non-empty file.
+    Returns:
+        An iterable of student teams parsed from the file.
     """


### PR DESCRIPTION
#880 

This PR is part refactor, part feature. It extracts the parsing of the students file into a hook function such that the exact implementation can be overridden with plugins. This opens up for implementing students file parsing in any way one wishes to.

@davbeek I've briefly played around with this to implement a plugin for to parse YAML files, allowing one to specify something like this:

```yml
some-team:
    members: [alice, eve, bob]
other-team:
    members: [simon, ric]
```

This would create the teams `some-team` and `other-team` with the specified members, and any associated repos would by default then have names prefixed with those team names (as usual). You could of course add that group id of yours as part of the team name. I haven't decided on the details here, but the good news is that supporting your use case is not hard at all.

@htdebeer-tue I recall that at some point we discussed fetching student lists from Canvas. I believe that with this hook, that should be possible.