### PR TITLE
[fix] Rate limit modify requests in GitHub API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ test_requirements = [
     "pytest-mock",
     "pytest>=6.0.0",
     "virtualenv",
+    "responses>=0.18.0",
     # type stubs required for MyPy
     "types-pkg-resources",
     "types-requests",

--- a/src/_repobee/ext/defaults/github.py
+++ b/src/_repobee/ext/defaults/github.py
@@ -130,7 +130,9 @@ class GitHubAPI(plug.PlatformAPI):
         """
 
         # see https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits
-        rate_limit.rate_limit_modify_requests(rate_limit_in_seconds=1)
+        rate_limit.rate_limit_modify_requests(
+            base_url, rate_limit_in_seconds=1
+        )
 
         if not user:
             raise TypeError("argument 'user' must not be empty")

--- a/src/_repobee/rate_limit.py
+++ b/src/_repobee/rate_limit.py
@@ -1,0 +1,49 @@
+import requests
+import time
+import functools
+
+MODIFY_REQUEST_METHOD_NAMES = ("post", "put", "patch", "delete")
+
+_ORIGINAL_REQUESTS_METHODS = {
+    method_name: getattr(requests, method_name)
+    for method_name in MODIFY_REQUEST_METHOD_NAMES + ("request",)
+}
+
+
+def rate_limit_modify_requests(rate_limit_in_seconds: int) -> None:
+    """Apply a rate limit to all modifying requests (put, patch, delete, post).
+
+    This is currently necessary at least for GitHub due to the newly introduced
+    secondary rate limits, see
+    https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits.
+
+    Args:
+        rate_limit_in_seconds: Minimum amount of seconds between each modify
+            request.
+    """
+    last_modify_time = 0
+
+    original_request_method = requests.request
+
+    def request(method, *args, **kwargs):
+        nonlocal last_modify_time
+
+        if method.lower() in MODIFY_REQUEST_METHOD_NAMES:
+            seconds_since_last_modify = time.time() - last_modify_time
+            if seconds_since_last_modify < rate_limit_in_seconds:
+                time.sleep(rate_limit_in_seconds - seconds_since_last_modify)
+            last_modify_time = time.time()
+
+        original_request_method(method, *args, **kwargs)
+
+    requests.request = request
+    requests.put = functools.partial(request, "put")
+    requests.patch = functools.partial(request, "patch")
+    requests.delete = functools.partial(request, "delete")
+    requests.post = functools.partial(request, "post")
+
+
+def remove_rate_limits() -> None:
+    """Remove any previously applied rate limits."""
+    for method_name, original_method in _ORIGINAL_REQUESTS_METHODS.items():
+        setattr(requests, method_name, original_method)

--- a/src/_repobee/rate_limit.py
+++ b/src/_repobee/rate_limit.py
@@ -2,6 +2,8 @@ import requests
 import time
 import functools
 
+import repobee_plug as plug
+
 MODIFY_REQUEST_METHOD_NAMES = ("post", "put", "patch", "delete")
 
 _ORIGINAL_REQUESTS_METHODS = {
@@ -21,6 +23,10 @@ def rate_limit_modify_requests(rate_limit_in_seconds: int) -> None:
         rate_limit_in_seconds: Minimum amount of seconds between each modify
             request.
     """
+    plug.log.debug(
+        f"Rate limiting modify requests to {1 / rate_limit_in_seconds} "
+        "requests per second"
+    )
     last_modify_time = 0
 
     original_request_method = requests.request
@@ -45,5 +51,7 @@ def rate_limit_modify_requests(rate_limit_in_seconds: int) -> None:
 
 def remove_rate_limits() -> None:
     """Remove any previously applied rate limits."""
+    plug.log.debug("Removing rate limits")
+
     for method_name, original_method in _ORIGINAL_REQUESTS_METHODS.items():
         setattr(requests, method_name, original_method)

--- a/src/_repobee/rate_limit.py
+++ b/src/_repobee/rate_limit.py
@@ -12,14 +12,18 @@ _ORIGINAL_REQUESTS_METHODS = {
 }
 
 
-def rate_limit_modify_requests(rate_limit_in_seconds: int) -> None:
-    """Apply a rate limit to all modifying requests (put, patch, delete, post).
+def rate_limit_modify_requests(
+    base_url: str, rate_limit_in_seconds: float
+) -> None:
+    """Apply a rate limit to all modifying requests (put, patch, delete, post)
+    going to the given base URL.
 
     This is currently necessary at least for GitHub due to the newly introduced
     secondary rate limits, see
     https://docs.github.com/en/rest/guides/best-practices-for-integrators#dealing-with-secondary-rate-limits.
 
     Args:
+        base_url: Base URL on which to rate limit modify requests.
         rate_limit_in_seconds: Minimum amount of seconds between each modify
             request.
     """
@@ -31,16 +35,19 @@ def rate_limit_modify_requests(rate_limit_in_seconds: int) -> None:
 
     original_request_method = requests.request
 
-    def request(method, *args, **kwargs):
+    def request(method, url, *args, **kwargs):
         nonlocal last_modify_time
 
-        if method.lower() in MODIFY_REQUEST_METHOD_NAMES:
+        if (
+            url.casefold().startswith(base_url.casefold())
+            and method.lower() in MODIFY_REQUEST_METHOD_NAMES
+        ):
             seconds_since_last_modify = time.time() - last_modify_time
             if seconds_since_last_modify < rate_limit_in_seconds:
                 time.sleep(rate_limit_in_seconds - seconds_since_last_modify)
             last_modify_time = time.time()
 
-        original_request_method(method, *args, **kwargs)
+        original_request_method(method, url, *args, **kwargs)
 
     requests.request = request
     requests.put = functools.partial(request, "put")

--- a/tests/unit_tests/repobee/test_rate_limit.py
+++ b/tests/unit_tests/repobee/test_rate_limit.py
@@ -1,4 +1,5 @@
 import time
+from urllib.parse import urljoin
 
 import pytest
 import requests
@@ -7,6 +8,7 @@ import responses
 from _repobee import rate_limit
 
 
+_ARBITRARY_BASE_URL = "https://repobee.org"
 _ARBITRARY_NUMBER = 1
 
 
@@ -16,7 +18,9 @@ class TestRateLimitModifyRequests:
     def test_replaces_requests_modify_functions(self):
         original_functions = _get_requests_modify_functions()
 
-        rate_limit.rate_limit_modify_requests(_ARBITRARY_NUMBER)
+        rate_limit.rate_limit_modify_requests(
+            _ARBITRARY_BASE_URL, _ARBITRARY_NUMBER
+        )
 
         functions_after_rate_limiting = _get_requests_modify_functions()
 
@@ -27,17 +31,18 @@ class TestRateLimitModifyRequests:
         "method_name", rate_limit.MODIFY_REQUEST_METHOD_NAMES
     )
     def test_rate_limits_modify_requests(self, method_name):
-        url = "https://repobee.org"
+        url = urljoin(_ARBITRARY_BASE_URL, "/endpoint")
 
         responses.add(
             getattr(responses, method_name.upper()),
             url,
-            json={"yay": "yay"},
-            status=200,
+            status=201,
         )
 
         rate_limit_in_seconds = 0.5
-        rate_limit.rate_limit_modify_requests(rate_limit_in_seconds)
+        rate_limit.rate_limit_modify_requests(
+            _ARBITRARY_BASE_URL, rate_limit_in_seconds
+        )
 
         time_before = time.time()
 
@@ -48,13 +53,41 @@ class TestRateLimitModifyRequests:
         elapsed_time = time.time() - time_before
         assert elapsed_time > rate_limit_in_seconds
 
+    @responses.activate
+    @pytest.mark.parametrize(
+        "method_name", rate_limit.MODIFY_REQUEST_METHOD_NAMES
+    )
+    def test_does_not_rate_limit_non_targeted_url(self, method_name):
+        base_url = "https://repobee.org/should_limit"
+        other_url = "https://repobee.org/should_not_limit"
+
+        responses.add(
+            getattr(responses, method_name.upper()),
+            other_url,
+            status=201,
+        )
+
+        rate_limit_in_seconds = 0.5
+        rate_limit.rate_limit_modify_requests(base_url, rate_limit_in_seconds)
+
+        time_before = time.time()
+
+        request_function = getattr(requests, method_name)
+        request_function(other_url)
+        request_function(other_url)
+
+        elapsed_time = time.time() - time_before
+        assert elapsed_time < rate_limit_in_seconds
+
 
 class TestRemoveRateLimits:
     """Tests for the remove_rate_limits function."""
 
     def test_restores_original_functions(self):
         original_functions = _get_requests_modify_functions()
-        rate_limit.rate_limit_modify_requests(_ARBITRARY_NUMBER)
+        rate_limit.rate_limit_modify_requests(
+            _ARBITRARY_BASE_URL, _ARBITRARY_NUMBER
+        )
 
         assert (
             original_functions != _get_requests_modify_functions()

--- a/tests/unit_tests/repobee/test_rate_limit.py
+++ b/tests/unit_tests/repobee/test_rate_limit.py
@@ -1,0 +1,79 @@
+import time
+
+import pytest
+import requests
+import responses
+
+from _repobee import rate_limit
+
+
+_ARBITRARY_NUMBER = 1
+
+
+class TestRateLimitModifyRequests:
+    """Tests for the rate_limit_modify_requests function."""
+
+    def test_replaces_requests_modify_functions(self):
+        original_functions = _get_requests_modify_functions()
+
+        rate_limit.rate_limit_modify_requests(_ARBITRARY_NUMBER)
+
+        functions_after_rate_limiting = _get_requests_modify_functions()
+
+        assert original_functions != functions_after_rate_limiting
+
+    @responses.activate
+    @pytest.mark.parametrize(
+        "method_name", rate_limit.MODIFY_REQUEST_METHOD_NAMES
+    )
+    def test_rate_limits_modify_requests(self, method_name):
+        url = "https://repobee.org"
+
+        responses.add(
+            getattr(responses, method_name.upper()),
+            url,
+            json={"yay": "yay"},
+            status=200,
+        )
+
+        rate_limit_in_seconds = 0.5
+        rate_limit.rate_limit_modify_requests(rate_limit_in_seconds)
+
+        time_before = time.time()
+
+        request_function = getattr(requests, method_name)
+        request_function(url)
+        request_function(url)
+
+        elapsed_time = time.time() - time_before
+        assert elapsed_time > rate_limit_in_seconds
+
+
+class TestRemoveRateLimits:
+    """Tests for the remove_rate_limits function."""
+
+    def test_restores_original_functions(self):
+        original_functions = _get_requests_modify_functions()
+        rate_limit.rate_limit_modify_requests(_ARBITRARY_NUMBER)
+
+        assert (
+            original_functions != _get_requests_modify_functions()
+        ), "requests modify functions were not replaced, test setup invalid"
+
+        rate_limit.remove_rate_limits()
+
+        functions_after_rate_limit_removal = _get_requests_modify_functions()
+
+        assert functions_after_rate_limit_removal == original_functions
+
+
+@pytest.fixture(autouse=True)
+def remove_rate_limits():
+    rate_limit.remove_rate_limits()
+
+
+def _get_requests_modify_functions():
+    return {
+        getattr(requests, name)
+        for name in rate_limit.MODIFY_REQUEST_METHOD_NAMES + ("request",)
+    }


### PR DESCRIPTION
Fix #991 

With background of #991  and the new secondary rate limits in the GitHub API, we need to rate limit modify requests to 1 per second. This will significantly slow down certain portions of using RepoBee, but stability is more important than speed.

This may also be necessary to investigate for GitLab and Gitea, but I won't travel that road until a problem is reported (as of yet, nothing).