### PR TITLE
[feat] Add verbose output mode

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -211,6 +211,7 @@ disable=invalid-name,
         no-member,
         duplicate-code,
         used-before-assignment,
+        too-many-public-methods,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -366,7 +367,6 @@ enable=syntax-error,
        cyclic-import,
        consider-using-from-import,
        too-many-ancestors,
-       too-many-public-methods,
        too-many-return-statements,
        too-many-branches,
        too-many-statements,

--- a/src/_repobee/cli/argparse_ext.py
+++ b/src/_repobee/cli/argparse_ext.py
@@ -63,7 +63,7 @@ class RepobeeParser(argparse.ArgumentParser):
             "--user",
             "--base-url",
         }
-        debug_args = {"--traceback", "--quiet"}
+        debug_args = {"--traceback", "--quiet", "--verbose"}
         alpha_args = {"--hook-results-file", "--double-blind-key"}
 
         for arg in args:

--- a/src/_repobee/cli/argparse_ext.py
+++ b/src/_repobee/cli/argparse_ext.py
@@ -151,8 +151,16 @@ def add_debug_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "-q",
         "--quiet",
-        help="silence output (stacks up to 3 times: x1=only warnings "
-        "and errors, x2=only errors, x3=complete and utter silence)",
+        help="silence output (stacks up to 3 times: -q=only warnings "
+        "and errors, -qq=only errors, -qqq=complete and utter silence)",
+        action="count",
+        default=0,
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="increase verbosity of output (stacks up to 2 times: "
+        "-v=info logging, -vv=debug logging",
         action="count",
         default=0,
     )

--- a/src/_repobee/main.py
+++ b/src/_repobee/main.py
@@ -330,7 +330,7 @@ def _set_output_verbosity(verbosity: _OutputVerbosity):
             yield
 
 
-def _get_output_verbosity(parsed_args: argparse.Namespace) -> int:
+def _get_output_verbosity(parsed_args: argparse.Namespace) -> _OutputVerbosity:
     return _OutputVerbosity(
         -getattr(parsed_args, "quiet", 0) or getattr(parsed_args, "verbose", 0)
     )

--- a/tests/integration_tests/test_repos.py
+++ b/tests/integration_tests/test_repos.py
@@ -812,6 +812,38 @@ class TestClone:
         assert not out_err.out.strip()
         assert not out_err.err.strip()
 
+    def test_clone_with_verbose_output(
+        self, with_student_repos, platform_url, capsys, tmp_path
+    ):
+        """Cloning repos with verbose output should result in [INFO] logging
+        being displayed, but not [DEBUG] logging.
+        """
+        funcs.run_repobee(
+            f"{plug.cli.CoreCommand.repos.clone} -a {TEMPLATE_REPOS_ARG} "
+            f"--base-url {platform_url} "
+            "-v"
+        )
+
+        out_err = capsys.readouterr()
+        assert "[INFO]" in out_err.err
+        assert "[DEBUG]" not in out_err.err
+
+    def test_clone_with_very_verbose_output(
+        self, with_student_repos, platform_url, capsys, tmp_path
+    ):
+        """Cloning repos with verbose output should result in [INFO] logging
+        [DEBUG] logging being displayed on stderr.
+        """
+        funcs.run_repobee(
+            f"{plug.cli.CoreCommand.repos.clone} -a {TEMPLATE_REPOS_ARG} "
+            f"--base-url {platform_url} "
+            "-vv"
+        )
+
+        out_err = capsys.readouterr()
+        assert "[INFO]" in out_err.err
+        assert "[DEBUG]" in out_err.err
+
     def test_empty_student_repos_dont_cause_errors(
         self, with_student_repos, platform_url, capsys, tmp_path
     ):


### PR DESCRIPTION
Add a `--verbose|-v` debug flag that stacks up to two times for INFO and DEBUG logging.