### PR TITLE
[fix] Make empty repo check non-case sensitive

### DIFF
--- a/src/_repobee/git/_fetch.py
+++ b/src/_repobee/git/_fetch.py
@@ -11,7 +11,6 @@ import enum
 import pathlib
 import shutil
 import subprocess
-import sys
 from typing import List, Iterable, Tuple
 
 import repobee_plug as plug
@@ -36,12 +35,8 @@ async def _clone_async(clone_spec: CloneSpec):
     """
     rc, stderr = await pull_clone_async(clone_spec)
 
-    empty_repo_error = "fatal: couldn't find remote ref HEAD"
-    decoded_stderr = stderr.decode(sys.getdefaultencoding())
-    if (
-        rc != 0
-        and empty_repo_error.casefold() not in decoded_stderr.casefold()
-    ):
+    empty_repo_error = b"fatal: couldn't find remote ref HEAD"
+    if rc != 0 and empty_repo_error.lower() not in stderr.lower():
         raise exception.CloneFailedError(
             f"Failed to clone {clone_spec.repo_url}",
             returncode=rc,

--- a/src/_repobee/git/_fetch.py
+++ b/src/_repobee/git/_fetch.py
@@ -11,6 +11,7 @@ import enum
 import pathlib
 import shutil
 import subprocess
+import sys
 from typing import List, Iterable, Tuple
 
 import repobee_plug as plug
@@ -35,8 +36,12 @@ async def _clone_async(clone_spec: CloneSpec):
     """
     rc, stderr = await pull_clone_async(clone_spec)
 
-    empty_repo_error = b"""fatal: Couldn't find remote ref HEAD"""
-    if rc != 0 and empty_repo_error not in stderr:
+    empty_repo_error = "fatal: couldn't find remote ref HEAD"
+    decoded_stderr = stderr.decode(sys.getdefaultencoding())
+    if (
+        rc != 0
+        and empty_repo_error.casefold() not in decoded_stderr.casefold()
+    ):
         raise exception.CloneFailedError(
             f"Failed to clone {clone_spec.repo_url}",
             returncode=rc,

--- a/src/_repobee/git/_util.py
+++ b/src/_repobee/git/_util.py
@@ -109,6 +109,9 @@ def is_git_repo(path: Union[str, pathlib.Path]) -> bool:
 
 
 def _get_event_loop() -> asyncio.AbstractEventLoop:
+    if sys.version_info[:2] < (3, 10):
+        return asyncio.get_event_loop()
+
     try:
         return asyncio.get_running_loop()
     except RuntimeError:


### PR DESCRIPTION
The check was case sensitive, and the version of Git running in GitHub Actions used all lowercase (which RepoBee did not account for). See #981 