### PR TITLE
[fix] Fix empty StudentTeam name in post_setup hook

### DIFF
--- a/src/_repobee/command/repos.py
+++ b/src/_repobee/command/repos.py
@@ -154,7 +154,7 @@ def _post_setup(
         plug.StudentRepo(
             name=repo.name,
             url=repo.url,
-            team=plug.StudentTeam(members=team.members),
+            team=plug.StudentTeam(name=team.name, members=team.members),
         )
         for team, repo in teams_and_repos
     ]

--- a/src/repobee_testhelpers/localapi.py
+++ b/src/repobee_testhelpers/localapi.py
@@ -168,9 +168,8 @@ class LocalAPI(plug.PlatformAPI):
         permission: plug.TeamPermission = plug.TeamPermission.PUSH,
     ) -> None:
         """See :py:meth:`repobee_plug.PlatformAPI.assign_members`."""
-        team.implementation.add_members(
-            [self._get_user(m) for m in members or []]
-        )
+        users = (self._users.get(m) for m in (members or []) if m)
+        team.implementation.add_members([user for user in users if user])
 
     def assign_repo(
         self, team: plug.Team, repo: plug.Repo, permission: plug.TeamPermission

--- a/tests/new_integration_tests/test_repos.py
+++ b/tests/new_integration_tests/test_repos.py
@@ -462,6 +462,29 @@ other-team:
         ]
         assert sorted(actual_repo_names) == sorted(expected_repo_names)
 
+    def test_post_setup_hook_gets_correct_student_team_names(
+        self, platform_url
+    ):
+        """Test that the student teams in post_setup hook get correct team
+        names. Replicates the bug from #771.
+        """
+        nonexisting_student = "nonexisting"
+
+        actual_student_team_names = set()
+
+        class PostSetup(plug.Plugin):
+            def post_setup(self, repo, api):
+                actual_student_team_names.add(repo.team.name)
+
+        funcs.run_repobee(
+            f"{plug.cli.CoreCommand.repos.setup} --base-url {platform_url} "
+            f"--assignments {TEMPLATE_REPOS_ARG} "
+            f"--students {nonexisting_student}",
+            plugins=[PostSetup],
+        )
+
+        assert actual_student_team_names == {nonexisting_student}
+
 
 class TestClone:
     """Tests for the ``repos clone`` command."""


### PR DESCRIPTION
Fix #771 

The StudentTeam names were derived from the actual members of the team, which didn't work when the students didn't yet exist.