### PR TITLE
[misc] Pin dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,18 @@ updates:
   - package-ecosystem: "pip"
     directory: "/requirements"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      dev-deps:
+        dependency-type: "depelopment"
+      prod-deps:
+        dependency-type: "production"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"

--- a/requirements/requirements.dev.txt
+++ b/requirements/requirements.dev.txt
@@ -1,5 +1,3 @@
-.[DEV]
-
 bandit==1.7.5
 black==23.11.0
 flake8==6.1.0
@@ -10,3 +8,12 @@ pytest-mock==3.12.0
 pytest==7.4.2
 virtualenv==20.24.5
 sphinx_rtd_theme==1.3.0
+responses==0.22.0
+types-pkg-resources==0.1.3
+types-requests==2.28.11.14
+types-tabulate==0.9.0.1
+types-toml==0.10.8.5
+sphinx==6.1.3
+sphinx-autodoc-typehints==1.22
+sphinx_rtd_theme==1.3.0
+sphinx-argparse==0.4.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,12 @@
-.
+appdirs==1.4.4
+argcomplete==3.2.1
+bullet==2.2.0
+daiquiri==3.2.3
+gitpython==3.1.31
+more-itertools==9.0.0
+pluggy==1.3.0
+pygithub==2.1.1
+python-gitlab==4.4.0
+tabulate==0.9.0
+tqdm==4.66.1
+yamliny==0.0.2

--- a/setup.py
+++ b/setup.py
@@ -26,29 +26,19 @@ INSTALL_DIR = pathlib.Path('{install_dir}')
     )
 
 
-dev_requirements = [
-    "bandit",
-    "black",
-    "flake8>=3.8.3",
-    "mypy>=0.902",
-    "pylint",
-    "pytest-cov>=2.6.1",
-    "pytest-mock",
-    "pytest>=6.0.0",
-    "virtualenv",
-    "responses>=0.18.0",
-    # type stubs required for MyPy
-    "types-pkg-resources",
-    "types-requests",
-    "types-tabulate",
-    "types-toml",
-    # requirements for docs
-    "sphinx>=4.0.1",
-    "sphinx-autodoc-typehints",
-    "sphinx_rtd_theme",
-    "sphinx-argparse",
-]
+def read_requirements(requirements_file_name: str) -> list[str]:
+    """Read requirements from a file, stripping comments and empty lines."""
+    content = (
+        pathlib.Path(__file__).parent / "requirements" / requirements_file_name
+    ).read_text(encoding="utf8")
+    return [
+        stripped_req
+        for req in content.splitlines()
+        if (stripped_req := req.strip()) and not stripped_req.startswith("#")
+    ]
 
+
+dev_requirements = read_requirements("requirements.dev.txt")
 testhelper_resources_dir = pathlib.Path("src/repobee_testhelpers/resources")
 testhelper_resources = [
     p for p in testhelper_resources_dir.rglob("*") if p.is_file()
@@ -78,20 +68,7 @@ setup(
     ],
     py_modules=["repobee"],
     tests_require=dev_requirements,
-    install_requires=[
-        "appdirs>=1.4.4",
-        "argcomplete>=3.2.1",
-        "bullet>=2.2.0",
-        "daiquiri>=3.2.3",
-        "gitpython>=3.1.24",
-        "more-itertools>=8.4.0",
-        "pluggy>=1.3.0",
-        "pygithub==2.1.1",
-        "python-gitlab==4.4.0",
-        "tabulate>=0.9.0",
-        "tqdm>=4.66.1",
-        "yamliny>=0.0.2",
-    ],
+    install_requires=read_requirements("requirements.txt"),
     extras_require=dict(DEV=dev_requirements),
     entry_points=dict(
         console_scripts="repobee = repobee:main",


### PR DESCRIPTION
Should have done this ages ago. RepoBee is an application and its dependencies should be fixed to avoid unexpected breakage from later installs. It's happened multiple times that people have installed at different times, and had strange behavior due to new versions of dependencies.

Plugins on the other hand need to be looser on their requirements, but they should comply to the version of RepoBee their compatible with. It's just the way it has to be for RepoBee to function consistently as time passes.