### PR TITLE
[fix] lowercase issue author usernames

### DIFF
--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -89,6 +89,13 @@ class Issue(APIObject):
         compare=False, repr=False, default=None
     )
 
+    def __post_init__(self):
+        object.__setattr__(
+            self,
+            "author",
+            self.author.lower() if isinstance(self.author, str) else None,
+        )
+
     def to_dict(self):
         """Return a dictionary representation of this namedtuple, without
         the ``implementation`` field.

--- a/src/repobee_plug/platform.py
+++ b/src/repobee_plug/platform.py
@@ -93,7 +93,7 @@ class Issue(APIObject):
         object.__setattr__(
             self,
             "author",
-            self.author.lower() if isinstance(self.author, str) else None,
+            self.author.lower() if self.author is not None else None,
         )
 
     def to_dict(self):

--- a/tests/unit_tests/repobee_plug/test_platform.py
+++ b/tests/unit_tests/repobee_plug/test_platform.py
@@ -158,6 +158,18 @@ class TestIssue:
 
         assert reconstructed == issue
 
+    def test_lowercases_usernames(self):
+        """While all of the platforms currently supported are case insensitive,
+        some still allow usernames to contain e.g. capital letters. We don't
+        want this to appear in RepoBee, as it can case problems such as those
+        reported in https://github.com/repobee/repobee/issues/900.
+        """
+        username = "ZiNo"
+        lowercase_username = "zino"
+
+        issue = platform.Issue("Peer Review", "yup", author=username)
+        assert issue.author == lowercase_username
+
 
 class TestTeam:
     """Tests for the Team class."""


### PR DESCRIPTION
Fix #1014, #900 

This PR lowers authors' usernames to match the case-insensitive style used throughout the project. 

- Fixes a case where checking reviews compared issue authors' "real" GitHub usernames (not lowercased) with the internally saved team usernames, which have already received the lowercase treatment. The `reviews check` command would as a consequence not correctly mark finished reviews as such.