### PR TITLE
Revert "[feat] Make `--students` arg accept filepath and configurable"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 21.7b0
     hooks:
     - id: black
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/src/_repobee/cli/mainparser.py
+++ b/src/_repobee/cli/mainparser.py
@@ -738,19 +738,14 @@ def _create_base_parsers(get_default: Callable[[str], Optional[str]]):
     )
     students = base_student_parser.add_argument_group(
         "core"
-    ).add_mutually_exclusive_group(
-        required=not configured("students_file") and not configured("students")
-    )
+    ).add_mutually_exclusive_group(required=not configured("students_file"))
     _add_students_file_arg(students, get_default)
     students.add_argument(
         "-s",
         "--students",
-        help="one or more whitespace separated student usernames, "
-        "or a path to a students file. NOTE: Configured value always "
-        "interpreted as a filepath.",
+        help="One or more whitespace separated student usernames.",
         type=str,
         nargs="+",
-        default=get_default("students"),
     )
 
     template_org_parser = argparse_ext.RepobeeParser(

--- a/src/_repobee/cli/parsing.py
+++ b/src/_repobee/cli/parsing.py
@@ -16,7 +16,7 @@ import pathlib
 import re
 import sys
 import enum
-from typing import Iterable, Optional, List, Tuple, Union
+from typing import Iterable, Optional, List, Tuple
 
 import argcomplete  # type: ignore
 import daiquiri  # type: ignore
@@ -242,45 +242,21 @@ def _extract_groups(args: argparse.Namespace) -> List[plug.StudentTeam]:
         `students_file` is in the namespace.
     """
     if "students" in args and args.students:
-        students_file = _extract_students_filepath_or_none(args.students)
-        if students_file:
-            return _parse_students_file(students_file)
-
-        return [plug.StudentTeam(members=[s]) for s in args.students]
+        students = [plug.StudentTeam(members=[s]) for s in args.students]
     elif "students_file" in args and args.students_file:
-        return _parse_students_file(args.students_file)
+        students_file = pathlib.Path(args.students_file).resolve()
+        if not students_file.is_file():
+            raise exception.FileError(f"'{students_file}' is not a file")
+        if not students_file.stat().st_size:
+            raise exception.FileError(f"'{students_file}' is empty")
 
-    return []
+        students = list(
+            plug.manager.hook.parse_students_file(students_file=students_file)
+        )
+    else:
+        students = []
 
-
-def _extract_students_filepath_or_none(
-    students_arg: Union[str, List[str], Tuple[str]]
-) -> Optional[pathlib.Path]:
-    if not isinstance(students_arg, str) and not len(students_arg) == 1:
-        return None
-
-    students = (
-        students_arg[0] if not isinstance(students_arg, str) else students_arg
-    )
-    return pathlib.Path(students) if _looks_like_filepath(students) else None
-
-
-def _looks_like_filepath(s: str) -> bool:
-    return "." in s or os.sep in s
-
-
-def _parse_students_file(
-    students_file: Union[str, pathlib.Path],
-) -> List[plug.StudentTeam]:
-    students_file = pathlib.Path(students_file).resolve()
-    if not students_file.is_file():
-        raise exception.FileError(f"'{students_file}' is not a file")
-    if not students_file.stat().st_size:
-        raise exception.FileError(f"'{students_file}' is empty")
-
-    return list(
-        plug.manager.hook.parse_students_file(students_file=students_file)
-    )
+    return students
 
 
 def _connect_to_api(

--- a/src/_repobee/constants.py
+++ b/src/_repobee/constants.py
@@ -37,7 +37,6 @@ ORDERED_CONFIGURABLE_ARGS = (
     "template_org_name",
     "token",
     "students_file",
-    "students",
     plug.Config.PARENT_CONFIG_KEY,
 )
 CONFIGURABLE_ARGS = set(ORDERED_CONFIGURABLE_ARGS)

--- a/src/_repobee/ext/core_commands/repos.py
+++ b/src/_repobee/ext/core_commands/repos.py
@@ -39,10 +39,7 @@ def students_option():
     return plug.cli.option(
         "-s",
         "--students",
-        help="one or more whitespace separated student usernames, "
-        "or a path to a students file. NOTE: Configured value always "
-        "interpreted as a filepath.",
-        configurable=True,
+        help="one or more whitespace separated student usernames",
         argparse_kwargs=dict(nargs="+"),
     )
 

--- a/src/repobee_plug/config.py
+++ b/src/repobee_plug/config.py
@@ -24,9 +24,6 @@ class ConfigSection(Protocol):
     def __contains__(self, key: str) -> bool:
         ...
 
-    def __delitem__(self, key: str) -> None:
-        ...
-
 
 class Config:
     """Object representing RepoBee's config.
@@ -180,6 +177,3 @@ class _ParentAwareConfigSection:
 
     def __contains__(self, key: str) -> bool:
         return self._config.get(self._section_key, key) is not None
-
-    def __delitem__(self, key: str) -> None:
-        del self._config._config_parser[self._section_key][key]

--- a/src/repobee_testhelpers/funcs.py
+++ b/src/repobee_testhelpers/funcs.py
@@ -83,39 +83,24 @@ def run_repobee(
     plugins = (kwargs.get("plugins") or []) + [localapi]
     kwargs["plugins"] = plugins
 
-    with tempfile.NamedTemporaryFile() as tmp:
-        config_file = pathlib.Path(tmp.name)
-        create_default_config_at(config_file)
-        kwargs.setdefault("config_file", config_file)
-
-        return repobee.run(cmd, **kwargs)
-
-
-def create_default_config_at(config_file: pathlib.Path) -> plug.Config:
-    """Create the default config file for integration tests at the specified
-    location.
-
-    Args:
-        config_file: Path to store the config file at.
-    Returns:
-        The default integration test config.
-    """
-    config_file.parent.mkdir(parents=True, exist_ok=True)
-    config = plug.Config(config_file)
-    core_section = config[config.CORE_SECTION_NAME]
-
     students_file = (
         pathlib.Path(__file__).parent / "resources" / "students.txt"
     )
 
-    core_section["students_file"] = str(students_file)
-    core_section["org_name"] = const.TARGET_ORG_NAME
-    core_section["template_org_name"] = const.TEMPLATE_ORG_NAME
-    core_section["token"] = const.TOKEN
-    core_section["user"] = const.TEACHER
-    config.store()
+    with tempfile.NamedTemporaryFile() as tmp:
+        config_file = pathlib.Path(tmp.name)
+        config_file.write_text(
+            f"""[repobee]
+students_file = {students_file}
+org_name = {const.TARGET_ORG_NAME}
+user = {const.TEACHER}
+template_org_name = {const.TEMPLATE_ORG_NAME}
+token = {const.TOKEN}
+"""
+        )
+        kwargs.setdefault("config_file", config_file)
 
-    return config
+        return repobee.run(cmd, **kwargs)
 
 
 def template_repo_hashes() -> Mapping[str, str]:

--- a/tests/integration_tests/test_repos.py
+++ b/tests/integration_tests/test_repos.py
@@ -488,65 +488,6 @@ other-team:
 class TestClone:
     """Tests for the ``repos clone`` command."""
 
-    def test_clone_with_filepath_in_configured_students_arg(
-        self, platform_url, with_student_repos, tmp_path
-    ):
-        students_file = tmp_path / "students.txt"
-        students_file.write_text("\n".join(map(str, STUDENT_TEAMS)))
-
-        config_file = tmp_path / "repobee.ini"
-        config = funcs.create_default_config_at(config_file)
-
-        del config[config.CORE_SECTION_NAME]["students_file"]
-        config[config.CORE_SECTION_NAME]["students"] = str(students_file)
-        config.store()
-
-        funcs.run_repobee(
-            [
-                *plug.cli.CoreCommand.repos.clone.as_name_tuple(),
-                "--assignments",
-                *TEMPLATE_REPO_NAMES,
-                "--base-url",
-                platform_url,
-            ],
-            config_file=config_file,
-            workdir=tmp_path,
-        )
-
-        assert_cloned_student_repos_match_templates(
-            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, tmp_path
-        )
-
-    def test_clone_with_filepath_in_students_arg(
-        self, platform_url, with_student_repos, tmp_path
-    ):
-        students_file = tmp_path / "students.txt"
-        students_file.write_text("\n".join(map(str, STUDENT_TEAMS)))
-
-        config_file = tmp_path / "repobee.ini"
-        config = funcs.create_default_config_at(config_file)
-
-        del config[config.CORE_SECTION_NAME]["students_file"]
-        config.store()
-
-        funcs.run_repobee(
-            [
-                *plug.cli.CoreCommand.repos.clone.as_name_tuple(),
-                "--assignments",
-                *TEMPLATE_REPO_NAMES,
-                "--base-url",
-                platform_url,
-                "--students",
-                str(students_file),
-            ],
-            config_file=config_file,
-            workdir=tmp_path,
-        )
-
-        assert_cloned_student_repos_match_templates(
-            STUDENT_TEAMS, TEMPLATE_REPO_NAMES, tmp_path
-        )
-
     def test_clone_all_repos(self, platform_url, with_student_repos, tmp_path):
         funcs.run_repobee(
             f"repos clone -a {TEMPLATE_REPOS_ARG} "


### PR DESCRIPTION
Reverts repobee/repobee#1040

The usage of `--students` with two completely different kinds of input (a single filepath or any amount of student usernames) is just too confusing, I think.