### PR TITLE
[misc] Make install script install from GitHub instead of PyPi

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -228,7 +228,7 @@ function resolve_repobee_pip_uri() {
             repobee_pip_uri="git+$REPOBEE_HTTPS_URL.git@$version"
         fi
     else
-        repobee_pip_uri="repobee==$(get_latest_version)"
+        repobee_pip_uri="git+$REPOBEE_HTTPS_URL.git@$(get_latest_version)"
     fi
     echo "$repobee_pip_uri"
 }


### PR DESCRIPTION
First install must not be from a wheel because then it won't enable the `plugin` and `manage` commands. See the shenanigans in `setup.py` and `distinfo.py`.

Fix #1144