### PR TITLE
[test] Fix broken dist test

### DIFF
--- a/tests/integration_tests/test_dist.py
+++ b/tests/integration_tests/test_dist.py
@@ -511,9 +511,7 @@ class TestManageUpgrade:
         """Test that dist plugins (e.g. the ``plugin`` category of commands)
         are activated properly upon an upgrade.
         """
-        repobee.run(
-            shlex.split("manage upgrade --version-spec '==v3.8.1'")
-        )
+        repobee.run(shlex.split("manage upgrade --version-spec '==v3.8.1'"))
         proc = run_dist("plugin list")
 
         assert proc.returncode == 0

--- a/tests/integration_tests/test_dist.py
+++ b/tests/integration_tests/test_dist.py
@@ -512,7 +512,7 @@ class TestManageUpgrade:
         are activated properly upon an upgrade.
         """
         repobee.run(
-            shlex.split("manage upgrade --version-spec '==v3.0.0-beta.1'")
+            shlex.split("manage upgrade --version-spec '==v3.8.1'")
         )
         proc = run_dist("plugin list")
 


### PR DESCRIPTION
#1116 Installing RepoBee versions 3.x before 3.8.1 doesn't work if you install from source as the version specifier for `dataclasses` is broken. This test was failing as it used an old beta version.