### PR TITLE
[feat] Add support for a single configurable argument in mutex groups

### DIFF
--- a/src/repobee_plug/_pluginmeta.py
+++ b/src/repobee_plug/_pluginmeta.py
@@ -190,7 +190,7 @@ def _attach_options(self, config: repobee_plug.config.Config, parser):
                 f"'{opt_name}' to be configured"
             )
 
-        return _convert_configured_value(opt, configured_value)
+        return _pack_configured_value(opt, configured_value)
 
     for (arg_name, opt) in opts:
         if isinstance(opt, _MutuallyExclusiveGroup):
@@ -206,15 +206,9 @@ def _attach_options(self, config: repobee_plug.config.Config, parser):
     return parser
 
 
-def _convert_configured_value(
+def _pack_configured_value(
     opt: _Option, configured_value: Optional[Any]
 ) -> Optional[Any]:
-    """Try to fetch a configured value from the config, respecting the
-    converter of the option and also handling list-like arguments.
-
-    Returns:
-        The configured value, or none if there was no configured value.
-    """
     if (
         configured_value
         and opt.argparse_kwargs

--- a/src/repobee_plug/cli/args.py
+++ b/src/repobee_plug/cli/args.py
@@ -334,6 +334,13 @@ def mutually_exclusive_group(*, __required__: bool = False, **kwargs):
         __required__: Whether or not this mutex group is required.
         kwargs: Keyword arguments on the form ``name=plug.cli.option()``.
     """
+    num_configurable = sum(option.configurable or 0 for option in kwargs.values())
+    if num_configurable > 1:
+        raise ValueError(
+            f"at most 1 option in a mutex group can be configurable, found "
+            f"{num_configurable}"
+        )
+
     return _MutuallyExclusiveGroup(
         required=__required__, options=list(kwargs.items())
     )

--- a/src/repobee_plug/cli/args.py
+++ b/src/repobee_plug/cli/args.py
@@ -334,7 +334,9 @@ def mutually_exclusive_group(*, __required__: bool = False, **kwargs):
         __required__: Whether or not this mutex group is required.
         kwargs: Keyword arguments on the form ``name=plug.cli.option()``.
     """
-    num_configurable = sum(option.configurable or 0 for option in kwargs.values())
+    num_configurable = sum(
+        option.configurable or 0 for option in kwargs.values()
+    )
     if num_configurable > 1:
         raise ValueError(
             f"at most 1 option in a mutex group can be configurable, found "

--- a/tests/new_integration_tests/test_plugins.py
+++ b/tests/new_integration_tests/test_plugins.py
@@ -269,35 +269,3 @@ def test_get_configurable_args_merges_sections():
     assert not rest
     assert configurable_args.config_section_name == plugin_name
     assert configurable_args.argnames == ["duplicated_option"]
-
-
-def test_mutex_group_can_be_conditionally_required(tmp_path):
-    """If a required mutex group contains a configurable option that is
-    configured, it should not be required.
-    """
-    actual_name = None
-
-    class Greeting(plug.Plugin, plug.cli.Command):
-        age_mutex = plug.cli.mutually_exclusive_group(
-            name=plug.cli.option(configurable=True),
-            alias=plug.cli.option(),
-            __required__=True,
-        )
-
-        def command(self):
-            nonlocal actual_name
-            actual_name = self.args.name
-
-    config_file = tmp_path / "config.ini"
-    plugin_name = "greeting"
-    configured_name = "Alice"
-    config = plug.Config(config_file)
-    config.create_section(plugin_name)
-    config[plugin_name]["name"] = configured_name
-    config.store()
-
-    funcs.run_repobee(
-        Greeting.__name__.lower(), plugins=[Greeting], config_file=config_file
-    )
-
-    assert actual_name == configured_name

--- a/tests/new_integration_tests/test_plugins.py
+++ b/tests/new_integration_tests/test_plugins.py
@@ -269,3 +269,35 @@ def test_get_configurable_args_merges_sections():
     assert not rest
     assert configurable_args.config_section_name == plugin_name
     assert configurable_args.argnames == ["duplicated_option"]
+
+
+def test_mutex_group_can_be_conditionally_required(tmp_path):
+    """If a required mutex group contains a configurable option that is
+    configured, it should not be required.
+    """
+    actual_name = None
+
+    class Greeting(plug.Plugin, plug.cli.Command):
+        age_mutex = plug.cli.mutually_exclusive_group(
+            name=plug.cli.option(configurable=True),
+            alias=plug.cli.option(),
+            __required__=True,
+        )
+
+        def command(self):
+            nonlocal actual_name
+            actual_name = self.args.name
+
+    config_file = tmp_path / "config.ini"
+    plugin_name = "greeting"
+    configured_name = "Alice"
+    config = plug.Config(config_file)
+    config.create_section(plugin_name)
+    config[plugin_name]["name"] = configured_name
+    config.store()
+
+    funcs.run_repobee(
+        Greeting.__name__.lower(), plugins=[Greeting], config_file=config_file
+    )
+
+    assert actual_name == configured_name

--- a/tests/unit_tests/repobee_plug/cli/test_args.py
+++ b/tests/unit_tests/repobee_plug/cli/test_args.py
@@ -1,0 +1,16 @@
+import pytest
+import repobee_plug as plug
+
+
+class TestMutuallyExclusiveGroup:
+    def test_cannot_have_multiple_configurable_options(self):
+        with pytest.raises(ValueError) as exc_info:
+            plug.cli.mutually_exclusive_group(
+                name=plug.cli.option(configurable=True),
+                alias=plug.cli.option(configurable=True),
+            )
+
+        assert (
+            "at most 1 option in a mutex group can be configurable, found 2"
+            in str(exc_info.value)
+        )


### PR DESCRIPTION
Fix #1035 

Adds support for mutually exclusive groups to have a single configurable argument. More than one configurable argument is an error.

Mutex groups can be conditionally required. This means that a mutex group with `__required__=True` AND a configurable argument becomes non-required if said argument is configured.