### PR TITLE
[test] try running docker compose instead of docker-compose

### DIFF
--- a/system_tests/gitea/giteamanager.py
+++ b/system_tests/gitea/giteamanager.py
@@ -33,12 +33,12 @@ COMPOSE_FILE_OUTPUT = CURRENT_DIR / "docker-compose.yml"
 DOCKER_VOLUME = CURRENT_DIR / "gitea"
 DOCKER_START_COMMANDS = [
     "docker network create development",
-    "docker-compose up -d",
+    "docker compose up -d",
 ]
 REPOSITORIES_ROOT = DOCKER_VOLUME / "git" / "repositories"
 
 DOCKER_TEARDOWN_COMMANDS = [
-    "docker-compose down",
+    "docker compose down",
     "docker network rm development",
     f"rm -rf {str(DOCKER_VOLUME)}",
     f"git checkout {DOCKER_VOLUME}",

--- a/system_tests/gitlab/gitlabmanager.py
+++ b/system_tests/gitlab/gitlabmanager.py
@@ -25,15 +25,15 @@ BASE_URL = "https://localhost:3000"
 
 DOCKER_START_COMMANDS = [
     "docker network create development",
-    "docker-compose up -d",
+    "docker compose up -d",
     "docker exec -it gitlab update-permissions",
     "docker container stop gitlab",
-    "docker-compose up -d",
+    "docker compose up -d",
 ]
 DOCKER_VOLUME = CURRENT_DIR / "volume_data"
 
 DOCKER_TEARDOWN_COMMANDS = [
-    "docker-compose down",
+    "docker compose down",
     "docker network rm development",
     f"rm -rf {str(DOCKER_VOLUME)}",
     f"git checkout {str(DOCKER_VOLUME.relative_to(CURRENT_DIR))}",


### PR DESCRIPTION
Fix #1267 
Fix #1268 

The `docker-compose` command was deprecated a while back, so it might just be that the runner image was updated to only have the newer `docker compose` sub command.