### PR TITLE
[misc] Add support for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,13 +20,17 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
         core-commands-as-plugins: [false]
         exclude:
           - os: macos-latest
             python-version: 3.10
           - os: macos-latest
             python-version: 3.11
+          - os: macos-latest
+            python-version: 3.12
+          - os: macos-latest
+            python-version: 3.13
         include:
           - os: ubuntu-latest
             python-version: 3.9

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Coverage](https://codecov.io/gh/repobee/repobee/branch/master/graph/badge.svg)](https://codecov.io/gh/repobee/repobee)
 [![Documentation Status](https://readthedocs.org/projects/repobee/badge/?version=stable)](http://repobee.readthedocs.io/en/stable/)
 [![PyPi Version](https://badge.fury.io/py/repobee.svg)](https://badge.fury.io/py/repobee)
-![Supported Python Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11-blue.svg)
+![Supported Python Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11%2C%203.12%2C%203.13-blue.svg)
 ![Supported Platforms](https://img.shields.io/badge/platforms-Linux%2C%20macOS-blue.svg)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Coverage](https://codecov.io/gh/repobee/repobee/branch/master/graph/badge.svg)](https://codecov.io/gh/repobee/repobee)
 [![Documentation Status](https://readthedocs.org/projects/repobee/badge/?version=stable)](http://repobee.readthedocs.io/en/stable/)
 [![PyPi Version](https://badge.fury.io/py/repobee.svg)](https://badge.fury.io/py/repobee)
-![Supported Python Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11%2C%203.12-blue.svg)
+![Supported Python Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11%2C%203.12%2C%203.13-blue.svg)
 ![Supported Platforms](https://img.shields.io/badge/platforms-Linux%2C%20macOS-blue.svg)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Coverage](https://codecov.io/gh/repobee/repobee/branch/master/graph/badge.svg)](https://codecov.io/gh/repobee/repobee)
 [![Documentation Status](https://readthedocs.org/projects/repobee/badge/?version=stable)](http://repobee.readthedocs.io/en/stable/)
 [![PyPi Version](https://badge.fury.io/py/repobee.svg)](https://badge.fury.io/py/repobee)
-![Supported Python Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11%2C%203.12%2C%203.13-blue.svg)
+![Supported Python Versions](https://img.shields.io/badge/python-3.9%2C%203.10%2C%203.11%2C%203.12-blue.svg)
 ![Supported Platforms](https://img.shields.io/badge/platforms-Linux%2C%20macOS-blue.svg)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,7 +95,7 @@ function install_repobee() {
 
 function find_python() {
     # Find an appropriate python executable
-    for exec_suffix in "3.12" "3.11" "3.10" "3.9" "3" ""; do
+    for exec_suffix in "3.13" "3.12" "3.11" "3.10" "3.9" "3" ""; do
         python_exec="python$exec_suffix"
         minor_version=$(get_minor_python3_version "$python_exec")
         if [ "$minor_version" -ge "$MIN_PYTHON_VERSION" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,7 +95,7 @@ function install_repobee() {
 
 function find_python() {
     # Find an appropriate python executable
-    for exec_suffix in "3.13" "3.12" "3.11" "3.10" "3.9" "3" ""; do
+    for exec_suffix in "3.12" "3.11" "3.10" "3.9" "3" ""; do
         python_exec="python$exec_suffix"
         minor_version=$(get_minor_python3_version "$python_exec")
         if [ "$minor_version" -ge "$MIN_PYTHON_VERSION" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ REPOBEE_COMPLETION="$REPOBEE_INSTALL_DIR/completion"
 REPOBEE_BASH_COMPLETION="$REPOBEE_COMPLETION/bash_completion.sh"
 REGISTER_PYTHON_ARGCOMPLETE="$REPOBEE_INSTALL_DIR/env/bin/register-python-argcomplete"
 
-MIN_PYTHON_VERSION=8
+MIN_PYTHON_VERSION=9
 
 function install() {
     repobee_pip_uri=$1
@@ -95,7 +95,7 @@ function install_repobee() {
 
 function find_python() {
     # Find an appropriate python executable
-    for exec_suffix in "3.11" "3.10" "3.9" "3" ""; do
+    for exec_suffix in "3.13" "3.12" "3.11" "3.10" "3.9" "3" ""; do
         python_exec="python$exec_suffix"
         minor_version=$(get_minor_python3_version "$python_exec")
         if [ "$minor_version" -ge "$MIN_PYTHON_VERSION" ]; then

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX",

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "License :: OSI Approved :: MIT License",
         "Operating System :: POSIX",

--- a/tests/integration_tests/test_dist.py
+++ b/tests/integration_tests/test_dist.py
@@ -227,7 +227,7 @@ class Hello(plug.Plugin, plug.cli.Command):
         out-of-date.
         """
         # arrange
-        old_pip_version = "20.0.1"
+        old_pip_version = "24.3"
         assert (
             subprocess.run(
                 [


### PR DESCRIPTION
Fix #1205

Python 3.12 seems fine, but Python 3.13 seems to be causing issues in the integration (distro) tests on macOS.