### PR TITLE
[fix] Fix fetching of asyncio event loop

### DIFF
--- a/src/_repobee/git/_util.py
+++ b/src/_repobee/git/_util.py
@@ -39,7 +39,7 @@ def batch_execution(
         a list of exceptions raised in the tasks returned by the batch
         function.
     """
-    loop = asyncio.get_event_loop()
+    loop = _get_event_loop()
     return loop.run_until_complete(
         batch_execution_async(
             batch_func, arg_list, *batch_func_args, **batch_func_kwargs
@@ -57,7 +57,7 @@ async def batch_execution_async(
     import tqdm.asyncio  # type: ignore
 
     exceptions = []
-    loop = asyncio.get_event_loop()
+    loop = _get_event_loop()
     concurrent_tasks = 20
     for batch, args_chunk in enumerate(
         more_itertools.ichunked(arg_list, concurrent_tasks), start=1
@@ -106,3 +106,10 @@ def is_git_repo(path: Union[str, pathlib.Path]) -> bool:
         True if there is a .git subdirectory in the given directory.
     """
     return os.path.isdir(path) and ".git" in os.listdir(path)
+
+
+def _get_event_loop() -> asyncio.AbstractEventLoop:
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.new_event_loop()


### PR DESCRIPTION
`asyncio.get_event_loop()` was deprecated in Python 3.10, and the deprecation messages causes test failures.