### PR TITLE
Remove codecov dependency

### DIFF
--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -2,7 +2,6 @@
 
 bandit==1.7.4
 black==23.1.0
-codecov==2.1.12
 flake8==6.0.0
 mypy==1.0.1
 pylint==2.17.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ INSTALL_DIR = pathlib.Path('{install_dir}')
 dev_requirements = [
     "bandit",
     "black",
-    "codecov",
     "flake8>=3.8.3",
     "mypy>=0.902",
     "pylint",


### PR DESCRIPTION
It hasn't been used in a long time as we use the Codecov GitHub Action and [it was recently (apparently accidentally) removed from PyPi](https://about.codecov.io/blog/message-regarding-the-pypi-package/).