### PR TITLE
[fix] Fix LocalAPI overwriting connection settings

### DIFF
--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -92,6 +92,31 @@ def _assert_repos_match_templates(
 class TestSetup:
     """Tests for the ``repos setup`` command."""
 
+    def test_setup_with_custom_template_repo(
+        self, platform_dir, platform_url, tmp_path_factory
+    ):
+        api = funcs.get_api(platform_url, org_name=const.TEMPLATE_ORG_NAME)
+
+        template_repo = api.create_repo(
+            "epIcRepo", description="dontcare", private=False
+        )
+        local_template_dir = tmp_path_factory.mktemp("template")
+        (local_template_dir / "file.txt").write_text(
+            "this is a brand new file!"
+        )
+
+        branch = "master"
+        local_template_repo = funcs.initialize_repo(
+            local_template_dir, default_branch=branch
+        )
+        local_template_repo.git.push(
+            api.insert_auth(template_repo.url), branch
+        )
+
+        funcs.run_repobee(
+            f"repos setup -a {template_repo.name} --base-url {platform_url}"
+        )
+
     def test_setup_single_template_repo(self, platform_dir, platform_url):
         template_repo_name = TEMPLATE_REPO_NAMES[0]
         funcs.run_repobee(

--- a/tests/new_integration_tests/test_reviews.py
+++ b/tests/new_integration_tests/test_reviews.py
@@ -55,7 +55,7 @@ class TestAssign:
             f"--assignments {assignment_name}"
         )
 
-        api._restore_state()
+        api._restore_platform_state()
         num_repos_after = len(list(api.get_repos()))
         assert num_repos_after == num_repos_before + len(const.STUDENT_TEAMS)
 
@@ -107,7 +107,7 @@ class TestEnd:
             f"--assignments {assignment_name}"
         )
 
-        api._restore_state()
+        api._restore_platform_state()
         review_teams = [
             team for team in api.get_teams() if "-" not in team.name
         ]
@@ -123,7 +123,7 @@ class TestEnd:
         )
 
         # assert
-        api._restore_state()
+        api._restore_platform_state()
         num_repos_after = len(list(api.get_repos()))
         assert num_repos_after == num_repos_before
 


### PR DESCRIPTION
Fix #936 

This PR makes LocalAPI only store the platform state (i.e. the repos, teams and users), and not the connection settings to the platform (i.e. user, token etc) in the pickle file. This solves the problem of it being impossible to create a new API with a different value in the connection settings, such as a different user, as that was always immediately overwritten when restoring the state in the constructor.

There's still a problem with synchronization: if multiple instances of LocalAPI are used concurrently, they'll overwrite each others' states, as the state is only ever restored when the instance is created. But that's for a separate issue.