### PR TITLE
[misc] Avoid failing build if codecov upload fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           file: ./coverage.xml
 
   gitlab-system-tests:
@@ -109,7 +109,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           file: ./coverage.xml
 
   gitea-system-tests:
@@ -153,5 +153,5 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           file: ./coverage.xml


### PR DESCRIPTION
Codecov is failing sporadically which is super annoying. The whole build should continue even if Codecov upload fails.