### PR TITLE
[feat] Add extended students file syntax based on YAML

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ required = [
     "tabulate",
     "tqdm>=4.48.2",
     "typing-extensions",
+    "yamliny>=0.0.2",
 ]
 
 testhelper_resources_dir = pathlib.Path("src/repobee_testhelpers/resources")

--- a/src/_repobee/ext/studentsyml.py
+++ b/src/_repobee/ext/studentsyml.py
@@ -38,9 +38,12 @@ from typing import Iterable
 def parse_students_file(
     students_file: pathlib.Path,
 ) -> Iterable[plug.StudentTeam]:
-    students_dict = yamliny.loads(
-        students_file.read_text(encoding=sys.getdefaultencoding())
-    )
+    try:
+        students_dict = yamliny.loads(
+            students_file.read_text(encoding=sys.getdefaultencoding())
+        )
+    except yamliny.YamlinyError as exc:
+        raise plug.PlugError(f"Parse error '{students_file}': {exc}") from exc
     return [
         plug.StudentTeam(name=name, members=data["members"])
         for name, data in students_dict.items()

--- a/src/_repobee/ext/studentsyml.py
+++ b/src/_repobee/ext/studentsyml.py
@@ -33,6 +33,8 @@ import repobee_plug as plug
 
 from typing import Iterable
 
+_MEMBERS_KEY = "members"
+
 
 @plug.repobee_hook
 def parse_students_file(
@@ -45,6 +47,12 @@ def parse_students_file(
     except yamliny.YamlinyError as exc:
         raise plug.PlugError(f"Parse error '{students_file}': {exc}") from exc
     return [
-        plug.StudentTeam(name=name, members=data["members"])
+        _to_student_team(name=name, data=data)
         for name, data in students_dict.items()
     ]
+
+
+def _to_student_team(name: str, data: dict) -> plug.StudentTeam:
+    if _MEMBERS_KEY not in data:
+        raise plug.PlugError(f"Missing members mapping for '{name}'")
+    return plug.StudentTeam(name=name, members=data[_MEMBERS_KEY])

--- a/src/_repobee/ext/studentsyml.py
+++ b/src/_repobee/ext/studentsyml.py
@@ -1,0 +1,47 @@
+"""Plugin that enables an extended, YAML-based syntax for the students file.
+
+.. warning::
+
+    This plugin is in early development, and may change without notice. The
+    plan is to integrate this functionality directly into RepoBee once we're
+    satisfied with how it works.
+
+The point of this plugin is to allow one to specify student teams with more
+granularity. In particular, it allows one to specify names independently of
+the members of each team. For example, to have a team ``some-team`` with
+members alice and eve and another team ``other-team`` with sole member bob,
+the following file would do the trick:
+
+.. code-block:: yml
+    :caption: students.yml
+
+    some-team:
+        members: [alice, bob]
+    other-team:
+        members: [eve]
+
+Then provide it as the ``--students-file`` with this plugin active, and all
+is well!
+"""
+
+
+import sys
+import pathlib
+
+import yamliny
+import repobee_plug as plug
+
+from typing import Iterable
+
+
+@plug.repobee_hook
+def parse_students_file(
+    students_file: pathlib.Path,
+) -> Iterable[plug.StudentTeam]:
+    students_dict = yamliny.loads(
+        students_file.read_text(encoding=sys.getdefaultencoding())
+    )
+    return [
+        plug.StudentTeam(name=name, members=data["members"])
+        for name, data in students_dict.items()
+    ]

--- a/src/_repobee/ext/studentsyml.py
+++ b/src/_repobee/ext/studentsyml.py
@@ -40,16 +40,19 @@ _MEMBERS_KEY = "members"
 def parse_students_file(
     students_file: pathlib.Path,
 ) -> Iterable[plug.StudentTeam]:
+    return [
+        _to_student_team(name=name, data=data)
+        for name, data in _parse_yamliny(students_file).items()
+    ]
+
+
+def _parse_yamliny(students_file: pathlib.Path) -> dict:
     try:
-        students_dict = yamliny.loads(
+        return yamliny.loads(
             students_file.read_text(encoding=sys.getdefaultencoding())
         )
     except yamliny.YamlinyError as exc:
         raise plug.PlugError(f"Parse error '{students_file}': {exc}") from exc
-    return [
-        _to_student_team(name=name, data=data)
-        for name, data in students_dict.items()
-    ]
 
 
 def _to_student_team(name: str, data: dict) -> plug.StudentTeam:

--- a/src/repobee_testhelpers/funcs.py
+++ b/src/repobee_testhelpers/funcs.py
@@ -192,7 +192,9 @@ def get_student_teams(
     """
     api = get_api(platform_url, org_name=org_name)
     return [
-        plug.StudentTeam(members=[usr.username for usr in team.members])
+        plug.StudentTeam(
+            name=team.name, members=[usr.username for usr in team.members]
+        )
         for team in api._teams[org_name].values()
     ]
 

--- a/tests/new_integration_tests/test_teams.py
+++ b/tests/new_integration_tests/test_teams.py
@@ -1,7 +1,12 @@
 """Tests for the teams category of commands."""
+import sys
+
+import repobee_plug as plug
 
 from repobee_testhelpers import funcs
 from repobee_testhelpers import const
+
+import _repobee.ext.studentsyml
 
 
 class TestCreate:
@@ -19,4 +24,30 @@ class TestCreate:
         funcs.run_repobee(f"teams create --base-url {platform_url}")
         assert sorted(funcs.get_student_teams(platform_url)) == sorted(
             const.STUDENT_TEAMS
+        )
+
+    def test_run_with_extended_students_syntax(self, platform_url, tmp_path):
+        students_file = tmp_path / "students.yml"
+        students_file.write_text(
+            """
+some-team:
+    members: [simon]
+other-team:
+    members: [eve, alice]
+        """.strip(),
+            encoding=sys.getdefaultencoding(),
+        )
+        expected_teams = [
+            plug.StudentTeam(name="some-team", members=["simon"]),
+            plug.StudentTeam(name="other-team", members=["eve", "alice"]),
+        ]
+
+        funcs.run_repobee(
+            f"{plug.cli.CoreCommand.teams.create} --base-url {platform_url} "
+            f"--students-file {students_file}",
+            plugins=[_repobee.ext.studentsyml],
+        )
+
+        assert sorted(funcs.get_student_teams(platform_url)) == sorted(
+            expected_teams
         )

--- a/tests/unit_tests/repobee/plugin_tests/test_studentsyml.py
+++ b/tests/unit_tests/repobee/plugin_tests/test_studentsyml.py
@@ -1,0 +1,41 @@
+import sys
+
+import pytest
+import repobee_plug as plug
+
+from _repobee.ext import studentsyml
+
+
+def test_raises_PlugError_on_bad_syntax(tmp_path):
+    students_file = tmp_path / "students.yml"
+    students_file.write_text(
+        """
+first-team:
+    members: [first, second, third
+)
+""",
+        encoding=sys.getdefaultencoding(),
+    )
+
+    with pytest.raises(plug.PlugError) as exc_info:
+        studentsyml.parse_students_file(students_file)
+
+    assert f"Parse error '{students_file}': Line 2" in str(exc_info.value)
+
+
+def test_raises_PlugError_on_misspelled_members_mapping(tmp_path):
+    students_file = tmp_path / "students.yml"
+    students_file.write_text(
+        """
+first-team:
+    members: [first, second]
+second-team:
+    member: [third]
+""",
+        encoding=sys.getdefaultencoding(),
+    )
+
+    with pytest.raises(plug.PlugError) as exc_info:
+        studentsyml.parse_students_file(students_file)
+
+    assert "Missing members mapping for 'second-team'" in str(exc_info.value)


### PR DESCRIPTION
Fix #880 

This PR adds a plugin, `studentsyml`, that supports an extended students file syntax based on YAML.

The happy-path behavior is seemingly working fine, but error-handling needs to be implemented.