### PR TITLE
[misc] Improve error message on trying to install incompatible plugin

### DIFF
--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -97,6 +97,17 @@ class InstallPluginCommand(plug.Plugin, plug.cli.Command):
         installed_plugins = disthelpers.get_installed_plugins()
         active_plugins = disthelpers.get_active_plugins()
 
+        try:
+            self._install_plugin(plugins, installed_plugins, active_plugins)
+        except disthelpers.DependencyResolutionError as exc:
+            raise disthelpers.DependencyResolutionError(
+                f"Selected plugin is incompatible with RepoBee {__version__}. "
+                "Try upgrading RepoBee and then install the plugin again."
+            ) from exc
+
+    def _install_plugin(
+        self, plugins: dict, installed_plugins: dict, active_plugins: dict
+    ) -> None:
         if self.local:
             abspath = self.local.absolute()
             if not abspath.exists():

--- a/src/_repobee/ext/dist/pluginmanager.py
+++ b/src/_repobee/ext/dist/pluginmanager.py
@@ -106,7 +106,7 @@ class InstallPluginCommand(plug.Plugin, plug.cli.Command):
             ) from exc
 
     def _install_plugin(
-        self, plugins: dict, installed_plugins: dict, active_plugins: dict
+        self, plugins: dict, installed_plugins: dict, active_plugins: List[str]
     ) -> None:
         if self.local:
             abspath = self.local.absolute()


### PR DESCRIPTION
fix #768 

This PR improves the error message printed when installing a plugin that's incompatible with the current version of RepoBee. It prompts the user to upgrade RepoBee and try again, relying on the fact that most plugins specify requirements on the form `repobee>=x.y.z`.